### PR TITLE
Fixed Documentation hashexample.code

### DIFF
--- a/zokrates_book/src/sha256example.md
+++ b/zokrates_book/src/sha256example.md
@@ -76,7 +76,7 @@ First, Victor has to specify what hash he is interested in. Therefore, we have t
 ```zokrates
 import "LIBSNARK/sha256packed"
 
-def main(field a, field b, field c, field d) -> (field):
+def main(private field a, private field b, private field c, private field d) -> (field):
 	h0, h1 = sha256packed(a, b, c, d)
 	h0 == 263561599766550617289250058199814760685
 	h1 == 65303172752238645975888084098459749904


### PR DESCRIPTION
The documentation states that:

| In the example we're considering, all inputs are private and there is a single return value of 1, hence Alice has to define her public input array as follows: [1]

However, the example code doesn't reflect that:

```
import "LIBSNARK/sha256packed"

def main(field a, field b, field c, field d) -> (field):
    h0, h1 = sha256packed(a, b, c, d)
    h0 == 263561599766550617289250058199814760685
    h1 == 65303172752238645975888084098459749904
    return 1
```

I've changed that to

```
import "LIBSNARK/sha256packed"

def main(private field a, private field b, private field c, private field d) -> (field):
    h0, h1 = sha256packed(a, b, c, d)
    h0 == 263561599766550617289250058199814760685
    h1 == 65303172752238645975888084098459749904
    return 1
```