### PR TITLE
Use buffered io in CLI and tests

### DIFF
--- a/zokrates_stdlib/build.rs
+++ b/zokrates_stdlib/build.rs
@@ -2,7 +2,7 @@ use fs_extra::copy_items;
 use fs_extra::dir::CopyOptions;
 use std::env;
 use std::fs::File;
-use std::io::Write;
+use std::io::{BufWriter, Write};
 use std::path::{Path, PathBuf};
 
 fn main() {
@@ -25,14 +25,15 @@ fn write_tests() {
 
     let out_dir = env::var("OUT_DIR").unwrap();
     let destination = Path::new(&out_dir).join("tests.rs");
-    let mut test_file = File::create(&destination).unwrap();
+    let test_file = File::create(&destination).unwrap();
+    let mut writer = BufWriter::new(test_file);
 
     for directory in glob("./tests/bench/**/*.json").unwrap() {
-        write_test(&mut test_file, &directory.unwrap());
+        write_test(&mut writer, &directory.unwrap());
     }
 }
 
-fn write_test(test_file: &mut File, test_path: &PathBuf) {
+fn write_test<W: Write>(test_file: &mut W, test_path: &PathBuf) {
     let test_name = format!(
         "test_{}",
         test_path


### PR DESCRIPTION
Quick tests show that some programs compile 4x faster, and reading programs and witnesses is much faster too.