### PR TITLE
Speed up build by making deps optional

### DIFF
--- a/zokrates_core/Cargo.toml
+++ b/zokrates_core/Cargo.toml
@@ -8,8 +8,8 @@ build = "build.rs"
 
 [features]
 default = []
-libsnark = []
-wasm = []
+libsnark = ["cc", "cmake", "git2"]
+wasm = ["wasmi", "parity-wasm", "rustc-hex"]
 
 [dependencies]
 libc = "0.2.0"
@@ -30,9 +30,9 @@ pairing = { git = "https://github.com/matterinc/pairing", tag = "0.16.2" }
 ff = { git = 'https://github.com/matterinc/ff', features = ["derive"], tag = "0.5" }
 zokrates_field = { version = "0.3.0", path = "../zokrates_field" }
 rand = "0.4"
-wasmi = "0.4.2"
-parity-wasm = "0.35.3"
-rustc-hex = "1.0"
+wasmi = { version = "0.4.2", optional = true }
+parity-wasm = { version = "0.35.3", optional = true }
+rustc-hex = { version = "1.0", optional = true }
 csv = "1"
 
 [dev-dependencies]
@@ -40,6 +40,6 @@ glob = "0.2.11"
 assert_cli = "0.5"
 
 [build-dependencies]
-cc = { version = "1.0", features = ["parallel"] }
-cmake = "0.1.31"
-git2 = "0.8.0"
+cc = { version = "1.0", features = ["parallel"], optional = true }
+cmake = { version = "0.1.31", optional = true }
+git2 = { version = "0.8.0", optional = true }

--- a/zokrates_core/build.rs
+++ b/zokrates_core/build.rs
@@ -1,5 +1,8 @@
+#[cfg(feature = "libsnark")]
 extern crate cc;
+#[cfg(feature = "libsnark")]
 extern crate cmake;
+#[cfg(feature = "libsnark")]
 extern crate git2;
 
 fn main() {

--- a/zokrates_field/Cargo.toml
+++ b/zokrates_field/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zokrates_field"
 version = "0.3.2"
-authors = ["Guillaume Ballet <gballet@gmail.com>"]
+authors = ["Thibaut Schaeffer <thibaut@schaeff.fr>", "Guillaume Ballet <gballet@gmail.com>"]
 edition = "2018"
 
 [dependencies]


### PR DESCRIPTION
When not using libsnark or wasm, we still build cc, git, wasmi, etc.

Bind these to the features and reduce build time by ~40% when features are disabled.