### PR TITLE
This fixes macos installation issues as per: https://github.com/scipr…

### DIFF
--- a/zokrates_core/build.rs
+++ b/zokrates_core/build.rs
@@ -38,6 +38,7 @@ fn main() {
         // build libsnark
 
         let libsnark = cmake::Config::new(libsnark_source_path)
+            .define("WITH_SUPERCOP", "OFF")
             .define("WITH_PROCPS", "OFF")
             .define("CURVE", "ALT_BN128")
             .define("USE_PT_COMPRESSION", "OFF")


### PR DESCRIPTION
…-lab/libsnark/issues/86

Please try this out on other targets to ensure that the omission of SuperCop doesn't break anything 