### PR TITLE
add Abiv2 option to cli & changes proof format to uniform format

### DIFF
--- a/zokrates_cli/src/bin.rs
+++ b/zokrates_cli/src/bin.rs
@@ -133,6 +133,12 @@ fn cli() -> Result<(), String> {
             .takes_value(true)
             .required(false)
             .default_value(&default_scheme)
+        ).arg(Arg::with_name("abiv2")
+            .short("abiv2")
+            .long("abiv2")
+            .help("Flag for setting version of ABI Encoder used in the contract. Default is ABIv1")
+            .takes_value(false)
+            .required(false)
         )
     )
     .subcommand(SubCommand::with_name("compute-witness")
@@ -226,7 +232,7 @@ fn cli() -> Result<(), String> {
             .value_name("FORMAT")
             .help("Format in which the proof should be printed. [remix, json]")
             .takes_value(true)
-            .possible_values(&["remix", "json", "testingV1", "testingV2"])
+            .possible_values(&["remix", "json"])
             .required(true)
         )
     )
@@ -404,7 +410,7 @@ fn cli() -> Result<(), String> {
         ("export-verifier", Some(sub_matches)) => {
             {
                 let scheme = get_scheme(sub_matches.value_of("proving-scheme").unwrap())?;
-
+                let abiv2 = sub_matches.occurrences_of("abiv2") > 0;
                 println!("Exporting verifier...");
 
                 // read vk file
@@ -413,7 +419,7 @@ fn cli() -> Result<(), String> {
                     .map_err(|why| format!("couldn't open {}: {}", input_path.display(), why))?;
                 let reader = BufReader::new(input_file);
 
-                let verifier = scheme.export_solidity_verifier(reader);
+                let verifier = scheme.export_solidity_verifier(reader, &abiv2);
 
                 //write output file
                 let output_path = Path::new(sub_matches.value_of("output").unwrap());

--- a/zokrates_core/lib/gm17.cpp
+++ b/zokrates_core/lib/gm17.cpp
@@ -97,11 +97,11 @@ void serializeVerificationKeyToFile(r1cs_se_ppzksnark_verification_key<libff::al
 
   unsigned queryLength = vk.query.size();
 
-  ss << "\t\tvk.H = " << outputPointG2AffineAsHex(vk.H) << endl;
-  ss << "\t\tvk.Galpha = " << outputPointG1AffineAsHex(vk.G_alpha) << endl;
-  ss << "\t\tvk.Hbeta = " << outputPointG2AffineAsHex(vk.H_beta) << endl;
-  ss << "\t\tvk.Ggamma = " << outputPointG1AffineAsHex(vk.G_gamma) << endl;
-  ss << "\t\tvk.Hgamma = " << outputPointG2AffineAsHex(vk.H_gamma) << endl;
+  ss << "\t\tvk.h = " << outputPointG2AffineAsHex(vk.H) << endl;
+  ss << "\t\tvk.g_alpha = " << outputPointG1AffineAsHex(vk.G_alpha) << endl;
+  ss << "\t\tvk.h_beta = " << outputPointG2AffineAsHex(vk.H_beta) << endl;
+  ss << "\t\tvk.g_gamma = " << outputPointG1AffineAsHex(vk.G_gamma) << endl;
+  ss << "\t\tvk.h_gamma = " << outputPointG2AffineAsHex(vk.H_gamma) << endl;
   ss << "\t\tvk.query.len() = " << queryLength << endl;
   for (size_t i = 0; i < queryLength; ++i)
   {
@@ -124,14 +124,14 @@ void exportProof(r1cs_se_ppzksnark_proof<libff::alt_bn128_pp> proof, const char*
     ss << "{" << "\n";
       ss << "\t\"proof\":" << "\n";
         ss << "\t{" << "\n";
-          ss << "\t\t\"A\":" <<outputPointG1AffineAsHexJson(proof.A) << ",\n";
-          ss << "\t\t\"B\":" << "\n";
+          ss << "\t\t\"a\":" <<outputPointG1AffineAsHexJson(proof.A) << ",\n";
+          ss << "\t\t\"b\":" << "\n";
             ss << "\t\t\t" << outputPointG2AffineAsHexJson(proof.B) << ",\n";
           ss << "\t\t\n";
-          ss << "\t\t\"C\":" <<outputPointG1AffineAsHexJson(proof.C) << ",\n";
+          ss << "\t\t\"c\":" <<outputPointG1AffineAsHexJson(proof.C) << "\n";
         ss << "\t}," << "\n";
       //add input to json
-      ss << "\t\"input\":" << "[";
+      ss << "\t\"inputs\":" << "[";
       for (int i = 1; i < public_inputs_length; i++) {
         if(i!=1){
           ss << ",";

--- a/zokrates_core/lib/pghr13.cpp
+++ b/zokrates_core/lib/pghr13.cpp
@@ -97,15 +97,15 @@ void serializeVerificationKeyToFile(r1cs_ppzksnark_verification_key<libff::alt_b
 
   unsigned icLength = vk.encoded_IC_query.rest.indices.size() + 1;
 
-  ss << "\t\tvk.A = " << outputPointG2AffineAsHex(vk.alphaA_g2) << endl;
-  ss << "\t\tvk.B = " << outputPointG1AffineAsHex(vk.alphaB_g1) << endl;
-  ss << "\t\tvk.C = " << outputPointG2AffineAsHex(vk.alphaC_g2) << endl;
+  ss << "\t\tvk.a = " << outputPointG2AffineAsHex(vk.alphaA_g2) << endl;
+  ss << "\t\tvk.b = " << outputPointG1AffineAsHex(vk.alphaB_g1) << endl;
+  ss << "\t\tvk.c = " << outputPointG2AffineAsHex(vk.alphaC_g2) << endl;
   ss << "\t\tvk.gamma = " << outputPointG2AffineAsHex(vk.gamma_g2) << endl;
-  ss << "\t\tvk.gammaBeta1 = " << outputPointG1AffineAsHex(vk.gamma_beta_g1) << endl;
-  ss << "\t\tvk.gammaBeta2 = " << outputPointG2AffineAsHex(vk.gamma_beta_g2) << endl;
-  ss << "\t\tvk.Z = " << outputPointG2AffineAsHex(vk.rC_Z_g2) << endl;
-  ss << "\t\tvk.IC.len() = " << icLength << endl;
-  ss << "\t\tvk.IC[0] = " << outputPointG1AffineAsHex(vk.encoded_IC_query.first) << endl;
+  ss << "\t\tvk.gamma_beta_1 = " << outputPointG1AffineAsHex(vk.gamma_beta_g1) << endl;
+  ss << "\t\tvk.gamma_beta_2 = " << outputPointG2AffineAsHex(vk.gamma_beta_g2) << endl;
+  ss << "\t\tvk.z = " << outputPointG2AffineAsHex(vk.rC_Z_g2) << endl;
+  ss << "\t\tvk.ic.len() = " << icLength << endl;
+  ss << "\t\tvk.ic[0] = " << outputPointG1AffineAsHex(vk.encoded_IC_query.first) << endl;
   for (size_t i = 1; i < icLength; ++i)
   {
                   auto vkICi = outputPointG1AffineAsHex(vk.encoded_IC_query.rest.values[i - 1]);
@@ -127,19 +127,19 @@ void exportProof(r1cs_ppzksnark_proof<libff::alt_bn128_pp> proof, const char* pr
                 ss << "{" << "\n";
                   ss << "\t\"proof\":" << "\n";
                     ss << "\t{" << "\n";
-                      ss << "\t\t\"A\":" <<outputPointG1AffineAsHexJson(proof.g_A.g) << ",\n";
-                      ss << "\t\t\"A_p\":" <<outputPointG1AffineAsHexJson(proof.g_A.h) << ",\n";
-                      ss << "\t\t\"B\":" << "\n";
+                      ss << "\t\t\"a\":" <<outputPointG1AffineAsHexJson(proof.g_A.g) << ",\n";
+                      ss << "\t\t\"a_p\":" <<outputPointG1AffineAsHexJson(proof.g_A.h) << ",\n";
+                      ss << "\t\t\"b\":" << "\n";
                         ss << "\t\t\t" << outputPointG2AffineAsHexJson(proof.g_B.g) << ",\n";
                       ss << "\t\t\n";
-                      ss << "\t\t\"B_p\":" <<outputPointG1AffineAsHexJson(proof.g_B.h) << ",\n";
-                      ss << "\t\t\"C\":" <<outputPointG1AffineAsHexJson(proof.g_C.g) << ",\n";
-                      ss << "\t\t\"C_p\":" <<outputPointG1AffineAsHexJson(proof.g_C.h) << ",\n";
-                      ss << "\t\t\"H\":" <<outputPointG1AffineAsHexJson(proof.g_H) << ",\n";
-                      ss << "\t\t\"K\":" <<outputPointG1AffineAsHexJson(proof.g_K) << "\n";
+                      ss << "\t\t\"b_p\":" <<outputPointG1AffineAsHexJson(proof.g_B.h) << ",\n";
+                      ss << "\t\t\"c\":" <<outputPointG1AffineAsHexJson(proof.g_C.g) << ",\n";
+                      ss << "\t\t\"c_p\":" <<outputPointG1AffineAsHexJson(proof.g_C.h) << ",\n";
+                      ss << "\t\t\"h\":" <<outputPointG1AffineAsHexJson(proof.g_H) << ",\n";
+                      ss << "\t\t\"k\":" <<outputPointG1AffineAsHexJson(proof.g_K) << "\n";
                     ss << "\t}," << "\n";
                   //add input to json
-                  ss << "\t\"input\":" << "[";
+                  ss << "\t\"inputs\":" << "[";
                   for (int i = 1; i < public_inputs_length; i++) {
                     if(i!=1){
                       ss << ",";

--- a/zokrates_core/src/proof_system/bn128/gm17.rs
+++ b/zokrates_core/src/proof_system/bn128/gm17.rs
@@ -3,7 +3,9 @@ extern crate libc;
 use self::libc::{c_char, c_int};
 use ir;
 use proof_system::bn128::utils::libsnark::{prepare_generate_proof, prepare_setup};
-use proof_system::bn128::utils::solidity::{SOLIDITY_G2_ADDITION_LIB, SOLIDITY_PAIRING_LIB};
+use proof_system::bn128::utils::solidity::{
+    SOLIDITY_G2_ADDITION_LIB, SOLIDITY_PAIRING_LIB, SOLIDITY_PAIRING_LIB_V2,
+};
 use proof_system::ProofSystem;
 use regex::Regex;
 use std::fs::File;
@@ -105,10 +107,20 @@ impl ProofSystem for GM17 {
         }
     }
 
-    fn export_solidity_verifier(&self, reader: BufReader<File>) -> String {
+    fn export_solidity_verifier(&self, reader: BufReader<File>, abiv2: &bool) -> String {
         let mut lines = reader.lines();
 
-        let mut template_text = String::from(CONTRACT_TEMPLATE);
+        let mut template_text;
+        let solidity_pairing_lib;
+
+        if *abiv2 {
+            template_text = String::from(CONTRACT_TEMPLATE_V2);
+            solidity_pairing_lib = String::from(SOLIDITY_PAIRING_LIB_V2);
+        } else {
+            template_text = String::from(CONTRACT_TEMPLATE);
+            solidity_pairing_lib = String::from(SOLIDITY_PAIRING_LIB);
+        }
+
         let query_template = String::from("vk.query[index] = Pairing.G1Point(points);"); //copy this for each entry
 
         //replace things in template
@@ -178,33 +190,33 @@ impl ProofSystem for GM17 {
 
         format!(
             "{}{}{}",
-            SOLIDITY_G2_ADDITION_LIB, SOLIDITY_PAIRING_LIB, template_text
+            SOLIDITY_G2_ADDITION_LIB, solidity_pairing_lib, template_text
         )
     }
 }
 
-const CONTRACT_TEMPLATE: &str = r#"
+const CONTRACT_TEMPLATE_V2: &str = r#"
 contract Verifier {
     using Pairing for *;
     struct VerifyingKey {
-        Pairing.G2Point H;
-        Pairing.G1Point Galpha;
-        Pairing.G2Point Hbeta;
-        Pairing.G1Point Ggamma;
-        Pairing.G2Point Hgamma;
+        Pairing.G2Point h;
+        Pairing.G1Point g_alpha;
+        Pairing.G2Point h_beta;
+        Pairing.G1Point g_gamma;
+        Pairing.G2Point h_gamma;
         Pairing.G1Point[] query;
     }
     struct Proof {
-        Pairing.G1Point A;
-        Pairing.G2Point B;
-        Pairing.G1Point C;
+        Pairing.G1Point a;
+        Pairing.G2Point b;
+        Pairing.G1Point c;
     }
     function verifyingKey() pure internal returns (VerifyingKey memory vk) {
-        vk.H = Pairing.G2Point(<%vk_h%>);
-        vk.Galpha = Pairing.G1Point(<%vk_g_alpha%>);
-        vk.Hbeta = Pairing.G2Point(<%vk_h_beta%>);
-        vk.Ggamma = Pairing.G1Point(<%vk_g_gamma%>);
-        vk.Hgamma = Pairing.G2Point(<%vk_h_gamma%>);
+        vk.h= Pairing.G2Point(<%vk_h%>);
+        vk.g_alpha = Pairing.G1Point(<%vk_g_alpha%>);
+        vk.h_beta = Pairing.G2Point(<%vk_h_beta%>);
+        vk.g_gamma = Pairing.G1Point(<%vk_g_gamma%>);
+        vk.h_gamma = Pairing.G2Point(<%vk_h_gamma%>);
         vk.query = new Pairing.G1Point[](<%vk_query_length%>);
         <%vk_query_pts%>
     }
@@ -221,11 +233,75 @@ contract Verifier {
          *                              * e(C, H)
          * where psi = \sum_{i=0}^l input_i pvk.query[i]
          */
-        if (!Pairing.pairingProd4(vk.Galpha, vk.Hbeta, vk_x, vk.Hgamma, proof.C, vk.H, Pairing.negate(Pairing.addition(proof.A, vk.Galpha)), Pairing.addition(proof.B, vk.Hbeta))) return 1;
+        if (!Pairing.pairingProd4(vk.g_alpha, vk.h_beta, vk_x, vk.h_gamma, proof.c, vk.h, Pairing.negate(Pairing.addition(proof.a, vk.g_alpha)), Pairing.addition(proof.b, vk.h_beta))) return 1;
         /**
          * e(A, H^{gamma}) = e(G^{gamma}, B)
          */
-        if (!Pairing.pairingProd2(proof.A, vk.Hgamma, Pairing.negate(vk.Ggamma), proof.B)) return 2;
+        if (!Pairing.pairingProd2(proof.a, vk.h_gamma, Pairing.negate(vk.g_gamma), proof.b)) return 2;
+        return 0;
+    }
+    event Verified(string s);
+    function verifyTx(
+            Proof memory proof,
+            uint[<%vk_input_length%>] memory input
+        ) public returns (bool r) {
+        uint[] memory inputValues = new uint[](input.length);
+        for(uint i = 0; i < input.length; i++){
+            inputValues[i] = input[i];
+        }
+        if (verify(inputValues, proof) == 0) {
+            emit Verified("Transaction successfully verified.");
+            return true;
+        } else {
+            return false;
+        }
+    }
+}
+"#;
+
+const CONTRACT_TEMPLATE: &str = r#"
+contract Verifier {
+    using Pairing for *;
+    struct VerifyingKey {
+        Pairing.G2Point h;
+        Pairing.G1Point g_alpha;
+        Pairing.G2Point h_beta;
+        Pairing.G1Point g_gamma;
+        Pairing.G2Point h_gamma;
+        Pairing.G1Point[] query;
+    }
+    struct Proof {
+        Pairing.G1Point a;
+        Pairing.G2Point b;
+        Pairing.G1Point c;
+    }
+    function verifyingKey() pure internal returns (VerifyingKey memory vk) {
+        vk.h = Pairing.G2Point(<%vk_h%>);
+        vk.g_alpha = Pairing.G1Point(<%vk_g_alpha%>);
+        vk.h_beta = Pairing.G2Point(<%vk_h_beta%>);
+        vk.g_gamma = Pairing.G1Point(<%vk_g_gamma%>);
+        vk.h_gamma = Pairing.G2Point(<%vk_h_gamma%>);
+        vk.query = new Pairing.G1Point[](<%vk_query_length%>);
+        <%vk_query_pts%>
+    }
+    function verify(uint[] memory input, Proof memory proof) internal returns (uint) {
+        VerifyingKey memory vk = verifyingKey();
+        require(input.length + 1 == vk.query.length);
+        // Compute the linear combination vk_x
+        Pairing.G1Point memory vk_x = Pairing.G1Point(0, 0);
+        for (uint i = 0; i < input.length; i++)
+            vk_x = Pairing.addition(vk_x, Pairing.scalar_mul(vk.query[i + 1], input[i]));
+        vk_x = Pairing.addition(vk_x, vk.query[0]);
+        /**
+         * e(A*G^{alpha}, B*H^{beta}) = e(G^{alpha}, H^{beta}) * e(G^{psi}, H^{gamma})
+         *                              * e(C, H)
+         * where psi = \sum_{i=0}^l input_i pvk.query[i]
+         */
+        if (!Pairing.pairingProd4(vk.g_alpha, vk.h_beta, vk_x, vk.h_gamma, proof.c, vk.h, Pairing.negate(Pairing.addition(proof.a, vk.g_alpha)), Pairing.addition(proof.b, vk.h_beta))) return 1;
+        /**
+         * e(A, H^{gamma}) = e(G^{gamma}, b)
+         */
+        if (!Pairing.pairingProd2(proof.a, vk.h_gamma, Pairing.negate(vk.g_gamma), proof.b)) return 2;
         return 0;
     }
     event Verified(string s);
@@ -236,9 +312,9 @@ contract Verifier {
             uint[<%vk_input_length%>] memory input
         ) public returns (bool r) {
         Proof memory proof;
-        proof.A = Pairing.G1Point(a[0], a[1]);
-        proof.B = Pairing.G2Point([b[0][0], b[0][1]], [b[1][0], b[1][1]]);
-        proof.C = Pairing.G1Point(c[0], c[1]);
+        proof.a = Pairing.G1Point(a[0], a[1]);
+        proof.b = Pairing.G2Point([b[0][0], b[0][1]], [b[1][0], b[1][1]]);
+        proof.c = Pairing.G1Point(c[0], c[1]);
         uint[] memory inputValues = new uint[](input.length);
         for(uint i = 0; i < input.length; i++){
             inputValues[i] = input[i];

--- a/zokrates_core/src/proof_system/bn128/pghr13.rs
+++ b/zokrates_core/src/proof_system/bn128/pghr13.rs
@@ -3,7 +3,9 @@ extern crate libc;
 use self::libc::{c_char, c_int};
 use ir;
 use proof_system::bn128::utils::libsnark::{prepare_generate_proof, prepare_setup};
-use proof_system::bn128::utils::solidity::{SOLIDITY_G2_ADDITION_LIB, SOLIDITY_PAIRING_LIB};
+use proof_system::bn128::utils::solidity::{
+    SOLIDITY_G2_ADDITION_LIB, SOLIDITY_PAIRING_LIB, SOLIDITY_PAIRING_LIB_V2,
+};
 use proof_system::ProofSystem;
 
 use regex::Regex;
@@ -111,11 +113,21 @@ impl ProofSystem for PGHR13 {
         }
     }
 
-    fn export_solidity_verifier(&self, reader: BufReader<File>) -> String {
+    fn export_solidity_verifier(&self, reader: BufReader<File>, abiv2: &bool) -> String {
         let mut lines = reader.lines();
 
-        let mut template_text = String::from(CONTRACT_TEMPLATE);
-        let ic_template = String::from("vk.IC[index] = Pairing.G1Point(points);"); //copy this for each entry
+        let mut template_text;
+        let solidity_pairing_lib;
+
+        if *abiv2 {
+            template_text = String::from(CONTRACT_TEMPLATE_V2);
+            solidity_pairing_lib = String::from(SOLIDITY_PAIRING_LIB_V2);
+        } else {
+            template_text = String::from(CONTRACT_TEMPLATE);
+            solidity_pairing_lib = String::from(SOLIDITY_PAIRING_LIB);
+        }
+
+        let ic_template = String::from("vk.ic[index] = Pairing.G1Point(points);"); //copy this for each entry
 
         //replace things in template
         let vk_regex = Regex::new(r#"(<%vk_[^i%]*%>)"#).unwrap();
@@ -181,64 +193,139 @@ impl ProofSystem for PGHR13 {
 
         format!(
             "{}{}{}",
-            SOLIDITY_G2_ADDITION_LIB, SOLIDITY_PAIRING_LIB, template_text
+            SOLIDITY_G2_ADDITION_LIB, solidity_pairing_lib, template_text
         )
     }
 }
 
-const CONTRACT_TEMPLATE: &str = r#"contract Verifier {
+const CONTRACT_TEMPLATE_V2: &str = r#"contract Verifier {
     using Pairing for *;
     struct VerifyingKey {
-        Pairing.G2Point A;
-        Pairing.G1Point B;
-        Pairing.G2Point C;
+        Pairing.G2Point a;
+        Pairing.G1Point b;
+        Pairing.G2Point c;
         Pairing.G2Point gamma;
-        Pairing.G1Point gammaBeta1;
-        Pairing.G2Point gammaBeta2;
-        Pairing.G2Point Z;
-        Pairing.G1Point[] IC;
+        Pairing.G1Point gamma_beta_1;
+        Pairing.G2Point gamma_beta_2;
+        Pairing.G2Point z;
+        Pairing.G1Point[] ic;
     }
     struct Proof {
-        Pairing.G1Point A;
-        Pairing.G1Point A_p;
-        Pairing.G2Point B;
-        Pairing.G1Point B_p;
-        Pairing.G1Point C;
-        Pairing.G1Point C_p;
-        Pairing.G1Point K;
-        Pairing.G1Point H;
+        Pairing.G1Point a;
+        Pairing.G1Point a_p;
+        Pairing.G2Point b;
+        Pairing.G1Point b_p;
+        Pairing.G1Point c;
+        Pairing.G1Point c_p;
+        Pairing.G1Point k;
+        Pairing.G1Point h;
     }
     function verifyingKey() pure internal returns (VerifyingKey memory vk) {
-        vk.A = Pairing.G2Point(<%vk_a%>);
-        vk.B = Pairing.G1Point(<%vk_b%>);
-        vk.C = Pairing.G2Point(<%vk_c%>);
+        vk.a = Pairing.G2Point(<%vk_a%>);
+        vk.b = Pairing.G1Point(<%vk_b%>);
+        vk.c = Pairing.G2Point(<%vk_c%>);
         vk.gamma = Pairing.G2Point(<%vk_g%>);
-        vk.gammaBeta1 = Pairing.G1Point(<%vk_gb1%>);
-        vk.gammaBeta2 = Pairing.G2Point(<%vk_gb2%>);
-        vk.Z = Pairing.G2Point(<%vk_z%>);
-        vk.IC = new Pairing.G1Point[](<%vk_ic_length%>);
+        vk.gamma_beta_1 = Pairing.G1Point(<%vk_gb1%>);
+        vk.gamma_beta_2 = Pairing.G2Point(<%vk_gb2%>);
+        vk.z = Pairing.G2Point(<%vk_z%>);
+        vk.ic = new Pairing.G1Point[](<%vk_ic_length%>);
         <%vk_ic_pts%>
     }
     function verify(uint[] memory input, Proof memory proof) internal returns (uint) {
         VerifyingKey memory vk = verifyingKey();
-        require(input.length + 1 == vk.IC.length);
+        require(input.length + 1 == vk.ic.length);
         // Compute the linear combination vk_x
         Pairing.G1Point memory vk_x = Pairing.G1Point(0, 0);
         for (uint i = 0; i < input.length; i++)
-            vk_x = Pairing.addition(vk_x, Pairing.scalar_mul(vk.IC[i + 1], input[i]));
-        vk_x = Pairing.addition(vk_x, vk.IC[0]);
-        if (!Pairing.pairingProd2(proof.A, vk.A, Pairing.negate(proof.A_p), Pairing.P2())) return 1;
-        if (!Pairing.pairingProd2(vk.B, proof.B, Pairing.negate(proof.B_p), Pairing.P2())) return 2;
-        if (!Pairing.pairingProd2(proof.C, vk.C, Pairing.negate(proof.C_p), Pairing.P2())) return 3;
+            vk_x = Pairing.addition(vk_x, Pairing.scalar_mul(vk.ic[i + 1], input[i]));
+        vk_x = Pairing.addition(vk_x, vk.ic[0]);
+        if (!Pairing.pairingProd2(proof.a, vk.a, Pairing.negate(proof.a_p), Pairing.P2())) return 1;
+        if (!Pairing.pairingProd2(vk.b, proof.b, Pairing.negate(proof.b_p), Pairing.P2())) return 2;
+        if (!Pairing.pairingProd2(proof.c, vk.c, Pairing.negate(proof.c_p), Pairing.P2())) return 3;
         if (!Pairing.pairingProd3(
-            proof.K, vk.gamma,
-            Pairing.negate(Pairing.addition(vk_x, Pairing.addition(proof.A, proof.C))), vk.gammaBeta2,
-            Pairing.negate(vk.gammaBeta1), proof.B
+            proof.k, vk.gamma,
+            Pairing.negate(Pairing.addition(vk_x, Pairing.addition(proof.a, proof.c))), vk.gamma_beta_2,
+            Pairing.negate(vk.gamma_beta_1), proof.b
         )) return 4;
         if (!Pairing.pairingProd3(
-                Pairing.addition(vk_x, proof.A), proof.B,
-                Pairing.negate(proof.H), vk.Z,
-                Pairing.negate(proof.C), Pairing.P2()
+                Pairing.addition(vk_x, proof.a), proof.b,
+                Pairing.negate(proof.h), vk.z,
+                Pairing.negate(proof.c), Pairing.P2()
+        )) return 5;
+        return 0;
+    }
+    event Verified(string s);
+    function verifyTx(
+            Proof memory proof,
+            uint[<%vk_input_length%>] memory input
+        ) public returns (bool r) {
+        uint[] memory inputValues = new uint[](input.length);
+        for(uint i = 0; i < input.length; i++){
+            inputValues[i] = input[i];
+        }
+        if (verify(inputValues, proof) == 0) {
+            emit Verified("Transaction successfully verified.");
+            return true;
+        } else {
+            return false;
+        }
+    }
+}
+"#;
+
+const CONTRACT_TEMPLATE: &str = r#"contract Verifier {
+    using Pairing for *;
+    struct VerifyingKey {
+        Pairing.G2Point a;
+        Pairing.G1Point b;
+        Pairing.G2Point c;
+        Pairing.G2Point gamma;
+        Pairing.G1Point gamma_beta_1;
+        Pairing.G2Point gamma_beta_2;
+        Pairing.G2Point z;
+        Pairing.G1Point[] ic;
+    }
+    struct Proof {
+        Pairing.G1Point a;
+        Pairing.G1Point a_p;
+        Pairing.G2Point b;
+        Pairing.G1Point b_p;
+        Pairing.G1Point c;
+        Pairing.G1Point c_p;
+        Pairing.G1Point k;
+        Pairing.G1Point h;
+    }
+    function verifyingKey() pure internal returns (VerifyingKey memory vk) {
+        vk.a = Pairing.G2Point(<%vk_a%>);
+        vk.b = Pairing.G1Point(<%vk_b%>);
+        vk.c = Pairing.G2Point(<%vk_c%>);
+        vk.gamma = Pairing.G2Point(<%vk_g%>);
+        vk.gamma_beta_1 = Pairing.G1Point(<%vk_gb1%>);
+        vk.gamma_beta_2 = Pairing.G2Point(<%vk_gb2%>);
+        vk.z = Pairing.G2Point(<%vk_z%>);
+        vk.ic = new Pairing.G1Point[](<%vk_ic_length%>);
+        <%vk_ic_pts%>
+    }
+    function verify(uint[] memory input, Proof memory proof) internal returns (uint) {
+        VerifyingKey memory vk = verifyingKey();
+        require(input.length + 1 == vk.ic.length);
+        // Compute the linear combination vk_x
+        Pairing.G1Point memory vk_x = Pairing.G1Point(0, 0);
+        for (uint i = 0; i < input.length; i++)
+            vk_x = Pairing.addition(vk_x, Pairing.scalar_mul(vk.ic[i + 1], input[i]));
+        vk_x = Pairing.addition(vk_x, vk.ic[0]);
+        if (!Pairing.pairingProd2(proof.a, vk.a, Pairing.negate(proof.a_p), Pairing.P2())) return 1;
+        if (!Pairing.pairingProd2(vk.b, proof.b, Pairing.negate(proof.b_p), Pairing.P2())) return 2;
+        if (!Pairing.pairingProd2(proof.c, vk.c, Pairing.negate(proof.c_p), Pairing.P2())) return 3;
+        if (!Pairing.pairingProd3(
+            proof.k, vk.gamma,
+            Pairing.negate(Pairing.addition(vk_x, Pairing.addition(proof.a, proof.c))), vk.gamma_beta_2,
+            Pairing.negate(vk.gamma_beta_1), proof.b
+        )) return 4;
+        if (!Pairing.pairingProd3(
+                Pairing.addition(vk_x, proof.a), proof.b,
+                Pairing.negate(proof.h), vk.z,
+                Pairing.negate(proof.c), Pairing.P2()
         )) return 5;
         return 0;
     }
@@ -255,14 +342,14 @@ const CONTRACT_TEMPLATE: &str = r#"contract Verifier {
             uint[<%vk_input_length%>] memory input
         ) public returns (bool r) {
         Proof memory proof;
-        proof.A = Pairing.G1Point(a[0], a[1]);
-        proof.A_p = Pairing.G1Point(a_p[0], a_p[1]);
-        proof.B = Pairing.G2Point([b[0][0], b[0][1]], [b[1][0], b[1][1]]);
-        proof.B_p = Pairing.G1Point(b_p[0], b_p[1]);
-        proof.C = Pairing.G1Point(c[0], c[1]);
-        proof.C_p = Pairing.G1Point(c_p[0], c_p[1]);
-        proof.H = Pairing.G1Point(h[0], h[1]);
-        proof.K = Pairing.G1Point(k[0], k[1]);
+        proof.a = Pairing.G1Point(a[0], a[1]);
+        proof.a_p = Pairing.G1Point(a_p[0], a_p[1]);
+        proof.b = Pairing.G2Point([b[0][0], b[0][1]], [b[1][0], b[1][1]]);
+        proof.b_p = Pairing.G1Point(b_p[0], b_p[1]);
+        proof.c = Pairing.G1Point(c[0], c[1]);
+        proof.c_p = Pairing.G1Point(c_p[0], c_p[1]);
+        proof.h = Pairing.G1Point(h[0], h[1]);
+        proof.k = Pairing.G1Point(k[0], k[1]);
         uint[] memory inputValues = new uint[](input.length);
         for(uint i = 0; i < input.length; i++){
             inputValues[i] = input[i];

--- a/zokrates_core/src/proof_system/bn128/utils/solidity.rs
+++ b/zokrates_core/src/proof_system/bn128/utils/solidity.rs
@@ -394,13 +394,161 @@ library BN256G2 {
 }
 "#;
 
+pub const SOLIDITY_PAIRING_LIB_V2 : &str = r#"// This file is MIT Licensed.
+//
+// Copyright 2017 Christian Reitwiessner
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+pragma solidity ^0.5.0;
+pragma experimental ABIEncoderV2;
+library Pairing {
+    struct G1Point {
+        uint X;
+        uint Y;
+    }
+    // Encoding of field elements is: X[0] * z + X[1]
+    struct G2Point {
+        uint[2] X;
+        uint[2] Y;
+    }
+    /// @return the generator of G1
+    function P1() pure internal returns (G1Point memory) {
+        return G1Point(1, 2);
+    }
+    /// @return the generator of G2
+    function P2() pure internal returns (G2Point memory) {
+        return G2Point(
+            [11559732032986387107991004021392285783925812861821192530917403151452391805634,
+             10857046999023057135944570762232829481370756359578518086990519993285655852781],
+            [4082367875863433681332203403145435568316851327593401208105741076214120093531,
+             8495653923123431417604973247489272438418190587263600148770280649306958101930]
+        );
+    }
+    /// @return the negation of p, i.e. p.addition(p.negate()) should be zero.
+    function negate(G1Point memory p) pure internal returns (G1Point memory) {
+        // The prime q in the base field F_q for G1
+        uint q = 21888242871839275222246405745257275088696311157297823662689037894645226208583;
+        if (p.X == 0 && p.Y == 0)
+            return G1Point(0, 0);
+        return G1Point(p.X, q - (p.Y % q));
+    }
+    /// @return the sum of two points of G1
+    function addition(G1Point memory p1, G1Point memory p2) internal returns (G1Point memory r) {
+        uint[4] memory input;
+        input[0] = p1.X;
+        input[1] = p1.Y;
+        input[2] = p2.X;
+        input[3] = p2.Y;
+        bool success;
+        assembly {
+            success := call(sub(gas, 2000), 6, 0, input, 0xc0, r, 0x60)
+            // Use "invalid" to make gas estimation work
+            switch success case 0 { invalid() }
+        }
+        require(success);
+    }
+    /// @return the sum of two points of G2
+    function addition(G2Point memory p1, G2Point memory p2) internal returns (G2Point memory r) {
+        (r.X[1], r.X[0], r.Y[1], r.Y[0]) = BN256G2.ECTwistAdd(p1.X[1],p1.X[0],p1.Y[1],p1.Y[0],p2.X[1],p2.X[0],p2.Y[1],p2.Y[0]);
+    }
+    /// @return the product of a point on G1 and a scalar, i.e.
+    /// p == p.scalar_mul(1) and p.addition(p) == p.scalar_mul(2) for all points p.
+    function scalar_mul(G1Point memory p, uint s) internal returns (G1Point memory r) {
+        uint[3] memory input;
+        input[0] = p.X;
+        input[1] = p.Y;
+        input[2] = s;
+        bool success;
+        assembly {
+            success := call(sub(gas, 2000), 7, 0, input, 0x80, r, 0x60)
+            // Use "invalid" to make gas estimation work
+            switch success case 0 { invalid() }
+        }
+        require (success);
+    }
+    /// @return the result of computing the pairing check
+    /// e(p1[0], p2[0]) *  .... * e(p1[n], p2[n]) == 1
+    /// For example pairing([P1(), P1().negate()], [P2(), P2()]) should
+    /// return true.
+    function pairing(G1Point[] memory p1, G2Point[] memory p2) internal returns (bool) {
+        require(p1.length == p2.length);
+        uint elements = p1.length;
+        uint inputSize = elements * 6;
+        uint[] memory input = new uint[](inputSize);
+        for (uint i = 0; i < elements; i++)
+        {
+            input[i * 6 + 0] = p1[i].X;
+            input[i * 6 + 1] = p1[i].Y;
+            input[i * 6 + 2] = p2[i].X[0];
+            input[i * 6 + 3] = p2[i].X[1];
+            input[i * 6 + 4] = p2[i].Y[0];
+            input[i * 6 + 5] = p2[i].Y[1];
+        }
+        uint[1] memory out;
+        bool success;
+        assembly {
+            success := call(sub(gas, 2000), 8, 0, add(input, 0x20), mul(inputSize, 0x20), out, 0x20)
+            // Use "invalid" to make gas estimation work
+            switch success case 0 { invalid() }
+        }
+        require(success);
+        return out[0] != 0;
+    }
+    /// Convenience method for a pairing check for two pairs.
+    function pairingProd2(G1Point memory a1, G2Point memory a2, G1Point memory b1, G2Point memory b2) internal returns (bool) {
+        G1Point[] memory p1 = new G1Point[](2);
+        G2Point[] memory p2 = new G2Point[](2);
+        p1[0] = a1;
+        p1[1] = b1;
+        p2[0] = a2;
+        p2[1] = b2;
+        return pairing(p1, p2);
+    }
+    /// Convenience method for a pairing check for three pairs.
+    function pairingProd3(
+            G1Point memory a1, G2Point memory a2,
+            G1Point memory b1, G2Point memory b2,
+            G1Point memory c1, G2Point memory c2
+    ) internal returns (bool) {
+        G1Point[] memory p1 = new G1Point[](3);
+        G2Point[] memory p2 = new G2Point[](3);
+        p1[0] = a1;
+        p1[1] = b1;
+        p1[2] = c1;
+        p2[0] = a2;
+        p2[1] = b2;
+        p2[2] = c2;
+        return pairing(p1, p2);
+    }
+    /// Convenience method for a pairing check for four pairs.
+    function pairingProd4(
+            G1Point memory a1, G2Point memory a2,
+            G1Point memory b1, G2Point memory b2,
+            G1Point memory c1, G2Point memory c2,
+            G1Point memory d1, G2Point memory d2
+    ) internal returns (bool) {
+        G1Point[] memory p1 = new G1Point[](4);
+        G2Point[] memory p2 = new G2Point[](4);
+        p1[0] = a1;
+        p1[1] = b1;
+        p1[2] = c1;
+        p1[3] = d1;
+        p2[0] = a2;
+        p2[1] = b2;
+        p2[2] = c2;
+        p2[3] = d2;
+        return pairing(p1, p2);
+    }
+}
+"#;
+
 pub const SOLIDITY_PAIRING_LIB : &str = r#"// This file is MIT Licensed.
 //
 // Copyright 2017 Christian Reitwiessner
 // Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 // The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
 pragma solidity ^0.5.0;
 library Pairing {
     struct G1Point {

--- a/zokrates_core/src/proof_system/mod.rs
+++ b/zokrates_core/src/proof_system/mod.rs
@@ -23,5 +23,5 @@ pub trait ProofSystem {
         proof_path: &str,
     ) -> bool;
 
-    fn export_solidity_verifier(&self, reader: BufReader<File>) -> String;
+    fn export_solidity_verifier(&self, reader: BufReader<File>, abiv2: &bool) -> String;
 }


### PR DESCRIPTION
-adds abiv2 flag to export-verifier command -> will export contracts on v1 or v2 (default v1)
-normalizes format of proof.json so all schemes have a matching one
-removes testing functionality from print-proof command