### PR TITLE
Explicitly specify Solidity version for SOLIDITY_G2_ADDITION_LIB

### DIFF
--- a/zokrates_core/src/proof_system/bn128/utils/solidity.rs
+++ b/zokrates_core/src/proof_system/bn128/utils/solidity.rs
@@ -1,4 +1,5 @@
 pub const SOLIDITY_G2_ADDITION_LIB: &str = r#"// This file is LGPL3 Licensed
+pragma solidity ^0.5.0;
 
 /**
  * @title Elliptic curve operations on twist points for alt_bn128


### PR DESCRIPTION
This makes the code safer if it will be used separately from the other code