### PR TITLE
Added 256bitPadded.code for sha256 on field[256] -> field[256] 

### DIFF
--- a/zokrates_stdlib/stdlib/hashes/sha256/256bitPadded.code
+++ b/zokrates_stdlib/stdlib/hashes/sha256/256bitPadded.code
@@ -1,0 +1,30 @@
+import "./512bit.code" as sha256 
+
+// A function that takes 1 field[256] array as input 
+// and returns the sha256 full round output as an array of 256 field elements.
+def main(field[256] a) -> (field[256]):
+
+    // Hash is computed on the full 256bit block size 
+    // padding does not fit in the primary block
+    // add dummy block (single "1" followed by "0" + total length) 
+    field[256] dummyblock1 = [ \
+        1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, \
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, \
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, \
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, \
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, \
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, \
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, \
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, \
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, \
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, \
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, \
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, \
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, \
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, \
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, \
+        0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0]
+
+    digest = sha256(a, dummyblock1)
+
+    return digest

--- a/zokrates_stdlib/stdlib/hashes/sha256/256bitPadded.code
+++ b/zokrates_stdlib/stdlib/hashes/sha256/256bitPadded.code
@@ -5,7 +5,7 @@ import "./512bit.code" as sha256
 def main(field[256] a) -> (field[256]):
 
     // Hash is computed on 256 bits of input
-    // padding does not fit in the primary block
+    // padding fits in the remaining 256 bits of the first block
     // add dummy block (single "1" followed by "0" + total length) 
     field[256] dummyblock1 = [ \
         1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, \

--- a/zokrates_stdlib/stdlib/hashes/sha256/256bitPadded.code
+++ b/zokrates_stdlib/stdlib/hashes/sha256/256bitPadded.code
@@ -4,7 +4,7 @@ import "./512bit.code" as sha256
 // and returns the sha256 full round output as an array of 256 field elements.
 def main(field[256] a) -> (field[256]):
 
-    // Hash is computed on the full 256bit block size 
+    // Hash is computed on 256 bits of input
     // padding does not fit in the primary block
     // add dummy block (single "1" followed by "0" + total length) 
     field[256] dummyblock1 = [ \


### PR DESCRIPTION
Added 256bitPadded.code to /stdlib/hashes/sha256.
Allows to call sha256 on field[256] input, generating field[256] as output (no unpacking / packing).

Useful when computing Bitcoin's double-sha256.