### PR TITLE
Put resolvers behind feature in zokrates_cli

### DIFF
--- a/zokrates_cli/Cargo.toml
+++ b/zokrates_cli/Cargo.toml
@@ -6,9 +6,11 @@ repository = "https://github.com/JacobEberhardt/ZoKrates.git"
 edition = "2018"
 
 [features]
-default = []
+default = ["fs", "github"]
 libsnark = ["zokrates_core/libsnark"]
 wasm = ["zokrates_core/wasm"]
+github = ["zokrates_github_resolver"]
+fs = ["zokrates_fs_resolver"]
 
 [dependencies]
 clap = "2.26.2"
@@ -16,8 +18,8 @@ bincode = "0.8.0"
 regex = "0.2"
 zokrates_field = { version = "0.3", path = "../zokrates_field" }
 zokrates_core = { version = "0.3", path = "../zokrates_core" }
-zokrates_fs_resolver = { version = "0.4", path = "../zokrates_fs_resolver"}
-zokrates_github_resolver = { version = "0.1", path = "../zokrates_github_resolver"}
+zokrates_fs_resolver = { version = "0.4", path = "../zokrates_fs_resolver", optional = true}
+zokrates_github_resolver = { version = "0.1", path = "../zokrates_github_resolver", optional = true}
 serde_json = "1.0"
 
 [dev-dependencies]

--- a/zokrates_cli/Cargo.toml
+++ b/zokrates_cli/Cargo.toml
@@ -6,11 +6,10 @@ repository = "https://github.com/JacobEberhardt/ZoKrates.git"
 edition = "2018"
 
 [features]
-default = ["fs", "github"]
+default = ["github"]
 libsnark = ["zokrates_core/libsnark"]
 wasm = ["zokrates_core/wasm"]
 github = ["zokrates_github_resolver"]
-fs = ["zokrates_fs_resolver"]
 
 [dependencies]
 clap = "2.26.2"
@@ -18,7 +17,7 @@ bincode = "0.8.0"
 regex = "0.2"
 zokrates_field = { version = "0.3", path = "../zokrates_field" }
 zokrates_core = { version = "0.3", path = "../zokrates_core" }
-zokrates_fs_resolver = { version = "0.4", path = "../zokrates_fs_resolver", optional = true}
+zokrates_fs_resolver = { version = "0.4", path = "../zokrates_fs_resolver"}
 zokrates_github_resolver = { version = "0.1", path = "../zokrates_github_resolver", optional = true}
 serde_json = "1.0"
 

--- a/zokrates_cli/src/bin.rs
+++ b/zokrates_cli/src/bin.rs
@@ -16,7 +16,9 @@ use zokrates_core::compile::compile;
 use zokrates_core::ir;
 use zokrates_core::proof_system::*;
 use zokrates_field::field::{Field, FieldPrime};
+#[cfg(feature = "fs")]
 use zokrates_fs_resolver::resolve as fs_resolve;
+#[cfg(feature = "github")]
 use zokrates_github_resolver::{is_github_import, resolve as github_resolve};
 
 fn main() {
@@ -26,15 +28,18 @@ fn main() {
     })
 }
 
-fn resolve_fs_or_github(
+fn resolve(
     location: &Option<String>,
     source: &String,
 ) -> Result<(BufReader<File>, String, String), io::Error> {
-    if is_github_import(source) {
-        github_resolve(location, source)
-    } else {
-        fs_resolve(location, source)
+    #[cfg(feature = "github")]
+    {
+        if is_github_import(source) {
+            return github_resolve(location, source);
+        };
     }
+    #[cfg(feature = "fs")]
+    fs_resolve(location, source)
 }
 
 fn cli() -> Result<(), String> {
@@ -269,7 +274,7 @@ fn cli() -> Result<(), String> {
             let mut reader = BufReader::new(file);
 
             let program_flattened: ir::Prog<FieldPrime> =
-                compile(&mut reader, Some(location), Some(resolve_fs_or_github))
+                compile(&mut reader, Some(location), Some(resolve))
                     .map_err(|e| format!("Compilation failed:\n\n {}", e))?;
 
             // number of constraints the flattened program will translate to.

--- a/zokrates_cli/src/bin.rs
+++ b/zokrates_cli/src/bin.rs
@@ -16,7 +16,6 @@ use zokrates_core::compile::compile;
 use zokrates_core::ir;
 use zokrates_core::proof_system::*;
 use zokrates_field::field::{Field, FieldPrime};
-#[cfg(feature = "fs")]
 use zokrates_fs_resolver::resolve as fs_resolve;
 #[cfg(feature = "github")]
 use zokrates_github_resolver::{is_github_import, resolve as github_resolve};
@@ -38,7 +37,6 @@ fn resolve(
             return github_resolve(location, source);
         };
     }
-    #[cfg(feature = "fs")]
     fs_resolve(location, source)
 }
 
@@ -576,7 +574,7 @@ mod tests {
                 .unwrap();
 
             let _: ir::Prog<FieldPrime> =
-                compile(&mut reader, Some(location), Some(resolve_fs_or_github)).unwrap();
+                compile(&mut reader, Some(location), Some(resolve)).unwrap();
         }
     }
 
@@ -603,7 +601,7 @@ mod tests {
             let mut reader = BufReader::new(file);
 
             let program_flattened: ir::Prog<FieldPrime> =
-                compile(&mut reader, Some(location), Some(resolve_fs_or_github)).unwrap();
+                compile(&mut reader, Some(location), Some(resolve)).unwrap();
 
             let _ = program_flattened
                 .execute(&vec![FieldPrime::from(0)])
@@ -635,7 +633,7 @@ mod tests {
             let mut reader = BufReader::new(file);
 
             let program_flattened: ir::Prog<FieldPrime> =
-                compile(&mut reader, Some(location), Some(resolve_fs_or_github)).unwrap();
+                compile(&mut reader, Some(location), Some(resolve)).unwrap();
 
             let _ = program_flattened
                 .execute(&vec![FieldPrime::from(0)])


### PR DESCRIPTION
Make it possible to build `zokrates_cli` with fs resolver only.