### PR TITLE
Patch array access unrolling

### DIFF
--- a/zokrates_core/src/static_analysis/unroll.rs
+++ b/zokrates_core/src/static_analysis/unroll.rs
@@ -208,6 +208,12 @@ impl<'ast, T: Field> Folder<'ast, T> for Unroller<'ast> {
                     }
                 };
 
+                let base = self.fold_expression(base);
+                let indices = indices
+                    .into_iter()
+                    .map(|i| self.fold_field_expression(i))
+                    .collect();
+
                 let mut range_checks = HashSet::new();
                 let e = Self::choose_many(base, indices, expr, &mut range_checks);
 


### PR DESCRIPTION
When unrolling `array[index]`, we need to use the latest sea variables for both `array` and `index`