### PR TITLE
Remove strings from absy

### DIFF
--- a/zokrates_core/src/absy/mod.rs
+++ b/zokrates_core/src/absy/mod.rs
@@ -152,29 +152,6 @@ impl<'ast, T: Field> fmt::Display for Assignee<'ast, T> {
     }
 }
 
-// impl<'ast, T: Field> From<ExpressionNode<'ast, T>> for AssigneeNode<T> {
-//     fn from(e: ExpressionNode<'ast, T>) -> Self {
-//         match e.value {
-//             Expression::Select(box e1, box e2) => match e1 {
-//                 ExpressionNode {
-//                     value: Expression::Identifier(id),
-//                     start,
-//                     end,
-//                 } => Node::new(
-//                     e.start,
-//                     e.end,
-//                     Assignee::ArrayElement(
-//                         box Node::new(start, end, Assignee::Identifier(id)),
-//                         box e2,
-//                     ),
-//                 ),
-//                 _ => panic!("only use expression to assignee for elements like foo[bar]"),
-//             },
-//             _ => panic!("only use expression to assignee for elements like foo[bar]"),
-//         }
-//     }
-// }
-
 #[derive(Clone, PartialEq)]
 pub enum Statement<'ast, T: Field> {
     Return(ExpressionListNode<'ast, T>),

--- a/zokrates_core/src/absy/mod.rs
+++ b/zokrates_core/src/absy/mod.rs
@@ -20,15 +20,17 @@ use crate::imports::ImportNode;
 use std::fmt;
 use zokrates_field::field::Field;
 
+pub type Identifier<'ast> = &'ast str;
+
 #[derive(Clone, PartialEq)]
-pub struct Prog<T: Field> {
+pub struct Prog<'ast, T: Field> {
     /// Functions of the program
-    pub functions: Vec<FunctionNode<T>>,
+    pub functions: Vec<FunctionNode<'ast, T>>,
     pub imports: Vec<ImportNode>,
     pub imported_functions: Vec<FlatFunction<T>>,
 }
 
-impl<T: Field> fmt::Display for Prog<T> {
+impl<'ast, T: Field> fmt::Display for Prog<'ast, T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let mut res = vec![];
         res.extend(
@@ -53,7 +55,7 @@ impl<T: Field> fmt::Display for Prog<T> {
     }
 }
 
-impl<T: Field> fmt::Debug for Prog<T> {
+impl<'ast, T: Field> fmt::Debug for Prog<'ast, T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
             f,
@@ -78,20 +80,20 @@ impl<T: Field> fmt::Debug for Prog<T> {
 }
 
 #[derive(Clone, PartialEq)]
-pub struct Function<T: Field> {
+pub struct Function<'ast, T: Field> {
     /// Name of the program
-    pub id: String,
+    pub id: Identifier<'ast>,
     /// Arguments of the function
-    pub arguments: Vec<ParameterNode>,
+    pub arguments: Vec<ParameterNode<'ast>>,
     /// Vector of statements that are executed when running the function
-    pub statements: Vec<StatementNode<T>>,
+    pub statements: Vec<StatementNode<'ast, T>>,
     /// function signature
     pub signature: Signature,
 }
 
-pub type FunctionNode<T> = Node<Function<T>>;
+pub type FunctionNode<'ast, T> = Node<Function<'ast, T>>;
 
-impl<T: Field> fmt::Display for Function<T> {
+impl<'ast, T: Field> fmt::Display for Function<'ast, T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
             f,
@@ -111,7 +113,7 @@ impl<T: Field> fmt::Display for Function<T> {
     }
 }
 
-impl<T: Field> fmt::Debug for Function<T> {
+impl<'ast, T: Field> fmt::Debug for Function<'ast, T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
             f,
@@ -128,14 +130,14 @@ impl<T: Field> fmt::Debug for Function<T> {
 }
 
 #[derive(Clone, PartialEq)]
-pub enum Assignee<T: Field> {
-    Identifier(String),
-    ArrayElement(Box<AssigneeNode<T>>, Box<ExpressionNode<T>>),
+pub enum Assignee<'ast, T: Field> {
+    Identifier(Identifier<'ast>),
+    ArrayElement(Box<AssigneeNode<'ast, T>>, Box<ExpressionNode<'ast, T>>),
 }
 
-pub type AssigneeNode<T> = Node<Assignee<T>>;
+pub type AssigneeNode<'ast, T> = Node<Assignee<'ast, T>>;
 
-impl<T: Field> fmt::Debug for Assignee<T> {
+impl<'ast, T: Field> fmt::Debug for Assignee<'ast, T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             Assignee::Identifier(ref s) => write!(f, "{}", s),
@@ -144,48 +146,48 @@ impl<T: Field> fmt::Debug for Assignee<T> {
     }
 }
 
-impl<T: Field> fmt::Display for Assignee<T> {
+impl<'ast, T: Field> fmt::Display for Assignee<'ast, T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{:?}", self)
     }
 }
 
-impl<T: Field> From<ExpressionNode<T>> for AssigneeNode<T> {
-    fn from(e: ExpressionNode<T>) -> Self {
-        match e.value {
-            Expression::Select(box e1, box e2) => match e1 {
-                ExpressionNode {
-                    value: Expression::Identifier(id),
-                    start,
-                    end,
-                } => Node::new(
-                    e.start,
-                    e.end,
-                    Assignee::ArrayElement(
-                        box Node::new(start, end, Assignee::Identifier(id)),
-                        box e2,
-                    ),
-                ),
-                _ => panic!("only use expression to assignee for elements like foo[bar]"),
-            },
-            _ => panic!("only use expression to assignee for elements like foo[bar]"),
-        }
-    }
-}
+// impl<'ast, T: Field> From<ExpressionNode<'ast, T>> for AssigneeNode<T> {
+//     fn from(e: ExpressionNode<'ast, T>) -> Self {
+//         match e.value {
+//             Expression::Select(box e1, box e2) => match e1 {
+//                 ExpressionNode {
+//                     value: Expression::Identifier(id),
+//                     start,
+//                     end,
+//                 } => Node::new(
+//                     e.start,
+//                     e.end,
+//                     Assignee::ArrayElement(
+//                         box Node::new(start, end, Assignee::Identifier(id)),
+//                         box e2,
+//                     ),
+//                 ),
+//                 _ => panic!("only use expression to assignee for elements like foo[bar]"),
+//             },
+//             _ => panic!("only use expression to assignee for elements like foo[bar]"),
+//         }
+//     }
+// }
 
 #[derive(Clone, PartialEq)]
-pub enum Statement<T: Field> {
-    Return(ExpressionListNode<T>),
-    Declaration(VariableNode),
-    Definition(AssigneeNode<T>, ExpressionNode<T>),
-    Condition(ExpressionNode<T>, ExpressionNode<T>),
-    For(VariableNode, T, T, Vec<StatementNode<T>>),
-    MultipleDefinition(Vec<AssigneeNode<T>>, ExpressionNode<T>),
+pub enum Statement<'ast, T: Field> {
+    Return(ExpressionListNode<'ast, T>),
+    Declaration(VariableNode<'ast>),
+    Definition(AssigneeNode<'ast, T>, ExpressionNode<'ast, T>),
+    Condition(ExpressionNode<'ast, T>, ExpressionNode<'ast, T>),
+    For(VariableNode<'ast>, T, T, Vec<StatementNode<'ast, T>>),
+    MultipleDefinition(Vec<AssigneeNode<'ast, T>>, ExpressionNode<'ast, T>),
 }
 
-pub type StatementNode<T> = Node<Statement<T>>;
+pub type StatementNode<'ast, T> = Node<Statement<'ast, T>>;
 
-impl<T: Field> fmt::Display for Statement<T> {
+impl<'ast, T: Field> fmt::Display for Statement<'ast, T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             Statement::Return(ref expr) => write!(f, "return {}", expr),
@@ -212,7 +214,7 @@ impl<T: Field> fmt::Display for Statement<T> {
     }
 }
 
-impl<T: Field> fmt::Debug for Statement<T> {
+impl<'ast, T: Field> fmt::Debug for Statement<'ast, T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             Statement::Return(ref expr) => write!(f, "Return({:?})", expr),
@@ -235,36 +237,36 @@ impl<T: Field> fmt::Debug for Statement<T> {
     }
 }
 
-#[derive(Clone, PartialEq, Serialize, Deserialize)]
-pub enum Expression<T: Field> {
+#[derive(Clone, PartialEq)]
+pub enum Expression<'ast, T: Field> {
     Number(T),
-    Identifier(String),
-    Add(Box<ExpressionNode<T>>, Box<ExpressionNode<T>>),
-    Sub(Box<ExpressionNode<T>>, Box<ExpressionNode<T>>),
-    Mult(Box<ExpressionNode<T>>, Box<ExpressionNode<T>>),
-    Div(Box<ExpressionNode<T>>, Box<ExpressionNode<T>>),
-    Pow(Box<ExpressionNode<T>>, Box<ExpressionNode<T>>),
+    Identifier(Identifier<'ast>),
+    Add(Box<ExpressionNode<'ast, T>>, Box<ExpressionNode<'ast, T>>),
+    Sub(Box<ExpressionNode<'ast, T>>, Box<ExpressionNode<'ast, T>>),
+    Mult(Box<ExpressionNode<'ast, T>>, Box<ExpressionNode<'ast, T>>),
+    Div(Box<ExpressionNode<'ast, T>>, Box<ExpressionNode<'ast, T>>),
+    Pow(Box<ExpressionNode<'ast, T>>, Box<ExpressionNode<'ast, T>>),
     IfElse(
-        Box<ExpressionNode<T>>,
-        Box<ExpressionNode<T>>,
-        Box<ExpressionNode<T>>,
+        Box<ExpressionNode<'ast, T>>,
+        Box<ExpressionNode<'ast, T>>,
+        Box<ExpressionNode<'ast, T>>,
     ),
-    FunctionCall(String, Vec<ExpressionNode<T>>),
-    Lt(Box<ExpressionNode<T>>, Box<ExpressionNode<T>>),
-    Le(Box<ExpressionNode<T>>, Box<ExpressionNode<T>>),
-    Eq(Box<ExpressionNode<T>>, Box<ExpressionNode<T>>),
-    Ge(Box<ExpressionNode<T>>, Box<ExpressionNode<T>>),
-    Gt(Box<ExpressionNode<T>>, Box<ExpressionNode<T>>),
-    And(Box<ExpressionNode<T>>, Box<ExpressionNode<T>>),
-    Not(Box<ExpressionNode<T>>),
-    InlineArray(Vec<ExpressionNode<T>>),
-    Select(Box<ExpressionNode<T>>, Box<ExpressionNode<T>>),
-    Or(Box<ExpressionNode<T>>, Box<ExpressionNode<T>>),
+    FunctionCall(String, Vec<ExpressionNode<'ast, T>>),
+    Lt(Box<ExpressionNode<'ast, T>>, Box<ExpressionNode<'ast, T>>),
+    Le(Box<ExpressionNode<'ast, T>>, Box<ExpressionNode<'ast, T>>),
+    Eq(Box<ExpressionNode<'ast, T>>, Box<ExpressionNode<'ast, T>>),
+    Ge(Box<ExpressionNode<'ast, T>>, Box<ExpressionNode<'ast, T>>),
+    Gt(Box<ExpressionNode<'ast, T>>, Box<ExpressionNode<'ast, T>>),
+    And(Box<ExpressionNode<'ast, T>>, Box<ExpressionNode<'ast, T>>),
+    Not(Box<ExpressionNode<'ast, T>>),
+    InlineArray(Vec<ExpressionNode<'ast, T>>),
+    Select(Box<ExpressionNode<'ast, T>>, Box<ExpressionNode<'ast, T>>),
+    Or(Box<ExpressionNode<'ast, T>>, Box<ExpressionNode<'ast, T>>),
 }
 
-pub type ExpressionNode<T> = Node<Expression<T>>;
+pub type ExpressionNode<'ast, T> = Node<Expression<'ast, T>>;
 
-impl<T: Field> fmt::Display for Expression<T> {
+impl<'ast, T: Field> fmt::Display for Expression<'ast, T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             Expression::Number(ref i) => write!(f, "{}", i),
@@ -312,7 +314,7 @@ impl<T: Field> fmt::Display for Expression<T> {
     }
 }
 
-impl<T: Field> fmt::Debug for Expression<T> {
+impl<'ast, T: Field> fmt::Debug for Expression<'ast, T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             Expression::Number(ref i) => write!(f, "Num({})", i),
@@ -350,22 +352,22 @@ impl<T: Field> fmt::Debug for Expression<T> {
     }
 }
 
-#[derive(Clone, PartialEq, Serialize, Deserialize)]
-pub struct ExpressionList<T: Field> {
-    pub expressions: Vec<ExpressionNode<T>>,
+#[derive(Clone, PartialEq)]
+pub struct ExpressionList<'ast, T: Field> {
+    pub expressions: Vec<ExpressionNode<'ast, T>>,
 }
 
-pub type ExpressionListNode<T> = Node<ExpressionList<T>>;
+pub type ExpressionListNode<'ast, T> = Node<ExpressionList<'ast, T>>;
 
-impl<T: Field> ExpressionList<T> {
-    pub fn new() -> ExpressionList<T> {
+impl<'ast, T: Field> ExpressionList<'ast, T> {
+    pub fn new() -> ExpressionList<'ast, T> {
         ExpressionList {
             expressions: vec![],
         }
     }
 }
 
-impl<T: Field> fmt::Display for ExpressionList<T> {
+impl<'ast, T: Field> fmt::Display for ExpressionList<'ast, T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         for (i, param) in self.expressions.iter().enumerate() {
             r#try!(write!(f, "{}", param));
@@ -377,7 +379,7 @@ impl<T: Field> fmt::Display for ExpressionList<T> {
     }
 }
 
-impl<T: Field> fmt::Debug for ExpressionList<T> {
+impl<'ast, T: Field> fmt::Debug for ExpressionList<'ast, T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "ExpressionList({:?})", self.expressions)
     }

--- a/zokrates_core/src/absy/node.rs
+++ b/zokrates_core/src/absy/node.rs
@@ -62,14 +62,14 @@ use crate::absy::*;
 use crate::imports::*;
 use zokrates_field::field::Field;
 
-impl<T: Field> NodeValue for Expression<T> {}
-impl<T: Field> NodeValue for ExpressionList<T> {}
-impl<T: Field> NodeValue for Assignee<T> {}
-impl<T: Field> NodeValue for Statement<T> {}
-impl<T: Field> NodeValue for Function<T> {}
-impl<T: Field> NodeValue for Prog<T> {}
-impl NodeValue for Variable {}
-impl NodeValue for Parameter {}
+impl<'ast, T: Field> NodeValue for Expression<'ast, T> {}
+impl<'ast, T: Field> NodeValue for ExpressionList<'ast, T> {}
+impl<'ast, T: Field> NodeValue for Assignee<'ast, T> {}
+impl<'ast, T: Field> NodeValue for Statement<'ast, T> {}
+impl<'ast, T: Field> NodeValue for Function<'ast, T> {}
+impl<'ast, T: Field> NodeValue for Prog<'ast, T> {}
+impl<'ast> NodeValue for Variable<'ast> {}
+impl<'ast> NodeValue for Parameter<'ast> {}
 impl NodeValue for Import {}
 
 impl<T: NodeValue> std::cmp::PartialEq for Node<T> {

--- a/zokrates_core/src/absy/parameter.rs
+++ b/zokrates_core/src/absy/parameter.rs
@@ -1,25 +1,25 @@
 use crate::absy::{Node, VariableNode};
 use std::fmt;
 
-#[derive(Clone, PartialEq, Serialize, Deserialize)]
-pub struct Parameter {
-    pub id: VariableNode,
+#[derive(Clone, PartialEq)]
+pub struct Parameter<'ast> {
+    pub id: VariableNode<'ast>,
     pub private: bool,
 }
 
-impl Parameter {
-    pub fn new(v: VariableNode, private: bool) -> Self {
+impl<'ast> Parameter<'ast> {
+    pub fn new(v: VariableNode<'ast>, private: bool) -> Self {
         Parameter { id: v, private }
     }
 
-    pub fn public(v: VariableNode) -> Self {
+    pub fn public(v: VariableNode<'ast>) -> Self {
         Parameter {
             id: v,
             private: false,
         }
     }
 
-    pub fn private(v: VariableNode) -> Self {
+    pub fn private(v: VariableNode<'ast>) -> Self {
         Parameter {
             id: v,
             private: true,
@@ -27,9 +27,9 @@ impl Parameter {
     }
 }
 
-pub type ParameterNode = Node<Parameter>;
+pub type ParameterNode<'ast> = Node<Parameter<'ast>>;
 
-impl fmt::Display for Parameter {
+impl<'ast> fmt::Display for Parameter<'ast> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let visibility = if self.private { "private " } else { "" };
         write!(
@@ -42,7 +42,7 @@ impl fmt::Display for Parameter {
     }
 }
 
-impl fmt::Debug for Parameter {
+impl<'ast> fmt::Debug for Parameter<'ast> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
             f,

--- a/zokrates_core/src/absy/variable.rs
+++ b/zokrates_core/src/absy/variable.rs
@@ -2,37 +2,39 @@ use crate::absy::Node;
 use crate::types::Type;
 use std::fmt;
 
-#[derive(Serialize, Deserialize, Clone, PartialEq, Hash, Eq)]
-pub struct Variable {
-    pub id: String,
+use crate::absy::Identifier;
+
+#[derive(Clone, PartialEq, Hash, Eq)]
+pub struct Variable<'ast> {
+    pub id: Identifier<'ast>,
     pub _type: Type,
 }
 
-pub type VariableNode = Node<Variable>;
+pub type VariableNode<'ast> = Node<Variable<'ast>>;
 
-impl Variable {
-    pub fn new<S: Into<String>>(id: S, t: Type) -> Variable {
+impl<'ast> Variable<'ast> {
+    pub fn new<S: Into<&'ast str>>(id: S, t: Type) -> Variable<'ast> {
         Variable {
             id: id.into(),
             _type: t,
         }
     }
 
-    pub fn field_element<S: Into<String>>(id: S) -> Variable {
+    pub fn field_element<S: Into<&'ast str>>(id: S) -> Variable<'ast> {
         Variable {
             id: id.into(),
             _type: Type::FieldElement,
         }
     }
 
-    pub fn boolean<S: Into<String>>(id: S) -> Variable {
+    pub fn boolean<S: Into<&'ast str>>(id: S) -> Variable<'ast> {
         Variable {
             id: id.into(),
             _type: Type::Boolean,
         }
     }
 
-    pub fn field_array<S: Into<String>>(id: S, size: usize) -> Variable {
+    pub fn field_array<S: Into<&'ast str>>(id: S, size: usize) -> Variable<'ast> {
         Variable {
             id: id.into(),
             _type: Type::FieldElementArray(size),
@@ -44,13 +46,13 @@ impl Variable {
     }
 }
 
-impl fmt::Display for Variable {
+impl<'ast> fmt::Display for Variable<'ast> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{} {}", self._type, self.id,)
     }
 }
 
-impl fmt::Debug for Variable {
+impl<'ast> fmt::Debug for Variable<'ast> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "Variable(type: {:?}, id: {:?})", self._type, self.id,)
     }

--- a/zokrates_core/src/imports.rs
+++ b/zokrates_core/src/imports.rs
@@ -132,12 +132,17 @@ impl Importer {
         Importer {}
     }
 
-    pub fn apply_imports<T: Field, S: BufRead, E: Into<Error>>(
+    // Inject dependencies declared for `destination`
+    // The lifetime of the Program before injection outlives the lifetime after
+    pub fn apply_imports<'before, 'after, T: Field, S: BufRead, E: Into<Error>>(
         &self,
-        destination: Prog<T>,
+        destination: Prog<'before, T>,
         location: Option<String>,
         resolve_option: Option<fn(&Option<String>, &String) -> Result<(S, String, String), E>>,
-    ) -> Result<Prog<T>, CompileErrors> {
+    ) -> Result<Prog<'after, T>, CompileErrors>
+    where
+        'before: 'after,
+    {
         let mut origins: Vec<CompiledImport<T>> = vec![];
 
         for import in destination.imports.iter() {

--- a/zokrates_core/src/typed_absy/parameter.rs
+++ b/zokrates_core/src/typed_absy/parameter.rs
@@ -31,8 +31,8 @@ impl fmt::Debug for Parameter {
     }
 }
 
-impl From<absy::Parameter> for Parameter {
-    fn from(p: absy::Parameter) -> Parameter {
+impl<'ast> From<absy::Parameter<'ast>> for Parameter {
+    fn from(p: absy::Parameter<'ast>) -> Parameter {
         Parameter {
             private: p.private,
             id: p.id.value.into(),

--- a/zokrates_core/src/typed_absy/variable.rs
+++ b/zokrates_core/src/typed_absy/variable.rs
@@ -47,10 +47,10 @@ impl fmt::Debug for Variable {
     }
 }
 
-impl From<absy::Variable> for Variable {
+impl<'ast> From<absy::Variable<'ast>> for Variable {
     fn from(v: absy::Variable) -> Variable {
         Variable {
-            id: v.id,
+            id: v.id.to_string(),
             _type: v._type,
         }
     }


### PR DESCRIPTION
With the pest parser, the AST nodes bear references to the source string. Carry these over to absy instead of creating owned strings.