### PR TITLE
fixing issue with exponent order of operation

### DIFF
--- a/power.code
+++ b/power.code
@@ -1,0 +1,3 @@
+def main() -> (field): 
+    field a = 3+2**(1+2)
+    return (if a == 10 then 1 else 0 fi)

--- a/zokrates_core/src/parser/parse/expression.rs
+++ b/zokrates_core/src/parser/parse/expression.rs
@@ -300,7 +300,7 @@ pub fn parse_term1<T: Field>(
         (Token::Pow, s1, p1) => match parse_term(&s1, &p1) {
             Ok((e, s2, p2)) => Ok((Expression::Pow(box expr, box e), s2, p2)),
             Err(err) => Err(err),
-        }
+        },
         _ => Ok((expr, input, pos)),
     }
 }

--- a/zokrates_core/src/parser/parse/expression.rs
+++ b/zokrates_core/src/parser/parse/expression.rs
@@ -297,6 +297,10 @@ pub fn parse_term1<T: Field>(
             Ok((e, s2, p2)) => Ok((Expression::Div(box expr, box e), s2, p2)),
             Err(err) => Err(err),
         },
+        (Token::Pow, s1, p1) => match parse_term(&s1, &p1) {
+            Ok((e, s2, p2)) => Ok((Expression::Pow(box expr, box e), s2, p2)),
+            Err(err) => Err(err),
+        }
         _ => Ok((expr, input, pos)),
     }
 }
@@ -323,13 +327,6 @@ pub fn parse_expr1<T: Field>(
         },
         (Token::Sub, s1, p1) => match parse_term(&s1, &p1) {
             Ok((e2, s2, p2)) => parse_expr1(Expression::Sub(box expr, box e2), s2, p2),
-            Err(err) => Err(err),
-        },
-        (Token::Pow, s1, p1) => match parse_term(&s1, &p1) {
-            Ok((e, s2, p2)) => match parse_term1(Expression::Pow(box expr, box e), s2, p2) {
-                Ok((e3, s3, p3)) => parse_expr1(e3, s3, p3),
-                Err(err) => Err(err),
-            },
             Err(err) => Err(err),
         },
         _ => Ok((expr, input, pos)),


### PR DESCRIPTION
In reference to:  https://github.com/Zokrates/ZoKrates/issues/175

It seems the main reason the order of operations was not being handled for exponents is because exponentiation was being treated the same as the add and subtract operations. 

Here, we move the handling of exponents from `parse_expr1` into `parse_term1`, which handles them a little bit differently. 

Still trying to understand fully why this fixes the problem. 