### PR TITLE
Improved documentation on backends and their build

### DIFF
--- a/zokrates_book/src/reference/proving_schemes.md
+++ b/zokrates_book/src/reference/proving_schemes.md
@@ -17,6 +17,16 @@ When not using the default, the CLI flag has to be provided for the following co
 - `export-verifier`
 - `generate-proof`
 
+## Supporting backends
+
+As shown in the table above, the `PGHR13` and `GM17`schemes require [libsnark](https://github.com/scipr-lab/libsnark) as a backend, while G16 uses [bellman](https://github.com/zkcrypto/bellman), which is included as the default backend.
+
+To include libsnark in the build, compile ZoKrates from [source](https://github.com/ZoKrates/ZoKrates/) with the `libsnark` feature:
+```bash
+cargo +nightly -Z package-features build --release --package zokrates_cli --features="libsnark"
+```
+ Note, that this is only tested for Linux. If you are on another OS, consider using our Docker container, which includes a libsnark installation.
+
 ## G16 malleability
 
 When using G16, developers should pay attention to the fact that an attacker seeing a valid proof can very easily generate a different but still valid proof. Therefore, depending on the use case, making sure on chain that the same proof cannot be submitted twice may *not* be enough to guarantee that attackers cannot replay proofs. Mechanisms to solve this issue include:

--- a/zokrates_book/src/sha256example.md
+++ b/zokrates_book/src/sha256example.md
@@ -106,7 +106,7 @@ Finally, Peggy can run the command to construct the proof:
 
 As the inputs were declared as private in the program, they do not appear in the proof thanks to the zero knowledge property of the protocol.
 
-ZoKrates creates a file, `proof.json`,  consisting of the eight variables that make up the zkSNARKs proof. The `verifyTx` function in the smart contract deployed by Victor accepts these eight values, along with an array of public inputs. The array of public inputs consists of:
+ZoKrates creates a file, `proof.json`,  consisting of the three elliptic curve points that make up the zkSNARKs proof. The `verifyTx` function in the smart contract deployed by Victor accepts these three values, along with an array of public inputs. The array of public inputs consists of:
 
 * any public inputs to the main function, declared without the `private` keyword
 * the return values of the ZoKrates function


### PR DESCRIPTION
Adds information on how when and how to build ZoKrates with libsnark.
Also closes #361 