### PR TITLE
Disable codecov comments

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,1 @@
+comment: off


### PR DESCRIPTION
Coverage data is not yet useful in a PR. Disable comments for now.