### PR TITLE
fix cargo features in zokrates_abi

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ witness
 
 .DS_Store
 .idea
+.vscode

--- a/zokrates_abi/Cargo.toml
+++ b/zokrates_abi/Cargo.toml
@@ -4,9 +4,14 @@ version = "0.1.0"
 authors = ["Thibaut Schaeffer <thibaut@schaeff.fr>"]
 edition = "2018"
 
+[features]
+default = ["multicore"]
+multicore = ["zokrates_core/multicore"]
+wasm = ["zokrates_core/wasm"]
+
 [dependencies]
 zokrates_field = { version = "0.3", path = "../zokrates_field" }
-zokrates_core = { version = "0.4", path = "../zokrates_core" }
+zokrates_core = { version = "0.4", path = "../zokrates_core", default-features = false }
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"


### PR DESCRIPTION
**zokrates_abi** crate depends on **zokrates_core** which has "multicore" feature enabled by default. Multicore feature is not yet compatible with wasm target. This will remove the issue with targets not compatible with default "multicore" feature.