### PR TITLE
Simplify spreads of inline arrays

### DIFF
--- a/zokrates_core/src/semantics.rs
+++ b/zokrates_core/src/semantics.rs
@@ -657,18 +657,24 @@ impl<'ast> Checker<'ast> {
 
                 let checked_expression = self.check_expression(s.value.expression)?;
                 match checked_expression {
-                    TypedExpression::FieldElementArray(e) => {
-                        let size = e.size();
-                        Ok((0..size)
-                            .map(|i| {
-                                FieldElementExpression::Select(
-                                    box e.clone(),
-                                    box FieldElementExpression::Number(T::from(i)),
-                                )
-                                .into()
-                            })
-                            .collect())
-                    }
+                    TypedExpression::FieldElementArray(e) => match e {
+                        // if we're doing a spread over an inline array, we return the inside of the array: ...[x, y, z] == x, y, z
+                        FieldElementArrayExpression::Value(_, v) => {
+                            Ok(v.into_iter().map(|e| e.into()).collect())
+                        }
+                        e => {
+                            let size = e.size();
+                            Ok((0..size)
+                                .map(|i| {
+                                    FieldElementExpression::Select(
+                                        box e.clone(),
+                                        box FieldElementExpression::Number(T::from(i)),
+                                    )
+                                    .into()
+                                })
+                                .collect())
+                        }
+                    },
                     e => Err(Error {
                         pos: Some(pos),
 


### PR DESCRIPTION
There is a memory blowup in the way we desugar spreads:

```
size(...a) = n * size(a)
```
because 
```
...a = a[0], ..., a[n] <-- we have to copy a n times when we desugar
```
but if a is an inline value like [0, 1, 2]
```
size(a) = O(n)
```

With this change, we desugar `...a` when a is an inline array to the content of the array:
```
...[x, y, z] = x, y, z
```

The program
```
def main() -> ():
	field[3] a = [...[...[...[0, 0, 0]]]]
	return
```
Before this change:
```
def main() -> ():
	field[3] _a_0
	_a_0 = [[[[0, 0, 0][0], [0, 0, 0][1], [0, 0, 0][2]][0], [[0, 0, 0][0], [0, 0, 0][1], [0, 0, 0][2]][1], [[0, 0, 0][0], [0, 0, 0][1], [0, 0, 0][2]][2]][0], [[[0, 0, 0][0], [0, 0, 0][1], [0, 0, 0][2]][0], [[0, 0, 0][0], [0, 0, 0][1], [0, 0, 0][2]][1], [[0, 0, 0][0], [0, 0, 0][1], [0, 0, 0][2]][2]][1], [[[0, 0, 0][0], [0, 0, 0][1], [0, 0, 0][2]][0], [[0, 0, 0][0], [0, 0, 0][1], [0, 0, 0][2]][1], [[0, 0, 0][0], [0, 0, 0][1], [0, 0, 0][2]][2]][2]]
	return 
```
After this change:
```
def main() -> ():
	field[3] _a_0
	_a_0 = [0, 0, 0]
	return 
```

Replaces #462 which ends up being too complex of an approach.