### PR TITLE
Fix tests of empty import with and without ZOKRATES_HOME

### DIFF
--- a/zokrates_fs_resolver/src/lib.rs
+++ b/zokrates_fs_resolver/src/lib.rs
@@ -104,7 +104,26 @@ mod tests {
     }
 
     #[test]
-    fn no_file_name() {
+    #[should_panic]
+    fn no_file_name_without_stdlib() {
+        // an empty string is interpreted relative to the HOME folder. If there's none, panic
+        std::env::remove_var(ZOKRATES_HOME);
+        let _res = resolve(&Some(String::from(".")), &String::from(""));
+    }
+
+    #[test]
+    fn no_file_name_with_stdlib() {
+        use std::io::Write;
+
+        // create a HOME folder with a code file
+        let zokrates_home_folder = tempfile::tempdir().unwrap();
+        let file_path = zokrates_home_folder.path().join("bar.code");
+        let mut file = File::create(file_path).unwrap();
+        writeln!(file, "<stdlib code>").unwrap();
+
+        // assign HOME folder to ZOKRATES_HOME
+        std::env::set_var(ZOKRATES_HOME, zokrates_home_folder.path());
+
         let res = resolve(&Some(String::from(".")), &String::from(""));
         assert!(res.is_err());
     }


### PR DESCRIPTION
There's an edge case in the fs resolver when the file name is empty. To avoid handling it separately, make sure it behaves correctly with regards to the stdlib semantics: search for the empty file relative to ZOKRATES_HOME if it's defined (gracefully returning an error), panic otherwise.