### PR TITLE
Add production Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:18.04
 
-MAINTAINER JacobEberhardt <jacob.eberhardt@tu-berlin.de>, Dennis Kuhnert <mail@kyroy.com>
+MAINTAINER JacobEberhardt <jacob.eberhardt@tu-berlin.de>, Dennis Kuhnert <mail@kyroy.com>, Thibaut Schaeffer <thibaut@schaeff.fr>
 
 RUN useradd -u 1000 -m zokrates
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,8 @@
 def majorVersion
 def minorVersion
 def patchVersion
-def dockerImage
+def testImage
+def prodImage
 
 pipeline {
     agent any
@@ -34,8 +35,9 @@ pipeline {
             steps {
                 script {
                     ansiColor('xterm') {
-                        dockerImage = docker.build("zokrates/zokrates")
-                        dockerImage.inside {
+                        def testDockerfile = 'dev.Dockerfile'
+                        testImage = docker.build("zokrates/zokrates", "-f ${testDockerfile} .")
+                        testImage.inside {
                             sh 'RUSTFLAGS="-D warnings" ./build.sh'
                         }
                     }
@@ -47,7 +49,7 @@ pipeline {
             steps {
                 script {
                     ansiColor('xterm') {
-                        dockerImage.inside {
+                        testImage.inside {
                             sh 'RUSTFLAGS="-D warnings" ./test.sh'
                         }
                     }
@@ -62,7 +64,7 @@ pipeline {
             steps {
                 script {
                     ansiColor('xterm') {
-                        dockerImage.inside {
+                        testImage.inside {
                             sh 'RUSTFLAGS="-D warnings" ./full_test.sh'
                         }
                     }
@@ -77,13 +79,14 @@ pipeline {
             steps {
                 script {
                     ansiColor('xterm') {
+                        prodImage = docker.build("zokrates/zokrates"
                         docker.withRegistry('https://registry.hub.docker.com', 'dockerhub-kyroy') {
-                            dockerImage.push(patchVersion)
-                            dockerImage.push(minorVersion)
+                            prodImage.push(patchVersion)
+                            prodImage.push(minorVersion)
                             if (majorVersion > '0') {
-                                dockerImage.push(majorVersion)
+                                prodImage.push(majorVersion)
                             }
-                            dockerImage.push("latest")
+                            prodImage.push("latest")
                         }
                     }
                 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -79,7 +79,7 @@ pipeline {
             steps {
                 script {
                     ansiColor('xterm') {
-                        prodImage = docker.build("zokrates/zokrates"
+                        prodImage = docker.build("zokrates/zokrates")
                         docker.withRegistry('https://registry.hub.docker.com', 'dockerhub-kyroy') {
                             prodImage.push(patchVersion)
                             prodImage.push(minorVersion)

--- a/build_release.sh
+++ b/build_release.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# Exit if any subcommand fails
+set -e
+
+if [ -n "$WITH_LIBSNARK" ]; then
+	cargo build --release
+else
+	cargo -Z package-features build --release --no-default-features
+fi

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -1,0 +1,43 @@
+FROM ubuntu:14.04
+
+MAINTAINER JacobEberhardt <jacob.eberhardt@tu-berlin.de>, Dennis Kuhnert <mail@kyroy.com>
+
+RUN useradd -u 1000 -m zokrates
+
+ARG RUST_TOOLCHAIN=nightly-2018-06-04
+ARG LIBSNARK_COMMIT=f7c87b88744ecfd008126d415494d9b34c4c1b20
+ENV LIBSNARK_SOURCE_PATH=/home/zokrates/libsnark-$LIBSNARK_COMMIT
+ENV WITH_LIBSNARK=1
+
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    cmake \
+    curl \
+    libboost-all-dev \
+    libgmp3-dev \
+    libprocps3-dev \
+    libssl-dev \
+    pkg-config \
+    python-markdown \
+    git
+
+USER zokrates
+
+RUN curl https://sh.rustup.rs -sSf | \
+    sh -s -- --default-toolchain $RUST_TOOLCHAIN -y
+
+ENV PATH=/home/zokrates/.cargo/bin:$PATH
+
+RUN git clone https://github.com/scipr-lab/libsnark.git $LIBSNARK_SOURCE_PATH
+
+WORKDIR $LIBSNARK_SOURCE_PATH
+
+RUN git checkout $LIBSNARK_COMMIT
+RUN git submodule update --init --recursive
+
+WORKDIR /home/zokrates
+
+COPY --chown=zokrates:zokrates . ZoKrates
+
+RUN cd ZoKrates \
+    && ./build.sh

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:14.04
 
-MAINTAINER JacobEberhardt <jacob.eberhardt@tu-berlin.de>, Dennis Kuhnert <mail@kyroy.com>
+MAINTAINER JacobEberhardt <jacob.eberhardt@tu-berlin.de>, Dennis Kuhnert <mail@kyroy.com>, Thibaut Schaeffer <thibaut@schaeff.fr>
 
 RUN useradd -u 1000 -m zokrates
 


### PR DESCRIPTION
Since we moved to the new build process for libsnark, the size of our Docker images exploded.
It's hard to keep the same Dockerfile for both development and usage, as users do not need Rust, or the source code, or libsnark: they only need the ZoKrates binary.

This PR introduces a "production" Dockerfile which is lighter than the dev one thanks to:
- removal of rust
- removal of superfluous dependencies: mostly `libboost-dev-all` where `libboost-dev` and `libboost-program-options-dev` seem to be enough for what we're doing
- removal of source code
- keeping examples
- ubuntu 18:04

Locally, the size of the image as measured by `docker images` is 632mb (for context, libsnark-only images are around 420mb), down from 2.2gb (!)

Feedback would be much appreciated as this is not my domain of expertise @kyroy @JacobEberhardt @stefandeml :)

Todo:
- [ ] documentation