### PR TITLE
Return variables in ZIR functions

### DIFF
--- a/zokrates_core/src/ir/mod.rs
+++ b/zokrates_core/src/ir/mod.rs
@@ -63,7 +63,7 @@ pub struct Function<T: Field> {
     pub id: String,
     pub statements: Vec<Statement<T>>,
     pub arguments: Vec<FlatVariable>,
-    pub returns: Vec<QuadComb<T>>,
+    pub returns: Vec<FlatVariable>,
 }
 
 impl<T: Field> fmt::Display for Function<T> {


### PR DESCRIPTION
We currently return quadratic combinations in ZIR functions, however we could return FlatVariables because
- the only Function we have is `main` and it has to return FlatVariables anyway
- even if we had function calls in ZIR, they could be optimised to remove the introduced variables, see [here](https://hackmd.io/PxMjRswuSQ6E4YAsquZGGw)