### PR TITLE
Enforce boolean in function parameters

### DIFF
--- a/zokrates_core/src/flat_absy/mod.rs
+++ b/zokrates_core/src/flat_absy/mod.rs
@@ -17,7 +17,7 @@ use std::collections::{BTreeMap, HashMap};
 use std::fmt;
 use zokrates_field::field::Field;
 
-#[derive(Clone, PartialEq)]
+#[derive(Clone)]
 pub struct FlatProg<T: Field> {
     /// FlatFunctions of the program
     pub functions: Vec<FlatFunction<T>>,

--- a/zokrates_core/src/flat_absy/mod.rs
+++ b/zokrates_core/src/flat_absy/mod.rs
@@ -17,7 +17,7 @@ use std::collections::{BTreeMap, HashMap};
 use std::fmt;
 use zokrates_field::field::Field;
 
-#[derive(Clone)]
+#[derive(Clone, PartialEq)]
 pub struct FlatProg<T: Field> {
     /// FlatFunctions of the program
     pub functions: Vec<FlatFunction<T>>,


### PR DESCRIPTION
The two ways users can set values are function inputs and directives, the rest is deterministic.
Directives are already taken care of in terms of constraining outputs. For inputs, we need to make sure that booleans provided by as input to the main function are actually 1 or 0.

Implement this is the flattening process, where we add constraints based on types of the inputs.