### PR TITLE
Remove unused substitution and variable map in Flattener

### DIFF
--- a/zokrates_cli/tests/integration.rs
+++ b/zokrates_cli/tests/integration.rs
@@ -98,7 +98,7 @@ mod integration {
             "--light",
         ];
 
-        if program_name.contains("libsnark") {
+        if program_name.contains("sha") {
             // we don't want to test libsnark integrations if libsnark is not available
             #[cfg(not(feature = "libsnark"))]
             return;

--- a/zokrates_core/src/flat_absy/flat_parameter.rs
+++ b/zokrates_core/src/flat_absy/flat_parameter.rs
@@ -36,7 +36,7 @@ impl fmt::Debug for FlatParameter {
 }
 
 impl FlatParameter {
-    pub fn apply_direct_substitution(
+    pub fn apply_substitution(
         self,
         substitution: &HashMap<FlatVariable, FlatVariable>,
     ) -> FlatParameter {

--- a/zokrates_core/src/flat_absy/flat_variable.rs
+++ b/zokrates_core/src/flat_absy/flat_variable.rs
@@ -50,15 +50,8 @@ impl fmt::Debug for FlatVariable {
 }
 
 impl FlatVariable {
-    pub fn apply_substitution(
-        self,
-        substitution: &HashMap<FlatVariable, FlatVariable>,
-        should_fallback: bool,
-    ) -> Self {
-        match should_fallback {
-            true => substitution.get(&self).unwrap_or(&self).clone(),
-            false => substitution.get(&self).unwrap().clone(),
-        }
+    pub fn apply_substitution(self, substitution: &HashMap<FlatVariable, FlatVariable>) -> &Self {
+        substitution.get(&self).unwrap()
     }
 
     pub fn is_output(&self) -> bool {

--- a/zokrates_core/src/flat_absy/mod.rs
+++ b/zokrates_core/src/flat_absy/mod.rs
@@ -213,13 +213,6 @@ impl<T: Field> fmt::Debug for FlatStatement<T> {
 }
 
 impl<T: Field> FlatStatement<T> {
-    pub fn apply_recursive_substitution(
-        self,
-        substitution: &HashMap<FlatVariable, FlatVariable>,
-    ) -> FlatStatement<T> {
-        self.apply_substitution(substitution, true)
-    }
-
     pub fn apply_direct_substitution(
         self,
         substitution: &HashMap<FlatVariable, FlatVariable>,
@@ -276,13 +269,6 @@ pub enum FlatExpression<T: Field> {
 }
 
 impl<T: Field> FlatExpression<T> {
-    pub fn apply_recursive_substitution(
-        self,
-        substitution: &HashMap<FlatVariable, FlatVariable>,
-    ) -> FlatExpression<T> {
-        self.apply_substitution(substitution, true)
-    }
-
     pub fn apply_direct_substitution(
         self,
         substitution: &HashMap<FlatVariable, FlatVariable>,
@@ -404,13 +390,6 @@ impl<T: Field> FlatExpressionList<T> {
                 .map(|e| e.apply_substitution(substitution, should_fallback))
                 .collect(),
         }
-    }
-
-    pub fn apply_recursive_substitution(
-        self,
-        substitution: &HashMap<FlatVariable, FlatVariable>,
-    ) -> FlatExpressionList<T> {
-        self.apply_substitution(substitution, true)
     }
 
     pub fn apply_direct_substitution(

--- a/zokrates_core/src/flat_absy/mod.rs
+++ b/zokrates_core/src/flat_absy/mod.rs
@@ -213,40 +213,30 @@ impl<T: Field> fmt::Debug for FlatStatement<T> {
 }
 
 impl<T: Field> FlatStatement<T> {
-    pub fn apply_direct_substitution(
+    pub fn apply_substitution(
         self,
         substitution: &HashMap<FlatVariable, FlatVariable>,
-    ) -> FlatStatement<T> {
-        self.apply_substitution(substitution, false)
-    }
-
-    fn apply_substitution(
-        self,
-        substitution: &HashMap<FlatVariable, FlatVariable>,
-        should_fallback: bool,
     ) -> FlatStatement<T> {
         match self {
             FlatStatement::Definition(id, x) => FlatStatement::Definition(
-                id.apply_substitution(substitution, should_fallback),
-                x.apply_substitution(substitution, should_fallback),
+                *id.apply_substitution(substitution),
+                x.apply_substitution(substitution),
             ),
-            FlatStatement::Return(x) => {
-                FlatStatement::Return(x.apply_substitution(substitution, should_fallback))
-            }
+            FlatStatement::Return(x) => FlatStatement::Return(x.apply_substitution(substitution)),
             FlatStatement::Condition(x, y) => FlatStatement::Condition(
-                x.apply_substitution(substitution, should_fallback),
-                y.apply_substitution(substitution, should_fallback),
+                x.apply_substitution(substitution),
+                y.apply_substitution(substitution),
             ),
             FlatStatement::Directive(d) => {
                 let outputs = d
                     .outputs
                     .into_iter()
-                    .map(|o| o.apply_substitution(substitution, should_fallback))
+                    .map(|o| *o.apply_substitution(substitution))
                     .collect();
                 let inputs = d
                     .inputs
                     .into_iter()
-                    .map(|i| i.apply_substitution(substitution, should_fallback))
+                    .map(|i| i.apply_substitution(substitution))
                     .collect();
 
                 FlatStatement::Directive(DirectiveStatement {
@@ -269,34 +259,26 @@ pub enum FlatExpression<T: Field> {
 }
 
 impl<T: Field> FlatExpression<T> {
-    pub fn apply_direct_substitution(
+    pub fn apply_substitution(
         self,
         substitution: &HashMap<FlatVariable, FlatVariable>,
-    ) -> FlatExpression<T> {
-        self.apply_substitution(substitution, false)
-    }
-
-    fn apply_substitution(
-        self,
-        substitution: &HashMap<FlatVariable, FlatVariable>,
-        should_fallback: bool,
     ) -> FlatExpression<T> {
         match self {
             e @ FlatExpression::Number(_) => e,
             FlatExpression::Identifier(id) => {
-                FlatExpression::Identifier(id.apply_substitution(substitution, should_fallback))
+                FlatExpression::Identifier(*id.apply_substitution(substitution))
             }
             FlatExpression::Add(e1, e2) => FlatExpression::Add(
-                box e1.apply_substitution(substitution, should_fallback),
-                box e2.apply_substitution(substitution, should_fallback),
+                box e1.apply_substitution(substitution),
+                box e2.apply_substitution(substitution),
             ),
             FlatExpression::Sub(e1, e2) => FlatExpression::Sub(
-                box e1.apply_substitution(substitution, should_fallback),
-                box e2.apply_substitution(substitution, should_fallback),
+                box e1.apply_substitution(substitution),
+                box e2.apply_substitution(substitution),
             ),
             FlatExpression::Mult(e1, e2) => FlatExpression::Mult(
-                box e1.apply_substitution(substitution, should_fallback),
-                box e2.apply_substitution(substitution, should_fallback),
+                box e1.apply_substitution(substitution),
+                box e2.apply_substitution(substitution),
             ),
         }
     }
@@ -378,25 +360,17 @@ impl<T: Field> fmt::Display for FlatExpressionList<T> {
 }
 
 impl<T: Field> FlatExpressionList<T> {
-    fn apply_substitution(
+    pub fn apply_substitution(
         self,
         substitution: &HashMap<FlatVariable, FlatVariable>,
-        should_fallback: bool,
     ) -> FlatExpressionList<T> {
         FlatExpressionList {
             expressions: self
                 .expressions
                 .into_iter()
-                .map(|e| e.apply_substitution(substitution, should_fallback))
+                .map(|e| e.apply_substitution(substitution))
                 .collect(),
         }
-    }
-
-    pub fn apply_direct_substitution(
-        self,
-        substitution: &HashMap<FlatVariable, FlatVariable>,
-    ) -> FlatExpressionList<T> {
-        self.apply_substitution(substitution, false)
     }
 }
 

--- a/zokrates_core/src/flatten/mod.rs
+++ b/zokrates_core/src/flatten/mod.rs
@@ -483,19 +483,19 @@ impl Flattener {
                                 expressions: list
                                     .expressions
                                     .into_iter()
-                                    .map(|x| x.apply_direct_substitution(&replacement_map))
+                                    .map(|x| x.apply_substitution(&replacement_map))
                                     .collect(),
                             };
                         }
                         FlatStatement::Definition(var, rhs) => {
                             let new_var = self.issue_new_variable();
                             replacement_map.insert(var, new_var);
-                            let new_rhs = rhs.apply_direct_substitution(&replacement_map);
+                            let new_rhs = rhs.apply_substitution(&replacement_map);
                             statements_flattened.push(FlatStatement::Definition(new_var, new_rhs));
                         }
                         FlatStatement::Condition(lhs, rhs) => {
-                            let new_lhs = lhs.apply_direct_substitution(&replacement_map);
-                            let new_rhs = rhs.apply_direct_substitution(&replacement_map);
+                            let new_lhs = lhs.apply_substitution(&replacement_map);
+                            let new_rhs = rhs.apply_substitution(&replacement_map);
                             statements_flattened.push(FlatStatement::Condition(new_lhs, new_rhs));
                         }
                         FlatStatement::Directive(d) => {
@@ -511,7 +511,7 @@ impl Flattener {
                             let new_inputs = d
                                 .inputs
                                 .into_iter()
-                                .map(|i| i.apply_direct_substitution(&replacement_map))
+                                .map(|i| i.apply_substitution(&replacement_map))
                                 .collect();
                             statements_flattened.push(FlatStatement::Directive(
                                 DirectiveStatement {

--- a/zokrates_core/src/flatten/mod.rs
+++ b/zokrates_core/src/flatten/mod.rs
@@ -8,7 +8,7 @@
 use bimap::BiMap;
 use flat_absy::*;
 use helpers::{DirectiveStatement, Helper, RustHelper};
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use typed_absy::*;
 use types::conversions::cast;
 use types::Signature;
@@ -20,8 +20,6 @@ use zokrates_field::field::Field;
 pub struct Flattener {
     /// Number of bits needed to represent the maximum value.
     bits: usize,
-    /// Vector containing all used variables while processing the program.
-    variables: HashSet<FlatVariable>,
     /// Map of renamings for reassigned variables while processing the program.
     substitution: HashMap<FlatVariable, FlatVariable>,
     /// Index of the next introduced variable while processing the program.
@@ -38,7 +36,6 @@ impl Flattener {
     pub fn new(bits: usize) -> Flattener {
         Flattener {
             bits: bits,
-            variables: HashSet::new(),
             substitution: HashMap::new(),
             next_var_idx: 0,
             bijection: BiMap::new(),
@@ -1085,7 +1082,6 @@ impl Flattener {
                                 // handle return of function call
                                 let var_to_replace = self.get_latest_var_substitution(&debug_name);
                                 if !(var == var_to_replace)
-                                    && self.variables.contains(&var_to_replace)
                                     && !self.substitution.contains_key(&var_to_replace)
                                 {
                                     self.substitution
@@ -1109,7 +1105,6 @@ impl Flattener {
                                                 let var_to_replace =
                                                     self.get_latest_var_substitution(&debug_name);
                                                 if !(var == var_to_replace)
-                                                    && self.variables.contains(&var_to_replace)
                                                     && !self
                                                         .substitution
                                                         .contains_key(&var_to_replace)
@@ -1208,7 +1203,6 @@ impl Flattener {
                             // handle return of function call
                             let var_to_replace = self.get_latest_var_substitution(&debug_name);
                             if !(var == var_to_replace)
-                                && self.variables.contains(&var_to_replace)
                                 && !self.substitution.contains_key(&var_to_replace)
                             {
                                 self.substitution
@@ -1373,7 +1367,6 @@ impl Flattener {
                                         let var_to_replace =
                                             self.get_latest_var_substitution(&debug_name);
                                         if !(var == var_to_replace)
-                                            && self.variables.contains(&var_to_replace)
                                             && !self.substitution.contains_key(&var_to_replace)
                                         {
                                             self.substitution
@@ -1392,7 +1385,6 @@ impl Flattener {
                                     let var_to_replace =
                                         self.get_latest_var_substitution(&debug_name);
                                     if !(var == var_to_replace)
-                                        && self.variables.contains(&var_to_replace)
                                         && !self.substitution.contains_key(&var_to_replace)
                                     {
                                         self.substitution
@@ -1425,7 +1417,6 @@ impl Flattener {
         functions_flattened: &mut Vec<FlatFunction<T>>,
         funct: TypedFunction<T>,
     ) -> FlatFunction<T> {
-        self.variables = HashSet::new();
         self.substitution = HashMap::new();
 
         self.bijection = BiMap::new();

--- a/zokrates_core/src/optimizer.rs
+++ b/zokrates_core/src/optimizer.rs
@@ -103,7 +103,7 @@ impl Optimizer {
                     // filter out synonyms definitions
                     FlatStatement::Definition(_, FlatExpression::Identifier(_)) => None,
                     // substitute all other statements
-                    _ => Some(statement.apply_direct_substitution(&self.substitution)),
+                    _ => Some(statement.apply_substitution(&self.substitution)),
                 }
             })
             .collect();
@@ -112,7 +112,7 @@ impl Optimizer {
         let optimized_arguments = funct
             .arguments
             .into_iter()
-            .map(|arg| arg.apply_direct_substitution(&self.substitution))
+            .map(|arg| arg.apply_substitution(&self.substitution))
             .collect();
 
         FlatFunction {


### PR DESCRIPTION
These are actually unused since we use a bijection to find the latest FlatVariable for a given Variable