### PR TITLE
Optimize zero quadratic combinations

### DIFF
--- a/zokrates_core/src/ir/expression.rs
+++ b/zokrates_core/src/ir/expression.rs
@@ -31,6 +31,11 @@ impl<T: Field> QuadComb<T> {
             }
             _ => {}
         }
+
+        if self.left.is_zero() || self.right.is_zero() {
+            return Some(LinComb::zero());
+        }
+
         None
     }
 }


### PR DESCRIPTION
We remove linear constraints, ie if a constraint is of the form `k * ~one * linear == x` with `k` scalar and `x` yet undefined, we remove the constraint and substitute x for `k * linear` everywhere.

One edge case we do not cover is when the constraint is of the form `0 * linear == x` or `linear * 0 == x`, in which case we can substitute `x` by 0 everywhere.

Implement this edge case optimisation.