### PR TITLE
Added print-proof command to cli

### DIFF
--- a/zokrates_cli/src/bin.rs
+++ b/zokrates_cli/src/bin.rs
@@ -477,7 +477,19 @@ fn cli() -> Result<(), String> {
                 println!("{}", proof_object["inputs"]);
                 println!();
                 println!("~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~");
-            }
+            } else if format == String::from("testingV1") {
+                //used by testing pipeline to generate arguments for contract call
+                for (_key, value) in proof_object["proof"].as_object().unwrap().iter() {
+                    print!("{}", value);
+                    print!(",");
+                }
+                println!("{}", proof_object["inputs"]);
+            } else if format == String::from("testingV2") {
+                //used by testing pipeline to generate arguments for contract call
+                print!("{}", proof_object["proof"]);
+                print!(",");
+                println!("{}", proof_object["inputs"]);
+            } 
         }
         _ => unreachable!(),
     }


### PR DESCRIPTION
-cli now contains the print-proof command which will output a pastable version of the proof
-formats to pick from are json or remix compatible
-also will be used by testing pipeline in the future