### PR TITLE
Reduce Flattener API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -277,6 +277,11 @@ version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "glob"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "idna"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -785,18 +790,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "stdlib"
-version = "0.1.0"
-dependencies = [
- "serde 1.0.85 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.85 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.36 (registry+https://github.com/rust-lang/crates.io-index)",
- "zokrates_core 0.3.6",
- "zokrates_field 0.3.2",
- "zokrates_fs_resolver 0.4.0",
-]
-
-[[package]]
 name = "strsim"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1038,6 +1031,19 @@ dependencies = [
  "tempfile 3.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
+[[package]]
+name = "zokrates_stdlib"
+version = "0.1.0"
+dependencies = [
+ "glob 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.85 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.85 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.36 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zokrates_core 0.3.6",
+ "zokrates_field 0.3.2",
+ "zokrates_fs_resolver 0.4.0",
+]
+
 [metadata]
 "checksum aho-corasick 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)" = "1e9a933f4e58658d7b12defcf96dc5c720f20832deebe3e0a19efd3b6aaeeb9e"
 "checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
@@ -1072,6 +1078,7 @@ dependencies = [
 "checksum fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 "checksum git2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c7339329bfa14a00223244311560d11f8f489b453fb90092af97f267a6090ab0"
 "checksum glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb"
+"checksum glob 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 "checksum idna 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "38f09e0f0b1fb55fdee1f17470ad800da77af5186a1a76c026b679358b7e844e"
 "checksum itoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "1306f3464951f30e30d12373d31c79fbd52d236e5e896fd92f96ec7babbbe60b"
 "checksum lazy_static 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "cf186d1a8aa5f5bee5fd662bc9c1b949e0259e1bcc379d1f006847b0080c7417"

--- a/zokrates_core/src/compile.rs
+++ b/zokrates_core/src/compile.rs
@@ -162,7 +162,7 @@ pub fn compile_aux<T: Field, R: BufRead, S: BufRead, E: Into<imports::Error>>(
     let typed_ast = typed_ast.analyse();
 
     // flatten input program
-    let program_flattened = Flattener::new(T::get_required_bits()).flatten_program(typed_ast);
+    let program_flattened = Flattener::flatten(typed_ast);
 
     // analyse (constant propagation after call resolution)
     let program_flattened = program_flattened.analyse();

--- a/zokrates_core/src/flatten/mod.rs
+++ b/zokrates_core/src/flatten/mod.rs
@@ -1029,7 +1029,7 @@ impl Flattener {
         }
     }
 
-    pub fn flatten_statement<T: Field>(
+    fn flatten_statement<T: Field>(
         &mut self,
         functions_flattened: &Vec<FlatFunction<T>>,
         arguments_flattened: &Vec<FlatParameter>,
@@ -1424,7 +1424,7 @@ impl Flattener {
     ///
     /// * `functions_flattened` - Vector where new flattened functions can be added.
     /// * `funct` - `TypedFunction` that will be flattened.
-    pub fn flatten_function<T: Field>(
+    fn flatten_function<T: Field>(
         &mut self,
         functions_flattened: &mut Vec<FlatFunction<T>>,
         funct: TypedFunction<T>,
@@ -1490,7 +1490,7 @@ impl Flattener {
     /// # Arguments
     ///
     /// * `prog` - `Prog`ram that will be flattened.
-    pub fn flatten_program<T: Field>(&mut self, prog: TypedProg<T>) -> FlatProg<T> {
+    fn flatten_program<T: Field>(&mut self, prog: TypedProg<T>) -> FlatProg<T> {
         let mut functions_flattened = Vec::new();
 
         self.load_corelib(&mut functions_flattened);

--- a/zokrates_core/src/flatten/mod.rs
+++ b/zokrates_core/src/flatten/mod.rs
@@ -30,12 +30,16 @@ pub struct Flattener {
     bijection: BiMap<String, FlatVariable>,
 }
 impl Flattener {
+    pub fn flatten<T: Field>(p: TypedProg<T>) -> FlatProg<T> {
+        Flattener::new(T::get_required_bits()).flatten_program(p)
+    }
+
     /// Returns a `Flattener` with fresh a fresh [substitution] and [variables].
     ///
     /// # Arguments
     ///
     /// * `bits` - Number of bits needed to represent the maximum value.
-    pub fn new(bits: usize) -> Flattener {
+    fn new(bits: usize) -> Flattener {
         Flattener {
             bits: bits,
             variables: HashSet::new(),


### PR DESCRIPTION
As we expose the constructor of the Flattener, this would make it possible to reuse it, which isn't great as it's not stateless. Remove this possibility by creating the flattener in a static call.

Also stop exposing instance-level flattening functions.