### PR TITLE
Finish migration to rust edition 2018

### DIFF
--- a/zokrates_core/src/absy/mod.rs
+++ b/zokrates_core/src/absy/mod.rs
@@ -9,13 +9,13 @@ mod node;
 pub mod parameter;
 pub mod variable;
 
-pub use absy::node::{Node, NodeValue};
-pub use absy::parameter::{Parameter, ParameterNode};
-pub use absy::variable::{Variable, VariableNode};
-use types::Signature;
+pub use crate::absy::node::{Node, NodeValue};
+pub use crate::absy::parameter::{Parameter, ParameterNode};
+pub use crate::absy::variable::{Variable, VariableNode};
+use crate::types::Signature;
 
-use flat_absy::*;
-use imports::ImportNode;
+use crate::flat_absy::*;
+use crate::imports::ImportNode;
 use std::fmt;
 use zokrates_field::field::Field;
 
@@ -192,17 +192,17 @@ impl<T: Field> fmt::Display for Statement<T> {
             Statement::Definition(ref lhs, ref rhs) => write!(f, "{} = {}", lhs, rhs),
             Statement::Condition(ref lhs, ref rhs) => write!(f, "{} == {}", lhs, rhs),
             Statement::For(ref var, ref start, ref stop, ref list) => {
-                try!(write!(f, "for {} in {}..{} do\n", var, start, stop));
+                r#try!(write!(f, "for {} in {}..{} do\n", var, start, stop));
                 for l in list {
-                    try!(write!(f, "\t\t{}\n", l));
+                    r#try!(write!(f, "\t\t{}\n", l));
                 }
                 write!(f, "\tendfor")
             }
             Statement::MultipleDefinition(ref ids, ref rhs) => {
                 for (i, id) in ids.iter().enumerate() {
-                    try!(write!(f, "{}", id));
+                    r#try!(write!(f, "{}", id));
                     if i < ids.len() - 1 {
-                        try!(write!(f, ", "));
+                        r#try!(write!(f, ", "));
                     }
                 }
                 write!(f, " = {}", rhs)
@@ -221,9 +221,9 @@ impl<T: Field> fmt::Debug for Statement<T> {
             }
             Statement::Condition(ref lhs, ref rhs) => write!(f, "Condition({:?}, {:?})", lhs, rhs),
             Statement::For(ref var, ref start, ref stop, ref list) => {
-                try!(write!(f, "for {:?} in {:?}..{:?} do\n", var, start, stop));
+                r#try!(write!(f, "for {:?} in {:?}..{:?} do\n", var, start, stop));
                 for l in list {
-                    try!(write!(f, "\t\t{:?}\n", l));
+                    r#try!(write!(f, "\t\t{:?}\n", l));
                 }
                 write!(f, "\tendfor")
             }
@@ -279,11 +279,11 @@ impl<T: Field> fmt::Display for Expression<T> {
                 condition, consequent, alternative
             ),
             Expression::FunctionCall(ref i, ref p) => {
-                try!(write!(f, "{}(", i,));
+                r#try!(write!(f, "{}(", i,));
                 for (i, param) in p.iter().enumerate() {
-                    try!(write!(f, "{}", param));
+                    r#try!(write!(f, "{}", param));
                     if i < p.len() - 1 {
-                        try!(write!(f, ", "));
+                        r#try!(write!(f, ", "));
                     }
                 }
                 write!(f, ")")
@@ -296,11 +296,11 @@ impl<T: Field> fmt::Display for Expression<T> {
             Expression::And(ref lhs, ref rhs) => write!(f, "{} && {}", lhs, rhs),
             Expression::Not(ref exp) => write!(f, "!{}", exp),
             Expression::InlineArray(ref exprs) => {
-                try!(write!(f, "["));
+                r#try!(write!(f, "["));
                 for (i, e) in exprs.iter().enumerate() {
-                    try!(write!(f, "{}", e));
+                    r#try!(write!(f, "{}", e));
                     if i < exprs.len() - 1 {
-                        try!(write!(f, ", "));
+                        r#try!(write!(f, ", "));
                     }
                 }
                 write!(f, "]")
@@ -327,8 +327,8 @@ impl<T: Field> fmt::Debug for Expression<T> {
                 condition, consequent, alternative
             ),
             Expression::FunctionCall(ref i, ref p) => {
-                try!(write!(f, "FunctionCall({:?}, (", i));
-                try!(f.debug_list().entries(p.iter()).finish());
+                r#try!(write!(f, "FunctionCall({:?}, (", i));
+                r#try!(f.debug_list().entries(p.iter()).finish());
                 write!(f, ")")
             }
             Expression::Lt(ref lhs, ref rhs) => write!(f, "{} < {}", lhs, rhs),
@@ -339,8 +339,8 @@ impl<T: Field> fmt::Debug for Expression<T> {
             Expression::And(ref lhs, ref rhs) => write!(f, "{} && {}", lhs, rhs),
             Expression::Not(ref exp) => write!(f, "!{}", exp),
             Expression::InlineArray(ref exprs) => {
-                try!(write!(f, "InlineArray(["));
-                try!(f.debug_list().entries(exprs.iter()).finish());
+                r#try!(write!(f, "InlineArray(["));
+                r#try!(f.debug_list().entries(exprs.iter()).finish());
                 write!(f, "]")
             }
             Expression::Select(ref array, ref index) => write!(f, "{}[{}]", array, index),
@@ -367,9 +367,9 @@ impl<T: Field> ExpressionList<T> {
 impl<T: Field> fmt::Display for ExpressionList<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         for (i, param) in self.expressions.iter().enumerate() {
-            try!(write!(f, "{}", param));
+            r#try!(write!(f, "{}", param));
             if i < self.expressions.len() - 1 {
-                try!(write!(f, ", "));
+                r#try!(write!(f, ", "));
             }
         }
         write!(f, "")

--- a/zokrates_core/src/absy/node.rs
+++ b/zokrates_core/src/absy/node.rs
@@ -1,4 +1,4 @@
-use parser::Position;
+use crate::parser::Position;
 use std::fmt;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -41,8 +41,8 @@ impl<V: NodeValue> From<V> for Node<V> {
     }
 }
 
-use absy::*;
-use imports::*;
+use crate::absy::*;
+use crate::imports::*;
 use zokrates_field::field::Field;
 
 impl<T: Field> NodeValue for Expression<T> {}

--- a/zokrates_core/src/absy/parameter.rs
+++ b/zokrates_core/src/absy/parameter.rs
@@ -1,4 +1,4 @@
-use absy::{Node, VariableNode};
+use crate::absy::{Node, VariableNode};
 use std::fmt;
 
 #[derive(Clone, PartialEq, Serialize, Deserialize)]

--- a/zokrates_core/src/absy/variable.rs
+++ b/zokrates_core/src/absy/variable.rs
@@ -1,6 +1,6 @@
-use absy::Node;
+use crate::absy::Node;
+use crate::types::Type;
 use std::fmt;
-use types::Type;
 
 #[derive(Serialize, Deserialize, Clone, PartialEq, Hash, Eq)]
 pub struct Variable {

--- a/zokrates_core/src/compile.rs
+++ b/zokrates_core/src/compile.rs
@@ -3,15 +3,15 @@
 //! @file compile.rs
 //! @author Thibaut Schaeffer <thibaut@schaeff.fr>
 //! @date 2018
-use absy::Prog;
-use flat_absy::FlatProg;
-use flatten::Flattener;
-use imports::{self, Importer};
-use ir;
-use optimizer::Optimize;
-use parser::{self, parse_program};
-use semantics::{self, Checker};
-use static_analysis::Analyse;
+use crate::absy::Prog;
+use crate::flat_absy::FlatProg;
+use crate::flatten::Flattener;
+use crate::imports::{self, Importer};
+use crate::ir;
+use crate::optimizer::Optimize;
+use crate::parser::{self, parse_program};
+use crate::semantics::{self, Checker};
+use crate::static_analysis::Analyse;
 use std::fmt;
 use std::io;
 use std::io::BufRead;

--- a/zokrates_core/src/flat_absy/flat_parameter.rs
+++ b/zokrates_core/src/flat_absy/flat_parameter.rs
@@ -1,4 +1,4 @@
-use flat_absy::flat_variable::FlatVariable;
+use crate::flat_absy::flat_variable::FlatVariable;
 use std::collections::HashMap;
 use std::fmt;
 

--- a/zokrates_core/src/flat_absy/mod.rs
+++ b/zokrates_core/src/flat_absy/mod.rs
@@ -11,10 +11,10 @@ pub mod flat_variable;
 pub use self::flat_parameter::FlatParameter;
 pub use self::flat_variable::FlatVariable;
 
-use helpers::{DirectiveStatement, Executable};
+use crate::helpers::{DirectiveStatement, Executable};
+use crate::types::Signature;
 use std::collections::{BTreeMap, HashMap};
 use std::fmt;
-use types::Signature;
 use zokrates_field::field::Field;
 
 #[derive(Clone)]
@@ -339,9 +339,9 @@ pub struct FlatExpressionList<T: Field> {
 impl<T: Field> fmt::Display for FlatExpressionList<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         for (i, param) in self.expressions.iter().enumerate() {
-            try!(write!(f, "{}", param));
+            r#try!(write!(f, "{}", param));
             if i < self.expressions.len() - 1 {
-                try!(write!(f, ", "));
+                r#try!(write!(f, ", "));
             }
         }
         write!(f, "")

--- a/zokrates_core/src/flatten/mod.rs
+++ b/zokrates_core/src/flatten/mod.rs
@@ -5,14 +5,14 @@
 //! @author Jacob Eberhardt <jacob.eberhardt@tu-berlin.de>
 //! @date 2017
 
+use crate::flat_absy::*;
+use crate::helpers::{DirectiveStatement, Helper, RustHelper};
+use crate::typed_absy::*;
+use crate::types::conversions::cast;
+use crate::types::Signature;
+use crate::types::Type;
 use bimap::BiMap;
-use flat_absy::*;
-use helpers::{DirectiveStatement, Helper, RustHelper};
 use std::collections::HashMap;
-use typed_absy::*;
-use types::conversions::cast;
-use types::Signature;
-use types::Type;
 use zokrates_field::field::Field;
 
 /// Flattener, computes flattened program.
@@ -1341,8 +1341,8 @@ impl Flattener {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use types::Signature;
-    use types::Type;
+    use crate::types::Signature;
+    use crate::types::Type;
     use zokrates_field::field::FieldPrime;
 
     #[test]

--- a/zokrates_core/src/helpers/mod.rs
+++ b/zokrates_core/src/helpers/mod.rs
@@ -5,7 +5,7 @@ mod wasm;
 pub use self::rust::RustHelper;
 #[cfg(feature = "wasm")]
 pub use self::wasm::WasmHelper;
-use flat_absy::{FlatExpression, FlatVariable};
+use crate::flat_absy::{FlatExpression, FlatVariable};
 use std::fmt;
 use zokrates_field::field::Field;
 

--- a/zokrates_core/src/helpers/rust.rs
+++ b/zokrates_core/src/helpers/rust.rs
@@ -1,4 +1,4 @@
-use helpers::{Executable, Signed};
+use crate::helpers::{Executable, Signed};
 use std::fmt;
 use zokrates_embed::generate_sha256_round_witness;
 use zokrates_field::field::Field;

--- a/zokrates_core/src/imports.rs
+++ b/zokrates_core/src/imports.rs
@@ -4,11 +4,11 @@
 //! @author Thibaut Schaeffer <thibaut@schaeff.fr>
 //! @date 2018
 
-use absy::*;
-use compile::compile_aux;
-use compile::{CompileErrorInner, CompileErrors};
-use flat_absy::*;
-use parser::Position;
+use crate::absy::*;
+use crate::compile::compile_aux;
+use crate::compile::{CompileErrorInner, CompileErrors};
+use crate::flat_absy::*;
+use crate::parser::Position;
 use std::fmt;
 use std::io;
 use std::io::BufRead;
@@ -142,7 +142,7 @@ impl Importer {
             if import.source.starts_with("BELLMAN") {
                 match import.source.as_ref() {
                     "BELLMAN/sha256round" => {
-                        use standard::sha_round;
+                        use crate::standard::sha_round;
 
                         let compiled = FlatProg {
                             functions: vec![sha_round()],
@@ -164,7 +164,7 @@ impl Importer {
                     }
                 }
             } else if import.source.starts_with("PACKING") {
-                use types::conversions::split;
+                use crate::types::conversions::split;
 
                 match import.source.as_ref() {
                     "PACKING/split" => {

--- a/zokrates_core/src/ir/expression.rs
+++ b/zokrates_core/src/ir/expression.rs
@@ -1,4 +1,4 @@
-use flat_absy::FlatVariable;
+use crate::flat_absy::FlatVariable;
 use num::Zero;
 use std::collections::BTreeMap;
 use std::fmt;

--- a/zokrates_core/src/ir/folder.rs
+++ b/zokrates_core/src/ir/folder.rs
@@ -1,7 +1,7 @@
 // Generic walk through an IR AST. Not mutating in place
 
-use flat_absy::flat_variable::FlatVariable;
-use ir::*;
+use crate::flat_absy::flat_variable::FlatVariable;
+use crate::ir::*;
 use zokrates_field::field::Field;
 
 pub trait Folder<T: Field>: Sized {

--- a/zokrates_core/src/ir/from_flat.rs
+++ b/zokrates_core/src/ir/from_flat.rs
@@ -1,6 +1,6 @@
-use flat_absy::{FlatExpression, FlatFunction, FlatProg, FlatStatement, FlatVariable};
-use helpers;
-use ir::{Directive, Function, LinComb, Prog, QuadComb, Statement};
+use crate::flat_absy::{FlatExpression, FlatFunction, FlatProg, FlatStatement, FlatVariable};
+use crate::helpers;
+use crate::ir::{Directive, Function, LinComb, Prog, QuadComb, Statement};
 use num::Zero;
 use zokrates_field::field::Field;
 

--- a/zokrates_core/src/ir/interpreter.rs
+++ b/zokrates_core/src/ir/interpreter.rs
@@ -1,6 +1,6 @@
-use flat_absy::flat_variable::FlatVariable;
-use helpers::Executable;
-use ir::{LinComb, Prog, QuadComb, Statement, Witness};
+use crate::flat_absy::flat_variable::FlatVariable;
+use crate::helpers::Executable;
+use crate::ir::{LinComb, Prog, QuadComb, Statement, Witness};
 use std::collections::BTreeMap;
 use std::fmt;
 use zokrates_field::field::Field;

--- a/zokrates_core/src/ir/mod.rs
+++ b/zokrates_core/src/ir/mod.rs
@@ -1,6 +1,6 @@
-use flat_absy::flat_parameter::FlatParameter;
-use flat_absy::FlatVariable;
-use helpers::Helper;
+use crate::flat_absy::flat_parameter::FlatParameter;
+use crate::flat_absy::FlatVariable;
+use crate::helpers::Helper;
 use std::fmt;
 use zokrates_field::field::Field;
 

--- a/zokrates_core/src/ir/witness.rs
+++ b/zokrates_core/src/ir/witness.rs
@@ -1,4 +1,4 @@
-use flat_absy::FlatVariable;
+use crate::flat_absy::FlatVariable;
 use std::collections::{BTreeMap, HashMap};
 use std::fmt;
 use std::io;

--- a/zokrates_core/src/optimizer/mod.rs
+++ b/zokrates_core/src/optimizer/mod.rs
@@ -10,7 +10,7 @@ mod tautology;
 use self::redefinition::RedefinitionOptimizer;
 use self::tautology::TautologyOptimizer;
 
-use ir::Prog;
+use crate::ir::Prog;
 use zokrates_field::field::Field;
 
 pub trait Optimize {

--- a/zokrates_core/src/optimizer/redefinition.rs
+++ b/zokrates_core/src/optimizer/redefinition.rs
@@ -8,10 +8,10 @@
 // c := a
 // ```
 
-use flat_absy::flat_variable::FlatVariable;
-use ir::folder::{fold_function, Folder};
-use ir::LinComb;
-use ir::*;
+use crate::flat_absy::flat_variable::FlatVariable;
+use crate::ir::folder::{fold_function, Folder};
+use crate::ir::LinComb;
+use crate::ir::*;
 use num::Zero;
 use std::collections::HashMap;
 use zokrates_field::field::Field;

--- a/zokrates_core/src/optimizer/tautology.rs
+++ b/zokrates_core/src/optimizer/tautology.rs
@@ -5,9 +5,9 @@
 //
 // This makes the assumption that ~one has value 1, as should be guaranteed by the verifier
 
-use ir::folder::fold_statement;
-use ir::folder::Folder;
-use ir::*;
+use crate::ir::folder::fold_statement;
+use crate::ir::folder::Folder;
+use crate::ir::*;
 use zokrates_field::field::Field;
 
 pub struct TautologyOptimizer {}

--- a/zokrates_core/src/parser/error.rs
+++ b/zokrates_core/src/parser/error.rs
@@ -1,5 +1,5 @@
-use parser::tokenize::Position;
-use parser::tokenize::Token;
+use crate::parser::tokenize::Position;
+use crate::parser::tokenize::Token;
 use std::fmt;
 use zokrates_field::field::Field;
 

--- a/zokrates_core/src/parser/mod.rs
+++ b/zokrates_core/src/parser/mod.rs
@@ -2,6 +2,6 @@ mod error;
 mod parse;
 mod tokenize;
 
-pub use parser::error::Error;
-pub use parser::parse::parse_program;
-pub use parser::tokenize::Position;
+pub use crate::parser::error::Error;
+pub use crate::parser::parse::parse_program;
+pub use crate::parser::tokenize::Position;

--- a/zokrates_core/src/parser/parse/expression.rs
+++ b/zokrates_core/src/parser/parse/expression.rs
@@ -1,9 +1,9 @@
 use zokrates_field::field::Field;
 
-use parser::tokenize::{next_token, Position, Token};
-use parser::Error;
+use crate::parser::tokenize::{next_token, Position, Token};
+use crate::parser::Error;
 
-use absy::{Expression, ExpressionNode, Node};
+use crate::absy::{Expression, ExpressionNode, Node};
 
 fn parse_then_else<T: Field>(
     cond: ExpressionNode<T>,
@@ -912,7 +912,7 @@ mod tests {
 
     #[test]
     fn parse_boolean_operator_associativity() {
-        use absy::Expression::*;
+        use crate::absy::Expression::*;
         let pos = Position { line: 45, col: 121 };
         let string = String::from("2 == 3 || 4 == 5 && 6 == 7");
         let expr = Or::<FieldPrime>(
@@ -944,7 +944,7 @@ mod tests {
 
     #[test]
     fn parse_boolean_expr() {
-        use absy::Expression::*;
+        use crate::absy::Expression::*;
         let pos = Position { line: 45, col: 121 };
         let string = String::from("(a + 2 == 3) && (a * 2 + 3 == 2 || a < 3) || 1 < 2");
         let expr = Or::<FieldPrime>(

--- a/zokrates_core/src/parser/parse/expression_list.rs
+++ b/zokrates_core/src/parser/parse/expression_list.rs
@@ -1,11 +1,11 @@
 use zokrates_field::field::Field;
 
-use parser::tokenize::{next_token, Position, Token};
-use parser::Error;
+use crate::parser::tokenize::{next_token, Position, Token};
+use crate::parser::Error;
 
 use super::expression::parse_expr;
 
-use absy::{ExpressionList, ExpressionListNode, Node};
+use crate::absy::{ExpressionList, ExpressionListNode, Node};
 
 // parse an expression list
 pub fn parse_expression_list<T: Field>(
@@ -38,7 +38,7 @@ fn parse_comma_separated_expression_list_rec<T: Field>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use absy::Expression;
+    use crate::absy::Expression;
     use zokrates_field::field::FieldPrime;
 
     fn parse_comma_separated_list<T: Field>(

--- a/zokrates_core/src/parser/parse/function.rs
+++ b/zokrates_core/src/parser/parse/function.rs
@@ -3,15 +3,15 @@ use zokrates_field::field::Field;
 use std::io::prelude::*;
 use std::io::Lines;
 
-use parser::tokenize::{next_token, Position, Token};
-use parser::Error;
+use crate::parser::tokenize::{next_token, Position, Token};
+use crate::parser::Error;
 
 use super::statement::parse_statement;
 
-use absy::{
+use crate::absy::{
     Function, FunctionNode, Node, Parameter, ParameterNode, Statement, Variable, VariableNode,
 };
-use types::{Signature, Type};
+use crate::types::{Signature, Type};
 
 fn parse_function_identifier<T: Field>(
     input: &String,

--- a/zokrates_core/src/parser/parse/import.rs
+++ b/zokrates_core/src/parser/parse/import.rs
@@ -1,12 +1,12 @@
 use zokrates_field::field::Field;
 
-use parser::tokenize::{next_token, Position, Token};
-use parser::Error;
+use crate::parser::tokenize::{next_token, Position, Token};
+use crate::parser::Error;
 
-use parser::tokenize::parse_quoted_path;
+use crate::parser::tokenize::parse_quoted_path;
 
-use absy::Node;
-use imports::{Import, ImportNode};
+use crate::absy::Node;
+use crate::imports::{Import, ImportNode};
 
 pub fn parse_import<T: Field>(
     input: &String,

--- a/zokrates_core/src/parser/parse/program.rs
+++ b/zokrates_core/src/parser/parse/program.rs
@@ -2,13 +2,13 @@ use zokrates_field::field::Field;
 
 use std::io::prelude::*;
 
-use parser::error::Error;
-use parser::tokenize::{next_token, Position, Token};
+use crate::parser::error::Error;
+use crate::parser::tokenize::{next_token, Position, Token};
 
 use super::function::parse_function;
 use super::import::parse_import;
 
-use absy::Prog;
+use crate::absy::Prog;
 
 pub fn parse_program<T: Field, R: BufRead>(reader: &mut R) -> Result<Prog<T>, Error<T>> {
     let mut current_line = 1;

--- a/zokrates_core/src/parser/parse/statement.rs
+++ b/zokrates_core/src/parser/parse/statement.rs
@@ -3,20 +3,20 @@ use zokrates_field::field::Field;
 use std::io::prelude::*;
 use std::io::Lines;
 
-use parser::tokenize::{next_token, Position, Token};
-use parser::Error;
+use crate::parser::tokenize::{next_token, Position, Token};
+use crate::parser::Error;
 
-use parser::tokenize::skip_whitespaces;
+use crate::parser::tokenize::skip_whitespaces;
 
 use super::expression::{
     parse_array_select, parse_expr, parse_expr1, parse_function_call, parse_term1,
 };
 use super::expression_list::parse_expression_list;
 
-use absy::{
+use crate::absy::{
     Assignee, AssigneeNode, Expression, Node, Statement, StatementNode, Variable, VariableNode,
 };
-use types::Type;
+use crate::types::Type;
 
 pub fn parse_statement<T: Field, R: BufRead>(
     lines: &mut Lines<R>,

--- a/zokrates_core/src/parser/tokenize/token.rs
+++ b/zokrates_core/src/parser/tokenize/token.rs
@@ -1,5 +1,5 @@
+use crate::types::Type;
 use std::fmt;
-use types::Type;
 use zokrates_field::field::Field;
 
 #[derive(PartialEq)]

--- a/zokrates_core/src/parser/tokenize/tokenizer.rs
+++ b/zokrates_core/src/parser/tokenize/tokenizer.rs
@@ -1,6 +1,6 @@
 use super::position::Position;
 use super::token::Token;
-use types::Type;
+use crate::types::Type;
 use zokrates_field::field::Field;
 
 pub fn parse_num<T: Field>(input: &String, pos: &Position) -> (Token<T>, String, Position) {

--- a/zokrates_core/src/proof_system/bn128/g16.rs
+++ b/zokrates_core/src/proof_system/bn128/g16.rs
@@ -1,8 +1,8 @@
+use crate::ir;
+use crate::proof_system::bn128::utils::bellman::Computation;
+use crate::proof_system::bn128::utils::solidity::{SOLIDITY_G2_ADDITION_LIB, SOLIDITY_PAIRING_LIB};
+use crate::proof_system::ProofSystem;
 use bellman::groth16::Parameters;
-use ir;
-use proof_system::bn128::utils::bellman::Computation;
-use proof_system::bn128::utils::solidity::{SOLIDITY_G2_ADDITION_LIB, SOLIDITY_PAIRING_LIB};
-use proof_system::ProofSystem;
 use regex::Regex;
 use std::fs::File;
 use std::io::{BufRead, BufReader, Write};
@@ -273,9 +273,9 @@ mod tests {
 
         mod proof {
             use super::*;
-            use flat_absy::FlatVariable;
-            use ir::*;
-            use proof_system::bn128::g16::serialize::serialize_proof;
+            use crate::flat_absy::FlatVariable;
+            use crate::ir::*;
+            use crate::proof_system::bn128::g16::serialize::serialize_proof;
 
             #[allow(dead_code)]
             #[derive(Deserialize)]

--- a/zokrates_core/src/proof_system/bn128/utils/bellman.rs
+++ b/zokrates_core/src/proof_system/bn128/utils/bellman.rs
@@ -1,18 +1,18 @@
 extern crate rand;
 
+use crate::ir::{LinComb, Prog, Statement, Witness};
 use bellman::groth16::Proof;
 use bellman::groth16::{
     create_random_proof, generate_random_parameters, prepare_verifying_key, verify_proof,
     Parameters,
 };
 use bellman::{Circuit, ConstraintSystem, LinearCombination, SynthesisError, Variable};
-use ir::{LinComb, Prog, Statement, Witness};
 use pairing::bn256::{Bn256, Fr};
 use std::collections::BTreeMap;
 use zokrates_field::field::{Field, FieldPrime};
 
 use self::rand::*;
-use flat_absy::FlatVariable;
+use crate::flat_absy::FlatVariable;
 
 #[derive(Clone)]
 pub struct Computation<T: Field> {
@@ -192,7 +192,7 @@ impl Circuit<Bn256> for Computation<FieldPrime> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use ir::Function;
+    use crate::ir::Function;
     use zokrates_field::field::FieldPrime;
 
     mod prove {

--- a/zokrates_core/src/proof_system/mod.rs
+++ b/zokrates_core/src/proof_system/mod.rs
@@ -9,7 +9,7 @@ pub use self::bn128::GM17;
 #[cfg(feature = "libsnark")]
 pub use self::bn128::PGHR13;
 
-use ir;
+use crate::ir;
 use std::io::BufReader;
 
 pub trait ProofSystem {

--- a/zokrates_core/src/semantics.rs
+++ b/zokrates_core/src/semantics.rs
@@ -6,17 +6,17 @@
 //! @author Thibaut Schaeffer <thibaut@schaeff.fr>
 //! @date 2017
 
-use absy::variable::Variable;
-use absy::*;
+use crate::absy::variable::Variable;
+use crate::absy::*;
+use crate::typed_absy::*;
+use crate::types::Signature;
 use std::collections::HashSet;
 use std::fmt;
-use typed_absy::*;
-use types::Signature;
 use zokrates_field::field::Field;
 
-use parser::Position;
+use crate::parser::Position;
 
-use types::Type;
+use crate::types::Type;
 
 use std::hash::{Hash, Hasher};
 
@@ -44,21 +44,21 @@ pub struct FunctionQuery {
 
 impl fmt::Display for FunctionQuery {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        try!(write!(f, "("));
+        r#try!(write!(f, "("));
         for (i, t) in self.inputs.iter().enumerate() {
-            try!(write!(f, "{}", t));
+            r#try!(write!(f, "{}", t));
             if i < self.inputs.len() - 1 {
-                try!(write!(f, ", "));
+                r#try!(write!(f, ", "));
             }
         }
-        try!(write!(f, ") -> ("));
+        r#try!(write!(f, ") -> ("));
         for (i, t) in self.outputs.iter().enumerate() {
             match t {
-                Some(t) => try!(write!(f, "{}", t)),
-                None => try!(write!(f, "_")),
+                Some(t) => r#try!(write!(f, "{}", t)),
+                None => r#try!(write!(f, "_")),
             }
             if i < self.outputs.len() - 1 {
-                try!(write!(f, ", "));
+                r#try!(write!(f, ", "));
             }
         }
         write!(f, ")")

--- a/zokrates_core/src/standard.rs
+++ b/zokrates_core/src/standard.rs
@@ -1,9 +1,9 @@
+use crate::flat_absy::{FlatExpression, FlatExpressionList, FlatFunction, FlatStatement};
+use crate::flat_absy::{FlatParameter, FlatVariable};
+use crate::helpers::{DirectiveStatement, Helper, RustHelper};
+use crate::types::{Signature, Type};
 use bellman::pairing::ff::ScalarEngine;
-use flat_absy::{FlatExpression, FlatExpressionList, FlatFunction, FlatStatement};
-use flat_absy::{FlatParameter, FlatVariable};
-use helpers::{DirectiveStatement, Helper, RustHelper};
 use reduce::Reduce;
-use types::{Signature, Type};
 use zokrates_embed::{generate_sha256_round_constraints, BellmanConstraint};
 use zokrates_field::field::Field;
 
@@ -219,8 +219,8 @@ mod tests {
             FlatStatement::Condition(FlatVariable::new(1).into(), FlatVariable::new(26936).into())
         );
 
-        let f = ::ir::Function::from(compiled);
-        let prog = ::ir::Prog {
+        let f = crate::ir::Function::from(compiled);
+        let prog = crate::ir::Prog {
             main: f,
             private: vec![true; 768],
         };

--- a/zokrates_core/src/static_analysis/dead_code.rs
+++ b/zokrates_core/src/static_analysis/dead_code.rs
@@ -1,8 +1,8 @@
+use crate::typed_absy::folder::*;
+use crate::typed_absy::Folder;
+use crate::typed_absy::*;
+use crate::types::{Signature, Type};
 use std::collections::HashSet;
-use typed_absy::folder::*;
-use typed_absy::Folder;
-use typed_absy::*;
-use types::{Signature, Type};
 use zokrates_field::field::Field;
 
 pub struct DeadCode {

--- a/zokrates_core/src/static_analysis/flat_propagation.rs
+++ b/zokrates_core/src/static_analysis/flat_propagation.rs
@@ -4,8 +4,8 @@
 //! @author Thibaut Schaeffer <thibaut@schaeff.fr>
 //! @date 2018
 
-use flat_absy::*;
-use helpers::DirectiveStatement;
+use crate::flat_absy::*;
+use crate::helpers::DirectiveStatement;
 use std::collections::HashMap;
 use zokrates_field::field::Field;
 

--- a/zokrates_core/src/static_analysis/inline.rs
+++ b/zokrates_core/src/static_analysis/inline.rs
@@ -1,8 +1,8 @@
+use crate::typed_absy::folder::*;
+use crate::typed_absy::Folder;
+use crate::typed_absy::*;
+use crate::types::{Signature, Type};
 use std::collections::HashMap;
-use typed_absy::folder::*;
-use typed_absy::Folder;
-use typed_absy::*;
-use types::{Signature, Type};
 use zokrates_field::field::Field;
 
 pub struct Inliner<T: Field> {

--- a/zokrates_core/src/static_analysis/mod.rs
+++ b/zokrates_core/src/static_analysis/mod.rs
@@ -16,8 +16,8 @@ use self::inline::Inliner;
 use self::power_check::PowerChecker;
 use self::propagation::Propagator;
 use self::unroll::Unroller;
-use flat_absy::FlatProg;
-use typed_absy::TypedProg;
+use crate::flat_absy::FlatProg;
+use crate::typed_absy::TypedProg;
 use zokrates_field::field::Field;
 
 pub trait Analyse {

--- a/zokrates_core/src/static_analysis/power_check.rs
+++ b/zokrates_core/src/static_analysis/power_check.rs
@@ -1,6 +1,6 @@
-use typed_absy::folder::*;
-use typed_absy::Folder;
-use typed_absy::*;
+use crate::typed_absy::folder::*;
+use crate::typed_absy::Folder;
+use crate::typed_absy::*;
 use zokrates_field::field::Field;
 
 pub struct PowerChecker {}

--- a/zokrates_core/src/static_analysis/propagation.rs
+++ b/zokrates_core/src/static_analysis/propagation.rs
@@ -4,9 +4,9 @@
 //! @author Thibaut Schaeffer <thibaut@schaeff.fr>
 //! @date 2018
 
+use crate::typed_absy::folder::*;
+use crate::typed_absy::*;
 use std::collections::HashMap;
-use typed_absy::folder::*;
-use typed_absy::*;
 use zokrates_field::field::Field;
 
 pub struct Propagator<T: Field> {

--- a/zokrates_core/src/static_analysis/unroll.rs
+++ b/zokrates_core/src/static_analysis/unroll.rs
@@ -4,10 +4,10 @@
 //! @author Thibaut Schaeffer <thibaut@schaeff.fr>
 //! @date 2018
 
+use crate::typed_absy::folder::*;
+use crate::typed_absy::*;
+use crate::types::Type;
 use std::collections::HashMap;
-use typed_absy::folder::*;
-use typed_absy::*;
-use types::Type;
 use zokrates_field::field::Field;
 
 pub struct Unroller {
@@ -338,7 +338,7 @@ mod tests {
 
         #[test]
         fn incremental_multiple_definition() {
-            use types::Type;
+            use crate::types::Type;
 
             // field a
             // a = 2

--- a/zokrates_core/src/typed_absy/folder.rs
+++ b/zokrates_core/src/typed_absy/folder.rs
@@ -1,6 +1,6 @@
 // Generic walk through a typed AST. Not mutating in place
 
-use typed_absy::*;
+use crate::typed_absy::*;
 use zokrates_field::field::Field;
 
 pub trait Folder<T: Field>: Sized {

--- a/zokrates_core/src/typed_absy/mod.rs
+++ b/zokrates_core/src/typed_absy/mod.rs
@@ -9,14 +9,14 @@ pub mod folder;
 mod parameter;
 mod variable;
 
-pub use typed_absy::parameter::Parameter;
-pub use typed_absy::variable::Variable;
-use types::Signature;
+pub use crate::typed_absy::parameter::Parameter;
+pub use crate::typed_absy::variable::Variable;
+use crate::types::Signature;
 
-use flat_absy::*;
-use imports::Import;
+use crate::flat_absy::*;
+use crate::imports::Import;
+use crate::types::Type;
 use std::fmt;
-use types::Type;
 use zokrates_field::field::Field;
 
 pub use self::folder::Folder;
@@ -182,11 +182,11 @@ impl<T: Field> fmt::Debug for TypedStatement<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             TypedStatement::Return(ref exprs) => {
-                try!(write!(f, "Return("));
+                r#try!(write!(f, "Return("));
                 for (i, expr) in exprs.iter().enumerate() {
-                    try!(write!(f, "{}", expr));
+                    r#try!(write!(f, "{}", expr));
                     if i < exprs.len() - 1 {
-                        try!(write!(f, ", "));
+                        r#try!(write!(f, ", "));
                     }
                 }
                 write!(f, ")")
@@ -199,9 +199,9 @@ impl<T: Field> fmt::Debug for TypedStatement<T> {
                 write!(f, "Condition({:?}, {:?})", lhs, rhs)
             }
             TypedStatement::For(ref var, ref start, ref stop, ref list) => {
-                try!(write!(f, "for {:?} in {:?}..{:?} do\n", var, start, stop));
+                r#try!(write!(f, "for {:?} in {:?}..{:?} do\n", var, start, stop));
                 for l in list {
-                    try!(write!(f, "\t\t{:?}\n", l));
+                    r#try!(write!(f, "\t\t{:?}\n", l));
                 }
                 write!(f, "\tendfor")
             }
@@ -216,11 +216,11 @@ impl<T: Field> fmt::Display for TypedStatement<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             TypedStatement::Return(ref exprs) => {
-                try!(write!(f, "return "));
+                r#try!(write!(f, "return "));
                 for (i, expr) in exprs.iter().enumerate() {
-                    try!(write!(f, "{}", expr));
+                    r#try!(write!(f, "{}", expr));
                     if i < exprs.len() - 1 {
-                        try!(write!(f, ", "));
+                        r#try!(write!(f, ", "));
                     }
                 }
                 write!(f, "")
@@ -229,17 +229,17 @@ impl<T: Field> fmt::Display for TypedStatement<T> {
             TypedStatement::Definition(ref lhs, ref rhs) => write!(f, "{} = {}", lhs, rhs),
             TypedStatement::Condition(ref lhs, ref rhs) => write!(f, "{} == {}", lhs, rhs),
             TypedStatement::For(ref var, ref start, ref stop, ref list) => {
-                try!(write!(f, "for {} in {}..{} do\n", var, start, stop));
+                r#try!(write!(f, "for {} in {}..{} do\n", var, start, stop));
                 for l in list {
-                    try!(write!(f, "\t\t{}\n", l));
+                    r#try!(write!(f, "\t\t{}\n", l));
                 }
                 write!(f, "\tendfor")
             }
             TypedStatement::MultipleDefinition(ref ids, ref rhs) => {
                 for (i, id) in ids.iter().enumerate() {
-                    try!(write!(f, "{}", id));
+                    r#try!(write!(f, "{}", id));
                     if i < ids.len() - 1 {
-                        try!(write!(f, ", "));
+                        r#try!(write!(f, ", "));
                     }
                 }
                 write!(f, " = {}", rhs)
@@ -442,11 +442,11 @@ impl<T: Field> fmt::Display for FieldElementExpression<T> {
                 )
             }
             FieldElementExpression::FunctionCall(ref i, ref p) => {
-                try!(write!(f, "{}(", i,));
+                r#try!(write!(f, "{}(", i,));
                 for (i, param) in p.iter().enumerate() {
-                    try!(write!(f, "{}", param));
+                    r#try!(write!(f, "{}", param));
                     if i < p.len() - 1 {
-                        try!(write!(f, ", "));
+                        r#try!(write!(f, ", "));
                     }
                 }
                 write!(f, ")")
@@ -487,11 +487,11 @@ impl<T: Field> fmt::Display for FieldElementArrayExpression<T> {
                     .join(", ")
             ),
             FieldElementArrayExpression::FunctionCall(_, ref i, ref p) => {
-                try!(write!(f, "{}(", i,));
+                r#try!(write!(f, "{}(", i,));
                 for (i, param) in p.iter().enumerate() {
-                    try!(write!(f, "{}", param));
+                    r#try!(write!(f, "{}", param));
                     if i < p.len() - 1 {
-                        try!(write!(f, ", "));
+                        r#try!(write!(f, ", "));
                     }
                 }
                 write!(f, ")")
@@ -533,8 +533,8 @@ impl<T: Field> fmt::Debug for FieldElementExpression<T> {
                 )
             }
             FieldElementExpression::FunctionCall(ref i, ref p) => {
-                try!(write!(f, "FunctionCall({:?}, (", i));
-                try!(f.debug_list().entries(p.iter()).finish());
+                r#try!(write!(f, "FunctionCall({:?}, (", i));
+                r#try!(f.debug_list().entries(p.iter()).finish());
                 write!(f, ")")
             }
             FieldElementExpression::Select(ref id, ref index) => {
@@ -550,8 +550,8 @@ impl<T: Field> fmt::Debug for FieldElementArrayExpression<T> {
             FieldElementArrayExpression::Identifier(_, ref var) => write!(f, "{:?}", var),
             FieldElementArrayExpression::Value(_, ref values) => write!(f, "{:?}", values),
             FieldElementArrayExpression::FunctionCall(_, ref i, ref p) => {
-                try!(write!(f, "FunctionCall({:?}, (", i));
-                try!(f.debug_list().entries(p.iter()).finish());
+                r#try!(write!(f, "FunctionCall({:?}, (", i));
+                r#try!(f.debug_list().entries(p.iter()).finish());
                 write!(f, ")")
             }
             FieldElementArrayExpression::IfElse(ref condition, ref consequent, ref alternative) => {
@@ -569,11 +569,11 @@ impl<T: Field> fmt::Display for TypedExpressionList<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             TypedExpressionList::FunctionCall(ref i, ref p, _) => {
-                try!(write!(f, "{}(", i,));
+                r#try!(write!(f, "{}(", i,));
                 for (i, param) in p.iter().enumerate() {
-                    try!(write!(f, "{}", param));
+                    r#try!(write!(f, "{}", param));
                     if i < p.len() - 1 {
-                        try!(write!(f, ", "));
+                        r#try!(write!(f, ", "));
                     }
                 }
                 write!(f, ")")
@@ -586,8 +586,8 @@ impl<T: Field> fmt::Debug for TypedExpressionList<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             TypedExpressionList::FunctionCall(ref i, ref p, _) => {
-                try!(write!(f, "FunctionCall({:?}, (", i));
-                try!(f.debug_list().entries(p.iter()).finish());
+                r#try!(write!(f, "FunctionCall({:?}, (", i));
+                r#try!(f.debug_list().entries(p.iter()).finish());
                 write!(f, ")")
             }
         }

--- a/zokrates_core/src/typed_absy/parameter.rs
+++ b/zokrates_core/src/typed_absy/parameter.rs
@@ -1,6 +1,6 @@
-use absy;
+use crate::absy;
+use crate::typed_absy::Variable;
 use std::fmt;
-use typed_absy::Variable;
 
 #[derive(Clone, PartialEq, Serialize, Deserialize)]
 pub struct Parameter {

--- a/zokrates_core/src/typed_absy/variable.rs
+++ b/zokrates_core/src/typed_absy/variable.rs
@@ -1,6 +1,6 @@
-use absy;
+use crate::absy;
+use crate::types::Type;
 use std::fmt;
-use types::Type;
 
 #[derive(Serialize, Deserialize, Clone, PartialEq, Hash, Eq)]
 pub struct Variable {

--- a/zokrates_core/src/types/conversions.rs
+++ b/zokrates_core/src/types/conversions.rs
@@ -1,10 +1,10 @@
+use crate::flat_absy::flat_parameter::FlatParameter;
+use crate::flat_absy::flat_variable::FlatVariable;
+use crate::flat_absy::*;
+use crate::helpers::{DirectiveStatement, Helper};
+use crate::types::signature::Signature;
+use crate::types::Type;
 use bimap::BiMap;
-use flat_absy::flat_parameter::FlatParameter;
-use flat_absy::flat_variable::FlatVariable;
-use flat_absy::*;
-use helpers::{DirectiveStatement, Helper};
-use types::signature::Signature;
-use types::Type;
 use zokrates_field::field::Field;
 
 fn use_variable(

--- a/zokrates_core/src/types/mod.rs
+++ b/zokrates_core/src/types/mod.rs
@@ -1,5 +1,5 @@
+pub use crate::types::signature::Signature;
 use std::fmt;
-pub use types::signature::Signature;
 
 pub mod conversions;
 mod signature;

--- a/zokrates_core/src/types/signature.rs
+++ b/zokrates_core/src/types/signature.rs
@@ -1,5 +1,5 @@
+use crate::types::Type;
 use std::fmt;
-use types::Type;
 
 #[derive(Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct Signature {
@@ -19,18 +19,18 @@ impl fmt::Debug for Signature {
 
 impl fmt::Display for Signature {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        try!(write!(f, "("));
+        r#try!(write!(f, "("));
         for (i, t) in self.inputs.iter().enumerate() {
-            try!(write!(f, "{}", t));
+            r#try!(write!(f, "{}", t));
             if i < self.inputs.len() - 1 {
-                try!(write!(f, ", "));
+                r#try!(write!(f, ", "));
             }
         }
-        try!(write!(f, ") -> ("));
+        r#try!(write!(f, ") -> ("));
         for (i, t) in self.outputs.iter().enumerate() {
-            try!(write!(f, "{}", t));
+            r#try!(write!(f, "{}", t));
             if i < self.outputs.len() - 1 {
-                try!(write!(f, ", "));
+                r#try!(write!(f, ", "));
             }
         }
         write!(f, ")")


### PR DESCRIPTION
`zokrates_core` has not been migrated.
Transition operated with `cargo fix --edition` and `cargo fmt`, no manual changes.