### PR TITLE
Add boolean constants

### DIFF
--- a/zokrates_cli/examples/boolean_literal.code
+++ b/zokrates_cli/examples/boolean_literal.code
@@ -1,0 +1,2 @@
+def main(bool a) -> (bool):
+	return (false || true) && false

--- a/zokrates_core/src/absy/from_ast.rs
+++ b/zokrates_core/src/absy/from_ast.rs
@@ -521,7 +521,10 @@ impl<'ast> From<pest::Type<'ast>> for Type {
                         pest::ConstantExpression::DecimalNumber(n) => {
                             str::parse::<usize>(&n.value).unwrap()
                         }
-                        _ => unimplemented!("Array size should be a decimal number, found"),
+                        _ => unimplemented!(
+                            "Array size should be a decimal number, found {}",
+                            c.span().as_str()
+                        ),
                     },
                     e => {
                         unimplemented!("Array size should be constant, found {}", e.span().as_str())

--- a/zokrates_core/src/absy/from_ast.rs
+++ b/zokrates_core/src/absy/from_ast.rs
@@ -465,8 +465,14 @@ impl<'ast, T: Field> From<pest::PostfixExpression<'ast>> for absy::ExpressionNod
 impl<'ast, T: Field> From<pest::ConstantExpression<'ast>> for absy::ExpressionNode<'ast, T> {
     fn from(expression: pest::ConstantExpression<'ast>) -> absy::ExpressionNode<'ast, T> {
         use absy::NodeValue;
-        absy::Expression::Number(T::try_from_dec_str(&expression.value).unwrap())
-            .span(expression.span)
+        match expression {
+            pest::ConstantExpression::BooleanConstant(c) => {
+                absy::Expression::BooleanConstant(c.value.parse().unwrap()).span(c.span)
+            }
+            pest::ConstantExpression::DecimalNumber(n) => {
+                absy::Expression::Number(T::try_from_dec_str(&n.value).unwrap()).span(n.span)
+            }
+        }
     }
 }
 
@@ -511,7 +517,12 @@ impl<'ast> From<pest::Type<'ast>> for Type {
             },
             pest::Type::Array(t) => {
                 let size = match t.size {
-                    pest::Expression::Constant(c) => str::parse::<usize>(&c.value).unwrap(),
+                    pest::Expression::Constant(c) => match c {
+                        pest::ConstantExpression::DecimalNumber(n) => {
+                            str::parse::<usize>(&n.value).unwrap()
+                        }
+                        _ => unimplemented!("Array size should be a decimal number, found"),
+                    },
                     e => {
                         unimplemented!("Array size should be constant, found {}", e.span().as_str())
                     }

--- a/zokrates_core/src/absy/from_ast.rs
+++ b/zokrates_core/src/absy/from_ast.rs
@@ -549,7 +549,7 @@ mod tests {
 
     #[test]
     fn forty_two() {
-        let source = "def main() -> (field): return 42
+        let source = "def main() -> (field): return true
 		";
         let ast = pest::generate_ast(&source).unwrap();
         let expected: absy::Prog<FieldPrime> = absy::Prog {
@@ -558,7 +558,7 @@ mod tests {
                 arguments: vec![],
                 statements: vec![absy::Statement::Return(
                     absy::ExpressionList {
-                        expressions: vec![absy::Expression::Number(FieldPrime::from(42)).into()],
+                        expressions: vec![absy::Expression::BooleanConstant(true).into()],
                     }
                     .into(),
                 )

--- a/zokrates_core/src/absy/mod.rs
+++ b/zokrates_core/src/absy/mod.rs
@@ -315,6 +315,7 @@ impl<'ast, T: Field> fmt::Debug for Range<T> {
 #[derive(Clone, PartialEq)]
 pub enum Expression<'ast, T: Field> {
     Number(T),
+    BooleanConstant(bool),
     Identifier(Identifier<'ast>),
     Add(Box<ExpressionNode<'ast, T>>, Box<ExpressionNode<'ast, T>>),
     Sub(Box<ExpressionNode<'ast, T>>, Box<ExpressionNode<'ast, T>>),
@@ -354,6 +355,7 @@ impl<'ast, T: Field> fmt::Display for Expression<'ast, T> {
             Expression::Mult(ref lhs, ref rhs) => write!(f, "({} * {})", lhs, rhs),
             Expression::Div(ref lhs, ref rhs) => write!(f, "({} / {})", lhs, rhs),
             Expression::Pow(ref lhs, ref rhs) => write!(f, "{}**{}", lhs, rhs),
+            Expression::BooleanConstant(b) => write!(f, "{}", b),
             Expression::IfElse(ref condition, ref consequent, ref alternative) => write!(
                 f,
                 "if {} then {} else {} fi",
@@ -402,6 +404,7 @@ impl<'ast, T: Field> fmt::Debug for Expression<'ast, T> {
             Expression::Mult(ref lhs, ref rhs) => write!(f, "Mult({:?}, {:?})", lhs, rhs),
             Expression::Div(ref lhs, ref rhs) => write!(f, "Div({:?}, {:?})", lhs, rhs),
             Expression::Pow(ref lhs, ref rhs) => write!(f, "Pow({:?}, {:?})", lhs, rhs),
+            Expression::BooleanConstant(b) => write!(f, "{}", b),
             Expression::IfElse(ref condition, ref consequent, ref alternative) => write!(
                 f,
                 "IfElse({:?}, {:?}, {:?})",

--- a/zokrates_core/src/absy/mod.rs
+++ b/zokrates_core/src/absy/mod.rs
@@ -314,7 +314,7 @@ impl<'ast, T: Field> fmt::Debug for Range<T> {
 
 #[derive(Clone, PartialEq)]
 pub enum Expression<'ast, T: Field> {
-    Number(T),
+    FieldConstant(T),
     BooleanConstant(bool),
     Identifier(Identifier<'ast>),
     Add(Box<ExpressionNode<'ast, T>>, Box<ExpressionNode<'ast, T>>),
@@ -348,7 +348,7 @@ pub type ExpressionNode<'ast, T> = Node<Expression<'ast, T>>;
 impl<'ast, T: Field> fmt::Display for Expression<'ast, T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
-            Expression::Number(ref i) => write!(f, "{}", i),
+            Expression::FieldConstant(ref i) => write!(f, "{}", i),
             Expression::Identifier(ref var) => write!(f, "{}", var),
             Expression::Add(ref lhs, ref rhs) => write!(f, "({} + {})", lhs, rhs),
             Expression::Sub(ref lhs, ref rhs) => write!(f, "({} - {})", lhs, rhs),
@@ -397,7 +397,7 @@ impl<'ast, T: Field> fmt::Display for Expression<'ast, T> {
 impl<'ast, T: Field> fmt::Debug for Expression<'ast, T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
-            Expression::Number(ref i) => write!(f, "Num({})", i),
+            Expression::FieldConstant(ref i) => write!(f, "Num({})", i),
             Expression::Identifier(ref var) => write!(f, "Ide({})", var),
             Expression::Add(ref lhs, ref rhs) => write!(f, "Add({:?}, {:?})", lhs, rhs),
             Expression::Sub(ref lhs, ref rhs) => write!(f, "Sub({:?}, {:?})", lhs, rhs),

--- a/zokrates_core/src/semantics.rs
+++ b/zokrates_core/src/semantics.rs
@@ -569,6 +569,7 @@ impl<'ast> Checker<'ast> {
         let pos = expr.pos();
 
         match expr.value {
+            Expression::BooleanConstant(b) => Ok(BooleanExpression::Value(b).into()),
             Expression::Identifier(name) => {
                 // check that `id` is defined in the scope
                 match self.get_scope(&name) {

--- a/zokrates_core/src/semantics.rs
+++ b/zokrates_core/src/semantics.rs
@@ -717,7 +717,7 @@ impl<'ast> Checker<'ast> {
                     }),
                 }
             }
-            Expression::Number(n) => Ok(FieldElementExpression::Number(n).into()),
+            Expression::FieldConstant(n) => Ok(FieldElementExpression::Number(n).into()),
             Expression::FunctionCall(fun_id, arguments) => {
                 // check the arguments
                 let mut arguments_checked = vec![];
@@ -1156,7 +1156,7 @@ mod tests {
     //     foo_statements.push(Statement::Declaration(Variable::field_element("a")));
     //     foo_statements.push(Statement::Definition(
     //         Assignee::Identifier(String::from("a")),
-    //         Expression::Number(FieldPrime::from(1)),
+    //         Expression::FieldConstant(FieldPrime::from(1)),
     //     ));
     //     let foo = Function {
     //         id: "foo".to_string(),
@@ -1216,7 +1216,7 @@ mod tests {
     //         Statement::Declaration(Variable::field_element("a")),
     //         Statement::Definition(
     //             Assignee::Identifier(String::from("a")),
-    //             Expression::Number(FieldPrime::from(1)),
+    //             Expression::FieldConstant(FieldPrime::from(1)),
     //         ),
     //     ];
 
@@ -1235,7 +1235,7 @@ mod tests {
     //         Statement::Declaration(Variable::field_element("a")),
     //         Statement::Definition(
     //             Assignee::Identifier(String::from("a")),
-    //             Expression::Number(FieldPrime::from(2)),
+    //             Expression::FieldConstant(FieldPrime::from(2)),
     //         ),
     //         Statement::Return(ExpressionList {
     //             expressions: vec![Expression::Identifier(String::from("a"))],
@@ -1253,7 +1253,7 @@ mod tests {
 
     //     let main_args = vec![];
     //     let main_statements = vec![Statement::Return(ExpressionList {
-    //         expressions: vec![Expression::Number(FieldPrime::from(1))],
+    //         expressions: vec![Expression::FieldConstant(FieldPrime::from(1))],
     //     })];
 
     //     let main = Function {
@@ -1433,7 +1433,7 @@ mod tests {
     //     //   4 == foo()
     //     // should fail
     //     let bar_statements: Vec<Statement<FieldPrime>> = vec![Statement::Condition(
-    //         Expression::Number(FieldPrime::from(2)),
+    //         Expression::FieldConstant(FieldPrime::from(2)),
     //         Expression::FunctionCall("foo".to_string(), vec![]),
     //     )];
 
@@ -1513,8 +1513,8 @@ mod tests {
 
     //     let foo_statements: Vec<Statement<FieldPrime>> = vec![Statement::Return(ExpressionList {
     //         expressions: vec![
-    //             Expression::Number(FieldPrime::from(1)),
-    //             Expression::Number(FieldPrime::from(2)),
+    //             Expression::FieldConstant(FieldPrime::from(1)),
+    //             Expression::FieldConstant(FieldPrime::from(2)),
     //         ],
     //     })];
 
@@ -1545,7 +1545,7 @@ mod tests {
     //             ),
     //         ),
     //         Statement::Return(ExpressionList {
-    //             expressions: vec![Expression::Number(FieldPrime::from(1))],
+    //             expressions: vec![Expression::FieldConstant(FieldPrime::from(1))],
     //         }),
     //     ];
 
@@ -1580,7 +1580,7 @@ mod tests {
     //     //   1 == foo()
     //     // should fail
     //     let bar_statements: Vec<Statement<FieldPrime>> = vec![Statement::Condition(
-    //         Expression::Number(FieldPrime::from(1)),
+    //         Expression::FieldConstant(FieldPrime::from(1)),
     //         Expression::FunctionCall("foo".to_string(), vec![]),
     //     )];
 
@@ -1724,7 +1724,7 @@ mod tests {
     //     //
     //     // should fail
     //     let foo2_statements: Vec<Statement<FieldPrime>> = vec![Statement::Return(ExpressionList {
-    //         expressions: vec![Expression::Number(FieldPrime::from(1))],
+    //         expressions: vec![Expression::FieldConstant(FieldPrime::from(1))],
     //     })];
 
     //     let foo2_arguments = vec![
@@ -1780,7 +1780,7 @@ mod tests {
     //     // should fail
     //     let main1_statements: Vec<Statement<FieldPrime>> =
     //         vec![Statement::Return(ExpressionList {
-    //             expressions: vec![Expression::Number(FieldPrime::from(1))],
+    //             expressions: vec![Expression::FieldConstant(FieldPrime::from(1))],
     //         })];
 
     //     let main1_arguments = vec![Parameter {
@@ -1790,7 +1790,7 @@ mod tests {
 
     //     let main2_statements: Vec<Statement<FieldPrime>> =
     //         vec![Statement::Return(ExpressionList {
-    //             expressions: vec![Expression::Number(FieldPrime::from(1))],
+    //             expressions: vec![Expression::FieldConstant(FieldPrime::from(1))],
     //         })];
 
     //     let main2_arguments = vec![];
@@ -1904,7 +1904,7 @@ mod tests {
     //         // a[2] = 42
     //         let a = Assignee::ArrayElement(
     //             box Assignee::Identifier(String::from("a")),
-    //             box Expression::Number(FieldPrime::from(2)),
+    //             box Expression::FieldConstant(FieldPrime::from(2)),
     //         );
 
     //         let mut checker: Checker = Checker::new();

--- a/zokrates_parser/src/lib.rs
+++ b/zokrates_parser/src/lib.rs
@@ -100,7 +100,9 @@ mod tests {
                                 expression(43, 44, [
                                     term(43, 44, [
                                         primary_expression(43, 44, [
-                                            constant(43, 44)
+                                            constant(43, 44, [
+                                                decimal_number(43, 44)
+                                            ])
                                         ])
                                     ])
                                 ])

--- a/zokrates_parser/src/zokrates.pest
+++ b/zokrates_parser/src/zokrates.pest
@@ -77,9 +77,9 @@ unary_expression = { op_unary ~ term }
 
 assignee = { identifier ~ ("[" ~ range_or_expression ~ "]")* }
 identifier = @{ ((!keyword ~ ASCII_ALPHA) | (keyword ~ (ASCII_ALPHANUMERIC | "_"))) ~ (ASCII_ALPHANUMERIC | "_")* }
-constant = { decimal_number | boolean_constant }
+constant = { decimal_number | boolean_literal }
 decimal_number = @{ "0" | ASCII_NONZERO_DIGIT ~ ASCII_DIGIT* }
-boolean_constant = { "true" | "false" }
+boolean_literal = { "true" | "false" }
 
 op_inclusive_or = {"||"}
 op_exclusive_or = {"^"}

--- a/zokrates_parser/src/zokrates.pest
+++ b/zokrates_parser/src/zokrates.pest
@@ -77,7 +77,9 @@ unary_expression = { op_unary ~ term }
 
 assignee = { identifier ~ ("[" ~ range_or_expression ~ "]")* }
 identifier = @{ ((!keyword ~ ASCII_ALPHA) | (keyword ~ (ASCII_ALPHANUMERIC | "_"))) ~ (ASCII_ALPHANUMERIC | "_")* }
-constant = @{ "0" | ASCII_NONZERO_DIGIT ~ ASCII_DIGIT* }
+constant = { decimal_number | boolean_constant }
+decimal_number = @{ "0" | ASCII_NONZERO_DIGIT ~ ASCII_DIGIT* }
+boolean_constant = { "true" | "false" }
 
 op_inclusive_or = {"||"}
 op_exclusive_or = {"^"}

--- a/zokrates_pest_ast/src/lib.rs
+++ b/zokrates_pest_ast/src/lib.rs
@@ -709,14 +709,18 @@ mod tests {
                     returns: vec![Type::Basic(BasicType::Field(FieldType {}))],
                     statements: vec![Statement::Return(ReturnStatement {
                         expressions: vec![Expression::add(
-                            Expression::Constant(ConstantExpression {
-                                value: String::from("1"),
-                                span: Span::new(&source, 59, 60).unwrap()
-                            }),
-                            Expression::Constant(ConstantExpression {
-                                value: String::from("1"),
-                                span: Span::new(&source, 63, 64).unwrap()
-                            }),
+                            Expression::Constant(ConstantExpression::DecimalNumber(
+                                DecimalNumberExpression {
+                                    value: String::from("1"),
+                                    span: Span::new(&source, 59, 60).unwrap()
+                                }
+                            )),
+                            Expression::Constant(ConstantExpression::DecimalNumber(
+                                DecimalNumberExpression {
+                                    value: String::from("1"),
+                                    span: Span::new(&source, 63, 64).unwrap()
+                                }
+                            )),
                             Span::new(&source, 59, 64).unwrap()
                         )],
                         span: Span::new(&source, 52, 64).unwrap(),
@@ -754,24 +758,32 @@ mod tests {
                     returns: vec![Type::Basic(BasicType::Field(FieldType {}))],
                     statements: vec![Statement::Return(ReturnStatement {
                         expressions: vec![Expression::add(
-                            Expression::Constant(ConstantExpression {
-                                value: String::from("1"),
-                                span: Span::new(&source, 59, 60).unwrap()
-                            }),
+                            Expression::Constant(ConstantExpression::DecimalNumber(
+                                DecimalNumberExpression {
+                                    value: String::from("1"),
+                                    span: Span::new(&source, 59, 60).unwrap()
+                                }
+                            )),
                             Expression::mul(
-                                Expression::Constant(ConstantExpression {
-                                    value: String::from("2"),
-                                    span: Span::new(&source, 63, 64).unwrap()
-                                }),
+                                Expression::Constant(ConstantExpression::DecimalNumber(
+                                    DecimalNumberExpression {
+                                        value: String::from("2"),
+                                        span: Span::new(&source, 63, 64).unwrap()
+                                    }
+                                )),
                                 Expression::pow(
-                                    Expression::Constant(ConstantExpression {
-                                        value: String::from("3"),
-                                        span: Span::new(&source, 67, 68).unwrap()
-                                    }),
-                                    Expression::Constant(ConstantExpression {
-                                        value: String::from("4"),
-                                        span: Span::new(&source, 72, 73).unwrap()
-                                    }),
+                                    Expression::Constant(ConstantExpression::DecimalNumber(
+                                        DecimalNumberExpression {
+                                            value: String::from("3"),
+                                            span: Span::new(&source, 67, 68).unwrap()
+                                        }
+                                    )),
+                                    Expression::Constant(ConstantExpression::DecimalNumber(
+                                        DecimalNumberExpression {
+                                            value: String::from("4"),
+                                            span: Span::new(&source, 72, 73).unwrap()
+                                        }
+                                    )),
                                     Span::new(&source, 67, 73).unwrap()
                                 ),
                                 Span::new(&source, 63, 73).unwrap()
@@ -813,18 +825,24 @@ mod tests {
                     returns: vec![Type::Basic(BasicType::Field(FieldType {}))],
                     statements: vec![Statement::Return(ReturnStatement {
                         expressions: vec![Expression::if_else(
-                            Expression::Constant(ConstantExpression {
-                                value: String::from("1"),
-                                span: Span::new(&source, 62, 63).unwrap()
-                            }),
-                            Expression::Constant(ConstantExpression {
-                                value: String::from("2"),
-                                span: Span::new(&source, 69, 70).unwrap()
-                            }),
-                            Expression::Constant(ConstantExpression {
-                                value: String::from("3"),
-                                span: Span::new(&source, 76, 77).unwrap()
-                            }),
+                            Expression::Constant(ConstantExpression::DecimalNumber(
+                                DecimalNumberExpression {
+                                    value: String::from("1"),
+                                    span: Span::new(&source, 62, 63).unwrap()
+                                }
+                            )),
+                            Expression::Constant(ConstantExpression::DecimalNumber(
+                                DecimalNumberExpression {
+                                    value: String::from("2"),
+                                    span: Span::new(&source, 69, 70).unwrap()
+                                }
+                            )),
+                            Expression::Constant(ConstantExpression::DecimalNumber(
+                                DecimalNumberExpression {
+                                    value: String::from("3"),
+                                    span: Span::new(&source, 76, 77).unwrap()
+                                }
+                            )),
                             Span::new(&source, 59, 80).unwrap()
                         )],
                         span: Span::new(&source, 52, 80).unwrap(),
@@ -860,10 +878,12 @@ mod tests {
                     parameters: vec![],
                     returns: vec![Type::Basic(BasicType::Field(FieldType {}))],
                     statements: vec![Statement::Return(ReturnStatement {
-                        expressions: vec![Expression::Constant(ConstantExpression {
-                            value: String::from("1"),
-                            span: Span::new(&source, 31, 32).unwrap()
-                        })],
+                        expressions: vec![Expression::Constant(ConstantExpression::DecimalNumber(
+                            DecimalNumberExpression {
+                                value: String::from("1"),
+                                span: Span::new(&source, 31, 32).unwrap()
+                            }
+                        ))],
                         span: Span::new(&source, 23, 33).unwrap(),
                     })],
                     span: Span::new(&source, 0, 34).unwrap(),
@@ -913,19 +933,25 @@ mod tests {
                             },
                         ],
                         arguments: vec![
-                            Expression::Constant(ConstantExpression {
-                                value: String::from("1"),
-                                span: Span::new(&source, 40, 41).unwrap()
-                            }),
+                            Expression::Constant(ConstantExpression::DecimalNumber(
+                                DecimalNumberExpression {
+                                    value: String::from("1"),
+                                    span: Span::new(&source, 40, 41).unwrap()
+                                }
+                            )),
                             Expression::add(
-                                Expression::Constant(ConstantExpression {
-                                    value: String::from("2"),
-                                    span: Span::new(&source, 43, 44).unwrap()
-                                }),
-                                Expression::Constant(ConstantExpression {
-                                    value: String::from("3"),
-                                    span: Span::new(&source, 47, 48).unwrap()
-                                }),
+                                Expression::Constant(ConstantExpression::DecimalNumber(
+                                    DecimalNumberExpression {
+                                        value: String::from("2"),
+                                        span: Span::new(&source, 43, 44).unwrap()
+                                    }
+                                )),
+                                Expression::Constant(ConstantExpression::DecimalNumber(
+                                    DecimalNumberExpression {
+                                        value: String::from("3"),
+                                        span: Span::new(&source, 47, 48).unwrap()
+                                    }
+                                )),
                                 Span::new(&source, 43, 48).unwrap()
                             ),
                         ],

--- a/zokrates_pest_ast/src/lib.rs
+++ b/zokrates_pest_ast/src/lib.rs
@@ -517,7 +517,7 @@ mod ast {
             match self {
                 Expression::Binary(b) => &b.span,
                 Expression::Identifier(i) => &i.span,
-                Expression::Constant(c) => &c.span,
+                Expression::Constant(c) => &c.span(),
                 Expression::Ternary(t) => &t.span,
                 Expression::Postfix(p) => &p.span,
                 Expression::InlineArray(a) => &a.span,
@@ -552,7 +552,32 @@ mod ast {
 
     #[derive(Debug, FromPest, PartialEq, Clone)]
     #[pest_ast(rule(Rule::constant))]
-    pub struct ConstantExpression<'ast> {
+    pub enum ConstantExpression<'ast> {
+        DecimalNumber(DecimalNumberExpression<'ast>),
+        BooleanConstant(BooleanConstantExpression<'ast>),
+    }
+
+    impl<'ast> ConstantExpression<'ast> {
+        pub fn span(&self) -> &Span<'ast> {
+            match self {
+                ConstantExpression::DecimalNumber(n) => &n.span,
+                ConstantExpression::BooleanConstant(c) => &c.span,
+            }
+        }
+    }
+
+    #[derive(Debug, FromPest, PartialEq, Clone)]
+    #[pest_ast(rule(Rule::decimal_number))]
+    pub struct DecimalNumberExpression<'ast> {
+        #[pest_ast(outer(with(span_into_str)))]
+        pub value: String,
+        #[pest_ast(outer())]
+        pub span: Span<'ast>,
+    }
+
+    #[derive(Debug, FromPest, PartialEq, Clone)]
+    #[pest_ast(rule(Rule::boolean_constant))]
+    pub struct BooleanConstantExpression<'ast> {
         #[pest_ast(outer(with(span_into_str)))]
         pub value: String,
         #[pest_ast(outer())]

--- a/zokrates_pest_ast/src/lib.rs
+++ b/zokrates_pest_ast/src/lib.rs
@@ -554,14 +554,14 @@ mod ast {
     #[pest_ast(rule(Rule::constant))]
     pub enum ConstantExpression<'ast> {
         DecimalNumber(DecimalNumberExpression<'ast>),
-        BooleanConstant(BooleanConstantExpression<'ast>),
+        BooleanLiteral(BooleanLiteralExpression<'ast>),
     }
 
     impl<'ast> ConstantExpression<'ast> {
         pub fn span(&self) -> &Span<'ast> {
             match self {
                 ConstantExpression::DecimalNumber(n) => &n.span,
-                ConstantExpression::BooleanConstant(c) => &c.span,
+                ConstantExpression::BooleanLiteral(c) => &c.span,
             }
         }
     }
@@ -576,8 +576,8 @@ mod ast {
     }
 
     #[derive(Debug, FromPest, PartialEq, Clone)]
-    #[pest_ast(rule(Rule::boolean_constant))]
-    pub struct BooleanConstantExpression<'ast> {
+    #[pest_ast(rule(Rule::boolean_literal))]
+    pub struct BooleanLiteralExpression<'ast> {
         #[pest_ast(outer(with(span_into_str)))]
         pub value: String,
         #[pest_ast(outer())]


### PR DESCRIPTION
Boolean constants `true` and `false` are supported in typed_absy and flattening, but not in the parser.
Add them to the grammar, pest ast, and absy.