### PR TITLE
More robust integration testing + docs

### DIFF
--- a/zokrates_book/src/reference/Testing.md
+++ b/zokrates_book/src/reference/Testing.md
@@ -10,14 +10,17 @@ cargo test --release
 ## Integration tests
 
 Integration tests are excluded from `cargo test` by default.
-Before running integration tests 
-    1. Make sure your `$ZOKRATES_HOME` is set correctly 
-    2. You have [solcjs](https://github.com/ethereum/solc-js) installed and in your `$PATH`.
-    This can conventiely done through `npm` by running 
+
+Before running integration tests:
+1. Make sure your `$ZOKRATES_HOME` is set correctly 
+2. You have [solc](https://github.com/ethereum/solc-js) installed and in your `$PATH`.
+
+    Solc can conveniently be installed through `npm` by running 
     ```
     npm install -g solc
     ```
-Integration tests can then be included in a test run with the following command:
+
+Integration tests can then be run with the following command:
 
 ```
 cargo test --release -- --ignored

--- a/zokrates_book/src/reference/Testing.md
+++ b/zokrates_book/src/reference/Testing.md
@@ -1,0 +1,28 @@
+# Testing
+
+## Unit tests
+Unit tests can be executed with the following command:
+
+```
+cargo test --release
+```
+
+## Integration tests
+
+Integration tests are excluded from `cargo test` by default.
+Before running integration tests 
+    1. Make sure your `$ZOKRATES_HOME` is set correctly 
+    2. You have [solcjs](https://github.com/ethereum/solc-js) installed and in your `$PATH`.
+    This can conventiely done through `npm` by running 
+    ```
+    npm install -g solc
+    ```
+Integration tests can then be included in a test run with the following command:
+
+```
+cargo test --release -- --ignored
+```
+If you want to run unit and integrations tests together, run the following command:
+```
+cargo test --release & cargo test --release -- --ignored
+```

--- a/zokrates_cli/tests/integration.rs
+++ b/zokrates_cli/tests/integration.rs
@@ -17,23 +17,17 @@ mod integration {
     #[ignore]
     fn test_compile_and_witness_dir() {
         let dir = Path::new("./tests/code");
-        if dir.is_dir() {
-            for entry in fs::read_dir(dir).unwrap() {
-                let entry = entry.unwrap();
-                let path = entry.path();
-                if path.extension().unwrap() == "witness" {
-                    let program_name =
-                        Path::new(Path::new(path.file_stem().unwrap()).file_stem().unwrap());
-                    let prog = dir.join(program_name).with_extension("code");
-                    let witness = dir.join(program_name).with_extension("expected.witness");
-                    let args = dir.join(program_name).with_extension("arguments.json");
-                    test_compile_and_witness(
-                        program_name.to_str().unwrap(),
-                        &prog,
-                        &args,
-                        &witness,
-                    );
-                }
+        assert!(dir.is_dir());
+        for entry in fs::read_dir(dir).unwrap() {
+            let entry = entry.unwrap();
+            let path = entry.path();
+            if path.extension().unwrap() == "witness" {
+                let program_name =
+                    Path::new(Path::new(path.file_stem().unwrap()).file_stem().unwrap());
+                let prog = dir.join(program_name).with_extension("code");
+                let witness = dir.join(program_name).with_extension("expected.witness");
+                let args = dir.join(program_name).with_extension("arguments.json");
+                test_compile_and_witness(program_name.to_str().unwrap(), &prog, &args, &witness);
             }
         }
     }
@@ -76,12 +70,6 @@ mod integration {
             flattened_path.to_str().unwrap(),
             "--light",
         ];
-
-        if program_name.contains("sha") {
-            // we don't want to test libsnark integrations if libsnark is not available
-            #[cfg(not(feature = "libsnark"))]
-            return;
-        }
 
         // compile
         assert_cli::Assert::command(&compile).succeeds().unwrap();
@@ -219,7 +207,8 @@ mod integration {
                 .succeeds()
                 .stdout()
                 .doesnt_contain(r#""severity":"error""#)
-                .unwrap();
+                .execute()
+                .expect("solcjs not installed or not in scope.");
 
             // GENERATE-PROOF
             assert_cli::Assert::command(&[


### PR DESCRIPTION
Made integration tests more robust and improved documentation.
- Improved error message in case missing solc installation
- More robust testing condition
- Documentation on how to setup and run unit and integration tests
- Removed obsolete libsnark special case handling