### PR TITLE
Expose wasm feature in zokrates_cli

### DIFF
--- a/zokrates_cli/Cargo.toml
+++ b/zokrates_cli/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2018"
 [features]
 default = []
 libsnark = ["zokrates_core/libsnark"]
+wasm = ["zokrates_core/wasm"]
 
 [dependencies]
 clap = "2.26.2"


### PR DESCRIPTION
To allow enabling it alongside libsnark with:
`cargo -Z package-features build --package zokrates_cli --features="wasm, libsnark"`