### PR TITLE
Remove linear check in flat_absy to ir conversion

### DIFF
--- a/zokrates_core/src/ir/from_flat.rs
+++ b/zokrates_core/src/ir/from_flat.rs
@@ -81,7 +81,6 @@ impl<T: Field> From<FlatProg<T>> for Prog<T> {
 
 impl<T: Field> From<FlatExpression<T>> for LinComb<T> {
     fn from(flat_expression: FlatExpression<T>) -> LinComb<T> {
-        assert!(flat_expression.is_linear());
         match flat_expression {
             FlatExpression::Number(ref n) if *n == T::from(0) => LinComb::zero(),
             FlatExpression::Number(n) => LinComb::summand(n, FlatVariable::one()),


### PR DESCRIPTION
It has a huge performance impact (25s -> 6s on `stdlib/hashes/sha256/1024bitPadded.code`) and is not required as the match statement does the same job.