### PR TITLE
Remove loop in function call resolution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -277,6 +277,11 @@ version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "glob"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "idna"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -785,18 +790,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "stdlib"
-version = "0.1.0"
-dependencies = [
- "serde 1.0.85 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.85 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.36 (registry+https://github.com/rust-lang/crates.io-index)",
- "zokrates_core 0.3.6",
- "zokrates_field 0.3.2",
- "zokrates_fs_resolver 0.4.0",
-]
-
-[[package]]
 name = "strsim"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1038,6 +1031,19 @@ dependencies = [
  "tempfile 3.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
+[[package]]
+name = "zokrates_stdlib"
+version = "0.1.0"
+dependencies = [
+ "glob 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.85 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.85 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.36 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zokrates_core 0.3.6",
+ "zokrates_field 0.3.2",
+ "zokrates_fs_resolver 0.4.0",
+]
+
 [metadata]
 "checksum aho-corasick 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)" = "1e9a933f4e58658d7b12defcf96dc5c720f20832deebe3e0a19efd3b6aaeeb9e"
 "checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
@@ -1072,6 +1078,7 @@ dependencies = [
 "checksum fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 "checksum git2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c7339329bfa14a00223244311560d11f8f489b453fb90092af97f267a6090ab0"
 "checksum glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb"
+"checksum glob 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 "checksum idna 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "38f09e0f0b1fb55fdee1f17470ad800da77af5186a1a76c026b679358b7e844e"
 "checksum itoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "1306f3464951f30e30d12373d31c79fbd52d236e5e896fd92f96ec7babbbe60b"
 "checksum lazy_static 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "cf186d1a8aa5f5bee5fd662bc9c1b949e0259e1bcc379d1f006847b0080c7417"

--- a/zokrates_core/src/flatten/mod.rs
+++ b/zokrates_core/src/flatten/mod.rs
@@ -443,7 +443,9 @@ impl Flattener {
             .inputs(param_expressions.iter().map(|e| e.get_type()).collect())
             .outputs(return_types);
 
-        let funct = self.get_function(passed_signature, &functions_flattened, id).clone();
+        let funct = self
+            .get_function(passed_signature, &functions_flattened, id)
+            .clone();
 
         let mut replacement_map = HashMap::new();
 
@@ -451,7 +453,14 @@ impl Flattener {
         // Rename Parameters, assign them to values in call. Resolve complex expressions with definitions
         let params_flattened = param_expressions
             .into_iter()
-            .map(|param_expr| self.flatten_expression(functions_flattened, arguments_flattened, statements_flattened, param_expr.clone()))
+            .map(|param_expr| {
+                self.flatten_expression(
+                    functions_flattened,
+                    arguments_flattened,
+                    statements_flattened,
+                    param_expr.clone(),
+                )
+            })
             .into_iter()
             .flat_map(|x| x)
             .collect::<Vec<_>>();
@@ -1532,7 +1541,12 @@ impl Flattener {
         latest_var
     }
 
-    fn get_function<'a, T: Field>(&self, s: Signature, functions_flattened: &'a Vec<FlatFunction<T>>, id: &str) -> &'a FlatFunction<T> {
+    fn get_function<'a, T: Field>(
+        &self,
+        s: Signature,
+        functions_flattened: &'a Vec<FlatFunction<T>>,
+        id: &str,
+    ) -> &'a FlatFunction<T> {
         functions_flattened
             .iter()
             .find(|f| f.id == id && f.signature == s)

--- a/zokrates_core/src/flatten/mod.rs
+++ b/zokrates_core/src/flatten/mod.rs
@@ -440,107 +440,96 @@ impl Flattener {
         param_expressions: &Vec<TypedExpression<T>>,
     ) -> FlatExpressionList<T> {
         let passed_signature = Signature::new()
-            .inputs(
-                param_expressions
-                    .into_iter()
-                    .map(|e| e.get_type())
-                    .collect(),
-            )
+            .inputs(param_expressions.iter().map(|e| e.get_type()).collect())
             .outputs(return_types);
 
-        for funct in functions_flattened {
-            if funct.id == *id && funct.signature == passed_signature {
-                // funct is now the called function
+        let funct = self.get_function(passed_signature, &functions_flattened, id).clone();
 
-                // Stores prefixed variables
+        let mut replacement_map = HashMap::new();
 
-                let mut replacement_map = HashMap::new();
+        // Handle complex parameters and assign values:
+        // Rename Parameters, assign them to values in call. Resolve complex expressions with definitions
+        let params_flattened = param_expressions
+            .into_iter()
+            .map(|param_expr| self.flatten_expression(functions_flattened, arguments_flattened, statements_flattened, param_expr.clone()))
+            .into_iter()
+            .flat_map(|x| x)
+            .collect::<Vec<_>>();
 
-                // Handle complex parameters and assign values:
-                // Rename Parameters, assign them to values in call. Resolve complex expressions with definitions
-                let params_flattened = param_expressions
-                    .clone()
-                    .into_iter()
-                    .map(|param_expr| {
-                        self.flatten_expression(
-                            functions_flattened,
-                            arguments_flattened,
-                            statements_flattened,
-                            param_expr,
-                        )
-                    })
-                    .into_iter()
-                    .flat_map(|x| x)
-                    .collect::<Vec<_>>();
+        let params_flattened = params_flattened
+            .into_iter()
+            .map(|e| e.apply_recursive_substitution(&self.substitution))
+            .collect::<Vec<_>>();
 
-                let params_flattened = params_flattened
-                    .into_iter()
-                    .map(|e| e.apply_recursive_substitution(&self.substitution))
-                    .collect::<Vec<_>>();
-
-                for (index, r) in params_flattened.into_iter().enumerate() {
-                    let new_var = self.use_sym();
-                    statements_flattened.push(FlatStatement::Definition(new_var, r));
-                    replacement_map.insert(funct.arguments.get(index).unwrap().id.clone(), new_var);
-                }
-
-                // Ensure Renaming and correct returns:
-                // add all flattened statements, adapt return statement
-                for stat in funct.statements.clone() {
-                    match stat {
-                        // set return statements right sidreturne as expression result
-                        FlatStatement::Return(list) => {
-                            return FlatExpressionList {
-                                expressions: list
-                                    .expressions
-                                    .into_iter()
-                                    .map(|x| x.apply_direct_substitution(&replacement_map))
-                                    .collect(),
-                            };
-                        }
-                        FlatStatement::Definition(var, rhs) => {
-                            let new_var = self.issue_new_variable();
-                            replacement_map.insert(var, new_var);
-                            let new_rhs = rhs.apply_direct_substitution(&replacement_map);
-                            statements_flattened.push(FlatStatement::Definition(new_var, new_rhs));
-                        }
-                        FlatStatement::Condition(lhs, rhs) => {
-                            let new_lhs = lhs.apply_direct_substitution(&replacement_map);
-                            let new_rhs = rhs.apply_direct_substitution(&replacement_map);
-                            statements_flattened.push(FlatStatement::Condition(new_lhs, new_rhs));
-                        }
-                        FlatStatement::Directive(d) => {
-                            let new_outputs = d
-                                .outputs
-                                .into_iter()
-                                .map(|o| {
-                                    let new_o = self.issue_new_variable();
-                                    replacement_map.insert(o, new_o);
-                                    new_o
-                                })
-                                .collect();
-                            let new_inputs = d
-                                .inputs
-                                .into_iter()
-                                .map(|i| i.apply_direct_substitution(&replacement_map))
-                                .collect();
-                            statements_flattened.push(FlatStatement::Directive(
-                                DirectiveStatement {
-                                    outputs: new_outputs,
-                                    helper: d.helper.clone(),
-                                    inputs: new_inputs,
-                                },
-                            ))
-                        }
-                    }
-                }
-            }
+        for (concrete_argument, formal_argument) in
+            params_flattened.into_iter().zip(funct.arguments)
+        {
+            let new_var = self.use_sym();
+            statements_flattened.push(FlatStatement::Definition(new_var, concrete_argument));
+            replacement_map.insert(formal_argument.id, new_var);
         }
-        panic!(
-            "TypedFunction definition for function {} with {:?} argument(s) not found. Should have been detected during semantic checking.",
-            id,
-            param_expressions
-        );
+
+        // Ensure Renaming and correct returns:
+        // add all flattened statements, adapt return statement
+
+        let (return_statements, statements): (Vec<_>, Vec<_>) =
+            funct.statements.into_iter().partition(|s| match s {
+                FlatStatement::Return(..) => true,
+                _ => false,
+            });
+
+        let statements: Vec<_> = statements
+            .into_iter()
+            .map(|stat| match stat {
+                // set return statements right sidreturne as expression result
+                FlatStatement::Return(..) => unreachable!(),
+                FlatStatement::Definition(var, rhs) => {
+                    let new_var = self.issue_new_variable();
+                    replacement_map.insert(var, new_var);
+                    let new_rhs = rhs.apply_direct_substitution(&replacement_map);
+                    FlatStatement::Definition(new_var, new_rhs)
+                }
+                FlatStatement::Condition(lhs, rhs) => {
+                    let new_lhs = lhs.apply_direct_substitution(&replacement_map);
+                    let new_rhs = rhs.apply_direct_substitution(&replacement_map);
+                    FlatStatement::Condition(new_lhs, new_rhs)
+                }
+                FlatStatement::Directive(d) => {
+                    let new_outputs = d
+                        .outputs
+                        .into_iter()
+                        .map(|o| {
+                            let new_o = self.issue_new_variable();
+                            replacement_map.insert(o, new_o);
+                            new_o
+                        })
+                        .collect();
+                    let new_inputs = d
+                        .inputs
+                        .into_iter()
+                        .map(|i| i.apply_direct_substitution(&replacement_map))
+                        .collect();
+                    FlatStatement::Directive(DirectiveStatement {
+                        outputs: new_outputs,
+                        helper: d.helper,
+                        inputs: new_inputs,
+                    })
+                }
+            })
+            .collect();
+
+        statements_flattened.extend(statements);
+
+        match return_statements[0].clone() {
+            FlatStatement::Return(list) => FlatExpressionList {
+                expressions: list
+                    .expressions
+                    .into_iter()
+                    .map(|x| x.apply_direct_substitution(&replacement_map))
+                    .collect(),
+            },
+            _ => unreachable!(),
+        }
     }
 
     fn flatten_expression<T: Field>(
@@ -1541,6 +1530,13 @@ impl Flattener {
         //     }
         // }
         latest_var
+    }
+
+    fn get_function<'a, T: Field>(&self, s: Signature, functions_flattened: &'a Vec<FlatFunction<T>>, id: &str) -> &'a FlatFunction<T> {
+        functions_flattened
+            .iter()
+            .find(|f| f.id == id && f.signature == s)
+            .unwrap()
     }
 }
 


### PR DESCRIPTION
We currently `loop` over all functions, filtering by signature, then early-return in a match statement when we see a `return`.

Take a clearer, functional approach of 
- finding the function based on the signature
- isolating the return statement
- translate the other statements
- return with the return statement