### PR TITLE
Remove flat division

### DIFF
--- a/zokrates_core/src/flatten/mod.rs
+++ b/zokrates_core/src/flatten/mod.rs
@@ -692,17 +692,33 @@ impl Flattener {
                     statements_flattened,
                     right,
                 );
-                let new_left = {
+                let new_left: FlatExpression<T> = {
                     let id = self.use_sym();
                     statements_flattened.push(FlatStatement::Definition(id, left_flattened));
-                    FlatExpression::Identifier(id)
+                    id.into()
                 };
-                let new_right = {
+                let new_right: FlatExpression<T> = {
                     let id = self.use_sym();
                     statements_flattened.push(FlatStatement::Definition(id, right_flattened));
-                    FlatExpression::Identifier(id)
+                    id.into()
                 };
-                FlatExpression::Div(box new_left, box new_right)
+
+                let inverse = self.use_sym();
+
+                // # c = 1/b
+                statements_flattened.push(FlatStatement::Directive(DirectiveStatement::new(
+                    vec![inverse],
+                    Helper::Rust(RustHelper::Inverse),
+                    vec![new_right.clone()],
+                )));
+
+                // assert(c * b == 1)
+                statements_flattened.push(FlatStatement::Condition(
+                    FlatExpression::Number(T::from(1)),
+                    FlatExpression::Mult(box new_right, box inverse.into()),
+                ));
+
+                FlatExpression::Mult(box new_left, box inverse.into())
             }
             FieldElementExpression::Pow(box base, box exponent) => {
                 match exponent {
@@ -1933,6 +1949,103 @@ mod tests {
         flattener.load_corelib(&mut functions_flattened);
 
         flattener.flatten_field_expression(&functions_flattened, &vec![], &mut vec![], expression);
+    }
+
+    #[test]
+    fn div() {
+        // a = 5 / b / b
+        let mut flattener = Flattener::new(FieldPrime::get_required_bits());
+        let mut functions_flattened = vec![];
+        let arguments_flattened = vec![];
+        let mut statements_flattened = vec![];
+
+        let definition = TypedStatement::Definition(
+            TypedAssignee::Identifier(Variable::field_element("b")),
+            FieldElementExpression::Number(FieldPrime::from(42)).into(),
+        );
+
+        let statement = TypedStatement::Definition(
+            TypedAssignee::Identifier(Variable::field_element("a")),
+            FieldElementExpression::Div(
+                box FieldElementExpression::Div(
+                    box FieldElementExpression::Number(FieldPrime::from(5)),
+                    box FieldElementExpression::Identifier(String::from("b")),
+                ),
+                box FieldElementExpression::Identifier(String::from("b")),
+            )
+            .into(),
+        );
+
+        flattener.flatten_statement(
+            &mut functions_flattened,
+            &arguments_flattened,
+            &mut statements_flattened,
+            definition,
+        );
+
+        flattener.flatten_statement(
+            &mut functions_flattened,
+            &arguments_flattened,
+            &mut statements_flattened,
+            statement,
+        );
+
+        // define b
+        let b = FlatVariable::new(0);
+        // define new wires for members of Div
+        let five = FlatVariable::new(1);
+        let b0 = FlatVariable::new(2);
+        // Define inverse
+        let sym_0 = FlatVariable::new(3);
+        // Define result, which is first member to next Div
+        let sym_1 = FlatVariable::new(4);
+        // Define second member
+        let b1 = FlatVariable::new(5);
+        // Define inverse
+        let sym_2 = FlatVariable::new(6);
+        // Define left hand side
+        let a = FlatVariable::new(7);
+
+        assert_eq!(
+            statements_flattened,
+            vec![
+                FlatStatement::Definition(b, FlatExpression::Number(FieldPrime::from(42))),
+                // inputs to first div (5/b)
+                FlatStatement::Definition(five, FlatExpression::Number(FieldPrime::from(5))),
+                FlatStatement::Definition(b0, b.into()),
+                // execute div
+                FlatStatement::Directive(DirectiveStatement::new(
+                    vec![sym_0],
+                    Helper::Rust(RustHelper::Inverse),
+                    vec![b0]
+                )),
+                FlatStatement::Condition(
+                    FlatExpression::Number(FieldPrime::from(1)),
+                    FlatExpression::Mult(box b0.into(), box sym_0.into()),
+                ),
+                // inputs to second div (res/b)
+                FlatStatement::Definition(
+                    sym_1,
+                    FlatExpression::Mult(box five.into(), box sym_0.into())
+                ),
+                FlatStatement::Definition(b1, b.into()),
+                // execute div
+                FlatStatement::Directive(DirectiveStatement::new(
+                    vec![sym_2],
+                    Helper::Rust(RustHelper::Inverse),
+                    vec![b1]
+                )),
+                FlatStatement::Condition(
+                    FlatExpression::Number(FieldPrime::from(1)),
+                    FlatExpression::Mult(box b1.into(), box sym_2.into()),
+                ),
+                // result
+                FlatStatement::Definition(
+                    a,
+                    FlatExpression::Mult(box sym_1.into(), box sym_2.into())
+                ),
+            ]
+        );
     }
 
     #[test]

--- a/zokrates_core/src/flatten/mod.rs
+++ b/zokrates_core/src/flatten/mod.rs
@@ -705,20 +705,20 @@ impl Flattener {
 
                 let inverse = self.use_sym();
 
-                // # c = 1/b
+                // # c = a/b
                 statements_flattened.push(FlatStatement::Directive(DirectiveStatement::new(
                     vec![inverse],
-                    Helper::Rust(RustHelper::Inverse),
-                    vec![new_right.clone()],
+                    Helper::Rust(RustHelper::Div),
+                    vec![new_left.clone(), new_right.clone()],
                 )));
 
-                // assert(c * b == 1)
+                // assert(c * b == a)
                 statements_flattened.push(FlatStatement::Condition(
-                    FlatExpression::Number(T::from(1)),
+                    new_left.into(),
                     FlatExpression::Mult(box new_right, box inverse.into()),
                 ));
 
-                FlatExpression::Mult(box new_left, box inverse.into())
+                inverse.into()
             }
             FieldElementExpression::Pow(box base, box exponent) => {
                 match exponent {
@@ -2016,34 +2016,28 @@ mod tests {
                 // execute div
                 FlatStatement::Directive(DirectiveStatement::new(
                     vec![sym_0],
-                    Helper::Rust(RustHelper::Inverse),
-                    vec![b0]
+                    Helper::Rust(RustHelper::Div),
+                    vec![five, b0]
                 )),
                 FlatStatement::Condition(
-                    FlatExpression::Number(FieldPrime::from(1)),
+                    five.into(),
                     FlatExpression::Mult(box b0.into(), box sym_0.into()),
                 ),
                 // inputs to second div (res/b)
-                FlatStatement::Definition(
-                    sym_1,
-                    FlatExpression::Mult(box five.into(), box sym_0.into())
-                ),
+                FlatStatement::Definition(sym_1, sym_0.into()),
                 FlatStatement::Definition(b1, b.into()),
                 // execute div
                 FlatStatement::Directive(DirectiveStatement::new(
                     vec![sym_2],
-                    Helper::Rust(RustHelper::Inverse),
-                    vec![b1]
+                    Helper::Rust(RustHelper::Div),
+                    vec![sym_1, b1]
                 )),
                 FlatStatement::Condition(
-                    FlatExpression::Number(FieldPrime::from(1)),
+                    sym_1.into(),
                     FlatExpression::Mult(box b1.into(), box sym_2.into()),
                 ),
                 // result
-                FlatStatement::Definition(
-                    a,
-                    FlatExpression::Mult(box sym_1.into(), box sym_2.into())
-                ),
+                FlatStatement::Definition(a, sym_2.into()),
             ]
         );
     }

--- a/zokrates_core/src/helpers/mod.rs
+++ b/zokrates_core/src/helpers/mod.rs
@@ -17,16 +17,17 @@ pub struct DirectiveStatement<T: Field> {
 }
 
 impl<T: Field> DirectiveStatement<T> {
-    pub fn new(outputs: Vec<FlatVariable>, helper: Helper, inputs: Vec<FlatVariable>) -> Self {
+    pub fn new<E: Into<FlatExpression<T>>>(
+        outputs: Vec<FlatVariable>,
+        helper: Helper,
+        inputs: Vec<E>,
+    ) -> Self {
         let (in_len, out_len) = helper.get_signature();
         assert_eq!(in_len, inputs.len());
         assert_eq!(out_len, outputs.len());
         DirectiveStatement {
             helper,
-            inputs: inputs
-                .into_iter()
-                .map(|i| FlatExpression::Identifier(i))
-                .collect(),
+            inputs: inputs.into_iter().map(|i| i.into()).collect(),
             outputs,
         }
     }

--- a/zokrates_core/src/helpers/rust.rs
+++ b/zokrates_core/src/helpers/rust.rs
@@ -7,6 +7,7 @@ pub enum RustHelper {
     Identity,
     ConditionEq,
     Bits,
+    Inverse,
 }
 
 impl fmt::Display for RustHelper {
@@ -15,6 +16,7 @@ impl fmt::Display for RustHelper {
             RustHelper::Identity => write!(f, "Identity"),
             RustHelper::ConditionEq => write!(f, "ConditionEq"),
             RustHelper::Bits => write!(f, "Bits"),
+            RustHelper::Inverse => write!(f, "Inverse"),
         }
     }
 }
@@ -25,6 +27,7 @@ impl Signed for RustHelper {
             RustHelper::Identity => (1, 1),
             RustHelper::ConditionEq => (1, 2),
             RustHelper::Bits => (1, 254),
+            RustHelper::Inverse => (1, 1),
         }
     }
 }
@@ -52,6 +55,7 @@ impl<T: Field> Executable<T> for RustHelper {
                 assert_eq!(num, T::zero());
                 Ok(res)
             }
+            RustHelper::Inverse => Ok(vec![T::one() / inputs[0].clone()]),
         }
     }
 }

--- a/zokrates_core/src/helpers/rust.rs
+++ b/zokrates_core/src/helpers/rust.rs
@@ -7,7 +7,7 @@ pub enum RustHelper {
     Identity,
     ConditionEq,
     Bits,
-    Inverse,
+    Div,
 }
 
 impl fmt::Display for RustHelper {
@@ -16,7 +16,7 @@ impl fmt::Display for RustHelper {
             RustHelper::Identity => write!(f, "Identity"),
             RustHelper::ConditionEq => write!(f, "ConditionEq"),
             RustHelper::Bits => write!(f, "Bits"),
-            RustHelper::Inverse => write!(f, "Inverse"),
+            RustHelper::Div => write!(f, "Div"),
         }
     }
 }
@@ -27,7 +27,7 @@ impl Signed for RustHelper {
             RustHelper::Identity => (1, 1),
             RustHelper::ConditionEq => (1, 2),
             RustHelper::Bits => (1, 254),
-            RustHelper::Inverse => (1, 1),
+            RustHelper::Div => (2, 1),
         }
     }
 }
@@ -55,7 +55,7 @@ impl<T: Field> Executable<T> for RustHelper {
                 assert_eq!(num, T::zero());
                 Ok(res)
             }
-            RustHelper::Inverse => Ok(vec![T::one() / inputs[0].clone()]),
+            RustHelper::Div => Ok(vec![inputs[0].clone() / inputs[1].clone()]),
         }
     }
 }

--- a/zokrates_core/src/static_analysis/flat_propagation.rs
+++ b/zokrates_core/src/static_analysis/flat_propagation.rs
@@ -49,14 +49,6 @@ impl<T: Field> PropagateWithContext<T> for FlatExpression<T> {
                     (e1, e2) => FlatExpression::Mult(box e1, box e2),
                 }
             }
-            FlatExpression::Div(box e1, box e2) => {
-                match (e1.propagate(constants), e2.propagate(constants)) {
-                    (FlatExpression::Number(n1), FlatExpression::Number(n2)) => {
-                        FlatExpression::Number(n1 / n2)
-                    }
-                    (e1, e2) => FlatExpression::Div(box e1, box e2),
-                }
-            }
         }
     }
 }
@@ -171,19 +163,6 @@ mod tests {
                 assert_eq!(
                     e.propagate(&mut HashMap::new()),
                     FlatExpression::Number(FieldPrime::from(6))
-                );
-            }
-
-            #[test]
-            fn div() {
-                let e = FlatExpression::Div(
-                    box FlatExpression::Number(FieldPrime::from(6)),
-                    box FlatExpression::Number(FieldPrime::from(2)),
-                );
-
-                assert_eq!(
-                    e.propagate(&mut HashMap::new()),
-                    FlatExpression::Number(FieldPrime::from(3))
                 );
             }
         }


### PR DESCRIPTION
Our IR currently supports divisions. To move closer to R1CS, remove divisions and emulate them with multiplications.

Example: `a = b/c`
Currently flattens to 
```
a = b/c
```
We can do
```
# inv_c = Helper::Inverse(c) // return 1/c
c * inv_c == 1
a = b * inv_c
```

Or
```
# a = Helper::Div(b, c) // returns b/c
a * c == b
```

~Seems to me that the first version reads a bit better, but no strong opinion. @JacobEberhardt ?~
We take the latter approach.