### PR TITLE
Extend assertions to any boolean

### DIFF
--- a/zokrates_cli/examples/conditions.zok
+++ b/zokrates_cli/examples/conditions.zok
@@ -1,3 +1,11 @@
+struct Foo {
+	field a
+}
+
+struct Bar {
+	Foo foo
+}
+
 def isEqual(field a, field b) -> (bool):
 	return a == b
 
@@ -6,4 +14,6 @@ def main(field a) -> (field):
   2 * b == a * 12 + 60
   field c = 7 * (b + a)
   isEqual(c, 7 * b + 7 * a)
+  field k = if [1, 2] == [3, 4] then 1 else 3 fi
+  Bar { foo : Foo { a: 42 }} == Bar { foo : Foo { a: 42 }}
   return b + c

--- a/zokrates_cli/examples/conditions.zok
+++ b/zokrates_cli/examples/conditions.zok
@@ -1,6 +1,9 @@
+def isEqual(field a, field b) -> (bool):
+	return a == b
+
 def main(field a) -> (field):
   field b = (a + 5) * 6
   2 * b == a * 12 + 60
   field c = 7 * (b + a)
-  c == 7 * b + 7 * a
+  isEqual(c, 7 * b + 7 * a)
   return b + c

--- a/zokrates_cli/examples/conditions.zok
+++ b/zokrates_cli/examples/conditions.zok
@@ -3,7 +3,7 @@ struct Foo {
 }
 
 struct Bar {
-	Foo foo
+	Foo[1] foo
 }
 
 def isEqual(field a, field b) -> (bool):
@@ -15,5 +15,5 @@ def main(field a) -> (field):
   field c = 7 * (b + a)
   isEqual(c, 7 * b + 7 * a)
   field k = if [1, 2] == [3, 4] then 1 else 3 fi
-  Bar { foo : Foo { a: 42 }} == Bar { foo : Foo { a: 42 }}
+  [Bar { foo : [Foo { a: 42 }]}] == [Bar { foo : [Foo { a: 42 }]}]
   return b + c

--- a/zokrates_cli/examples/waldo.zok
+++ b/zokrates_cli/examples/waldo.zok
@@ -4,11 +4,7 @@
 
 def isWaldo(field a, field p, field q) -> (field):
   // make sure that p and q are both non zero
-  // we can't check inequalities, so let's create binary
-  // variables
-  field p1 = if p == 1 then 0 else 1 fi // "p != 1"
-  field q1 = if q == 1 then 0 else 1 fi // "q != 1"
-  q1 * p1 == 1 // "p1 and q1"
+  !(p == 1) && !(q == 1)
 
   // we know how to factor a
   a == p * q
@@ -16,10 +12,6 @@ def isWaldo(field a, field p, field q) -> (field):
   return 1
 
 // define all
-def main(field a0, field a1, field a2, field a3, private field index, private field p, private field q) -> (field):
+def main(field[4] a, private field index, private field p, private field q) -> (field):
   // prover provides the index of Waldo
-  field waldo = if index == 0 then a0 else 0 fi
-  waldo = waldo + if index == 1 then a1 else 0 fi
-  waldo = waldo + if index == 2 then a2 else 0 fi
-  waldo = waldo + if index == 3 then a3 else 0 fi
-  return isWaldo(waldo, p, q)
+  return isWaldo(a[index], p, q)

--- a/zokrates_core/src/absy/from_ast.rs
+++ b/zokrates_core/src/absy/from_ast.rs
@@ -250,23 +250,8 @@ impl<'ast, T: Field> From<pest::AssertionStatement<'ast>> for absy::StatementNod
     fn from(statement: pest::AssertionStatement<'ast>) -> absy::StatementNode<T> {
         use absy::NodeValue;
 
-        match statement.expression {
-            pest::Expression::Binary(e) => match e.op {
-                pest::BinaryOperator::Eq => absy::Statement::Condition(
-                    absy::ExpressionNode::from(*e.left),
-                    absy::ExpressionNode::from(*e.right),
-                ),
-                _ => unimplemented!(
-                    "Assertion statements should be an equality check, found {}",
-                    statement.span.as_str()
-                ),
-            },
-            _ => unimplemented!(
-                "Assertion statements should be an equality check, found {}",
-                statement.span.as_str()
-            ),
-        }
-        .span(statement.span)
+        absy::Statement::Assertion(absy::ExpressionNode::from(statement.expression))
+            .span(statement.span)
     }
 }
 

--- a/zokrates_core/src/absy/mod.rs
+++ b/zokrates_core/src/absy/mod.rs
@@ -281,7 +281,7 @@ pub enum Statement<'ast, T: Field> {
     Return(ExpressionListNode<'ast, T>),
     Declaration(VariableNode<'ast>),
     Definition(AssigneeNode<'ast, T>, ExpressionNode<'ast, T>),
-    Condition(ExpressionNode<'ast, T>, ExpressionNode<'ast, T>),
+    Assertion(ExpressionNode<'ast, T>),
     For(VariableNode<'ast>, T, T, Vec<StatementNode<'ast, T>>),
     MultipleDefinition(Vec<AssigneeNode<'ast, T>>, ExpressionNode<'ast, T>),
 }
@@ -294,7 +294,7 @@ impl<'ast, T: Field> fmt::Display for Statement<'ast, T> {
             Statement::Return(ref expr) => write!(f, "return {}", expr),
             Statement::Declaration(ref var) => write!(f, "{}", var),
             Statement::Definition(ref lhs, ref rhs) => write!(f, "{} = {}", lhs, rhs),
-            Statement::Condition(ref lhs, ref rhs) => write!(f, "{} == {}", lhs, rhs),
+            Statement::Assertion(ref e) => write!(f, "{}", e),
             Statement::For(ref var, ref start, ref stop, ref list) => {
                 write!(f, "for {} in {}..{} do\n", var, start, stop)?;
                 for l in list {
@@ -323,7 +323,7 @@ impl<'ast, T: Field> fmt::Debug for Statement<'ast, T> {
             Statement::Definition(ref lhs, ref rhs) => {
                 write!(f, "Definition({:?}, {:?})", lhs, rhs)
             }
-            Statement::Condition(ref lhs, ref rhs) => write!(f, "Condition({:?}, {:?})", lhs, rhs),
+            Statement::Assertion(ref e) => write!(f, "Assertion({:?})", e),
             Statement::For(ref var, ref start, ref stop, ref list) => {
                 write!(f, "for {:?} in {:?}..{:?} do\n", var, start, stop)?;
                 for l in list {

--- a/zokrates_core/src/flat_absy/mod.rs
+++ b/zokrates_core/src/flat_absy/mod.rs
@@ -252,7 +252,7 @@ impl<T: Field> FlatExpression<T> {
 impl<T: Field> fmt::Display for FlatExpression<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
-            FlatExpression::Number(ref i) => write!(f, "{}", i),
+            FlatExpression::Number(ref i) => write!(f, "{}", i.to_compact_dec_string()),
             FlatExpression::Identifier(ref var) => write!(f, "{}", var),
             FlatExpression::Add(ref lhs, ref rhs) => write!(f, "({} + {})", lhs, rhs),
             FlatExpression::Sub(ref lhs, ref rhs) => write!(f, "({} - {})", lhs, rhs),

--- a/zokrates_core/src/flat_absy/mod.rs
+++ b/zokrates_core/src/flat_absy/mod.rs
@@ -240,9 +240,9 @@ impl<T: Field> FlatExpression<T> {
                 x.is_linear() && y.is_linear()
             }
             FlatExpression::Mult(ref x, ref y) => match (x.clone(), y.clone()) {
-                (box FlatExpression::Number(_), box FlatExpression::Number(_))
-                | (box FlatExpression::Number(_), box FlatExpression::Identifier(_))
-                | (box FlatExpression::Identifier(_), box FlatExpression::Number(_)) => true,
+                (box FlatExpression::Number(_), box e) | (box e, box FlatExpression::Number(_)) => {
+                    e.is_linear()
+                }
                 _ => false,
             },
         }

--- a/zokrates_core/src/flatten/mod.rs
+++ b/zokrates_core/src/flatten/mod.rs
@@ -24,6 +24,15 @@ pub struct Flattener<'ast, T: Field> {
     flat_cache: HashMap<FunctionKey<'ast>, FlatFunction<T>>,
 }
 
+/// Express an equality check for arrays of any type with equality checks for basic types and field element arrays
+///
+/// # Arguments
+///
+/// * `lhs` - The left array
+/// * `rhs` - The right array
+///
+/// # Returns
+/// * A boolean expression which is true iff the arrays are equal
 fn reduce_array_eq<'ast, T: Field>(
     lhs: ArrayExpression<'ast, T>,
     rhs: ArrayExpression<'ast, T>,
@@ -86,6 +95,15 @@ fn reduce_array_eq<'ast, T: Field>(
     }
 }
 
+/// Express an equality check for structs of any type with equality checks for basic types and field element arrays
+///
+/// # Arguments
+///
+/// * `lhs` - The left struct
+/// * `rhs` - The right struct
+///
+/// # Returns
+/// * A boolean expression which is true iff the structs are equal
 fn reduce_struct_eq<'ast, T: Field>(
     lhs: StructExpression<'ast, T>,
     rhs: StructExpression<'ast, T>,

--- a/zokrates_core/src/flatten/mod.rs
+++ b/zokrates_core/src/flatten/mod.rs
@@ -485,7 +485,6 @@ impl<'ast, T: Field> Flattener<'ast, T> {
         array: ArrayExpression<'ast, T>,
         index: FieldElementExpression<'ast, T>,
     ) -> Vec<FlatExpression<T>> {
-
         let size = array.size();
         let ty = array.inner_type().clone();
 
@@ -1057,14 +1056,19 @@ impl<'ast, T: Field> Flattener<'ast, T> {
 
                                 let x = FlatExpression::Sub(box lhs, box rhs);
 
-                                statements_flattened.push(FlatStatement::Directive(FlatDirective::new(
-                                    vec![name_y, name_m],
-                                    Solver::ConditionEq,
-                                    vec![x.clone()],
-                                )));
+                                statements_flattened.push(FlatStatement::Directive(
+                                    FlatDirective::new(
+                                        vec![name_y, name_m],
+                                        Solver::ConditionEq,
+                                        vec![x.clone()],
+                                    ),
+                                ));
                                 statements_flattened.push(FlatStatement::Condition(
                                     FlatExpression::Identifier(name_y),
-                                    FlatExpression::Mult(box x.clone(), box FlatExpression::Identifier(name_m)),
+                                    FlatExpression::Mult(
+                                        box x.clone(),
+                                        box FlatExpression::Identifier(name_m),
+                                    ),
                                 ));
 
                                 let res = FlatExpression::Sub(
@@ -1078,15 +1082,25 @@ impl<'ast, T: Field> Flattener<'ast, T> {
                                 ));
 
                                 res
-                            }).collect::<Vec<_>>();
-                        let condition_sum = conditions.into_iter().fold(FlatExpression::Number(T::from(0)), |acc, e| {
-                            self.linearize(statements_flattened, FlatExpression::Add(box acc, box e))
-                        });
+                            })
+                            .collect::<Vec<_>>();
+                        let condition_sum = conditions.into_iter().fold(
+                            FlatExpression::Number(T::from(0)),
+                            |acc, e| {
+                                self.linearize(
+                                    statements_flattened,
+                                    FlatExpression::Add(box acc, box e),
+                                )
+                            },
+                        );
 
                         let name_y = self.use_sym();
                         let name_m = self.use_sym();
 
-                        let x = FlatExpression::Sub(box condition_sum, box FlatExpression::Number(T::from(size)));
+                        let x = FlatExpression::Sub(
+                            box condition_sum,
+                            box FlatExpression::Number(T::from(size)),
+                        );
 
                         statements_flattened.push(FlatStatement::Directive(FlatDirective::new(
                             vec![name_y, name_m],
@@ -1095,7 +1109,10 @@ impl<'ast, T: Field> Flattener<'ast, T> {
                         )));
                         statements_flattened.push(FlatStatement::Condition(
                             FlatExpression::Identifier(name_y),
-                            FlatExpression::Mult(box x.clone(), box FlatExpression::Identifier(name_m)),
+                            FlatExpression::Mult(
+                                box x.clone(),
+                                box FlatExpression::Identifier(name_m),
+                            ),
                         ));
 
                         let res = FlatExpression::Sub(
@@ -1116,7 +1133,7 @@ impl<'ast, T: Field> Flattener<'ast, T> {
                         reduce_array_eq(lhs, rhs),
                     ),
                 }
-            },
+            }
             BooleanExpression::StructEq(box lhs, box rhs) => self.flatten_boolean_expression(
                 symbols,
                 statements_flattened,

--- a/zokrates_core/src/ir/from_flat.rs
+++ b/zokrates_core/src/ir/from_flat.rs
@@ -84,14 +84,8 @@ impl<T: Field> From<FlatExpression<T>> for LinComb<T> {
             FlatExpression::Identifier(id) => LinComb::from(id),
             FlatExpression::Add(box e1, box e2) => LinComb::from(e1) + LinComb::from(e2),
             FlatExpression::Sub(box e1, box e2) => LinComb::from(e1) - LinComb::from(e2),
-            FlatExpression::Mult(
-                box FlatExpression::Number(n1),
-                box FlatExpression::Identifier(v1),
-            )
-            | FlatExpression::Mult(
-                box FlatExpression::Identifier(v1),
-                box FlatExpression::Number(n1),
-            ) => LinComb::summand(n1, v1),
+            FlatExpression::Mult(box FlatExpression::Number(n), box e)
+            | FlatExpression::Mult(box e, box FlatExpression::Number(n)) => LinComb::from(e) * &n,
             e => unimplemented!("{}", e),
         }
     }

--- a/zokrates_core/src/semantics.rs
+++ b/zokrates_core/src/semantics.rs
@@ -814,27 +814,17 @@ impl<'ast> Checker<'ast> {
                 }
                 .map_err(|e| vec![e])
             }
-            Statement::Condition(lhs, rhs) => {
-                let checked_lhs = self
-                    .check_expression(lhs, module_id, &types)
-                    .map_err(|e| vec![e])?;
-                let checked_rhs = self
-                    .check_expression(rhs, module_id, &types)
+            Statement::Assertion(e) => {
+                let e = self
+                    .check_expression(e, module_id, &types)
                     .map_err(|e| vec![e])?;
 
-                if checked_lhs.get_type() == checked_rhs.get_type() {
-                    Ok(TypedStatement::Condition(checked_lhs, checked_rhs))
-                } else {
-                    Err(Error {
+                match e {
+                    TypedExpression::Boolean(e) => Ok(TypedStatement::Assertion(e)),
+                    e => Err(Error {
                         pos: Some(pos),
-                        message: format!(
-                            "Cannot compare {} of type {:?} to {} of type {:?}",
-                            checked_lhs,
-                            checked_lhs.get_type(),
-                            checked_rhs,
-                            checked_rhs.get_type(),
-                        ),
-                    })
+                        message: format!("Cannot assert {} of type {:?}", e, e.get_type(),),
+                    }),
                 }
                 .map_err(|e| vec![e])
             }

--- a/zokrates_core/src/semantics.rs
+++ b/zokrates_core/src/semantics.rs
@@ -1380,6 +1380,38 @@ impl<'ast> Checker<'ast> {
                     (TypedExpression::Boolean(e1), TypedExpression::Boolean(e2)) => {
                         Ok(BooleanExpression::BoolEq(box e1, box e2).into())
                     }
+                    (TypedExpression::Array(e1), TypedExpression::Array(e2)) => {
+                        if e1.get_type() == e2.get_type() {
+                            Ok(BooleanExpression::ArrayEq(box e1, box e2).into())
+                        } else {
+                            Err(Error {
+                                pos: Some(pos),
+                                message: format!(
+                                    "Cannot compare {} of type {} to {} of type {}",
+                                    e1,
+                                    e1.get_type(),
+                                    e2,
+                                    e2.get_type()
+                                ),
+                            })
+                        }
+                    }
+                    (TypedExpression::Struct(e1), TypedExpression::Struct(e2)) => {
+                        if e1.get_type() == e2.get_type() {
+                            Ok(BooleanExpression::StructEq(box e1, box e2).into())
+                        } else {
+                            Err(Error {
+                                pos: Some(pos),
+                                message: format!(
+                                    "Cannot compare {} of type {} to {} of type {}",
+                                    e1,
+                                    e1.get_type(),
+                                    e2,
+                                    e2.get_type()
+                                ),
+                            })
+                        }
+                    }
                     (e1, e2) => Err(Error {
                         pos: Some(pos),
                         message: format!(

--- a/zokrates_core/src/semantics.rs
+++ b/zokrates_core/src/semantics.rs
@@ -2802,9 +2802,12 @@ mod tests {
         // def bar():
         //   2 == foo()
         // should fail
-        let bar_statements: Vec<StatementNode<FieldPrime>> = vec![Statement::Condition(
-            Expression::FieldConstant(FieldPrime::from(2)).mock(),
-            Expression::FunctionCall("foo", vec![]).mock(),
+        let bar_statements: Vec<StatementNode<FieldPrime>> = vec![Statement::Assertion(
+            Expression::Eq(
+                box Expression::FieldConstant(FieldPrime::from(2)).mock(),
+                box Expression::FunctionCall("foo", vec![]).mock(),
+            )
+            .mock(),
         )
         .mock()];
 
@@ -2991,9 +2994,12 @@ mod tests {
         // def bar():
         //   1 == foo()
         // should fail
-        let bar_statements: Vec<StatementNode<FieldPrime>> = vec![Statement::Condition(
-            Expression::FieldConstant(FieldPrime::from(1)).mock(),
-            Expression::FunctionCall("foo", vec![]).mock(),
+        let bar_statements: Vec<StatementNode<FieldPrime>> = vec![Statement::Assertion(
+            Expression::Eq(
+                box Expression::FieldConstant(FieldPrime::from(1)).mock(),
+                box Expression::FunctionCall("foo", vec![]).mock(),
+            )
+            .mock(),
         )
         .mock()];
 

--- a/zokrates_core/src/static_analysis/constrain_inputs.rs
+++ b/zokrates_core/src/static_analysis/constrain_inputs.rs
@@ -50,9 +50,9 @@ impl<'ast, T: Field> InputConstrainer<'ast, T> {
     fn constrain_expression(&mut self, e: TypedExpression<'ast, T>) {
         match e {
             TypedExpression::FieldElement(_) => {}
-            TypedExpression::Boolean(b) => self.constraints.push(TypedStatement::Condition(
-                b.clone().into(),
-                BooleanExpression::And(box b.clone(), box b).into(),
+            TypedExpression::Boolean(b) => self.constraints.push(TypedStatement::assert_bool_eq(
+                b.clone(),
+                BooleanExpression::And(box b.clone(), box b),
             )),
             TypedExpression::Array(a) => {
                 for i in 0..a.size() {

--- a/zokrates_core/src/static_analysis/propagation.rs
+++ b/zokrates_core/src/static_analysis/propagation.rs
@@ -79,12 +79,9 @@ impl<'ast, T: Field> Folder<'ast, T> for Propagator<'ast, T> {
                 unreachable!("struct update should have been replaced with full struct redef")
             }
             // propagate lhs and rhs for conditions
-            TypedStatement::Condition(e1, e2) => {
+            TypedStatement::Assertion(e) => {
                 // could stop execution here if condition is known to fail
-                Some(TypedStatement::Condition(
-                    self.fold_expression(e1),
-                    self.fold_expression(e2),
-                ))
+                Some(TypedStatement::Assertion(self.fold_boolean_expression(e)))
             }
             // we unrolled for loops in the previous step
             TypedStatement::For(..) => {

--- a/zokrates_core/src/static_analysis/unroll.rs
+++ b/zokrates_core/src/static_analysis/unroll.rs
@@ -65,13 +65,10 @@ impl<'ast> Unroller<'ast> {
 
                     match head {
                         Access::Select(head) => {
-                            statements.insert(TypedStatement::assert_bool_eq(
-                                BooleanExpression::Lt(
-                                    box head.clone(),
-                                    box FieldElementExpression::Number(T::from(size)),
-                                ),
-                                BooleanExpression::Value(true),
-                            ));
+                            statements.insert(TypedStatement::Assertion(BooleanExpression::Lt(
+                                box head.clone(),
+                                box FieldElementExpression::Number(T::from(size)),
+                            )));
 
                             ArrayExpressionInner::Value(
                                 (0..size)

--- a/zokrates_core/src/static_analysis/unroll.rs
+++ b/zokrates_core/src/static_analysis/unroll.rs
@@ -970,14 +970,10 @@ mod tests {
             assert_eq!(
                 u.fold_statement(s),
                 vec![
-                    TypedStatement::Condition(
-                        BooleanExpression::Lt(
-                            box FieldElementExpression::Number(FieldPrime::from(1)),
-                            box FieldElementExpression::Number(FieldPrime::from(2))
-                        )
-                        .into(),
-                        BooleanExpression::Value(true).into()
-                    ),
+                    TypedStatement::Assertion(BooleanExpression::Lt(
+                        box FieldElementExpression::Number(FieldPrime::from(1)),
+                        box FieldElementExpression::Number(FieldPrime::from(2))
+                    )),
                     TypedStatement::Definition(
                         TypedAssignee::Identifier(Variable::field_array(
                             Identifier::from("a").version(1),
@@ -1108,14 +1104,10 @@ mod tests {
             assert_eq!(
                 u.fold_statement(s),
                 vec![
-                    TypedStatement::Condition(
-                        BooleanExpression::Lt(
-                            box FieldElementExpression::Number(FieldPrime::from(1)),
-                            box FieldElementExpression::Number(FieldPrime::from(2))
-                        )
-                        .into(),
-                        BooleanExpression::Value(true).into()
-                    ),
+                    TypedStatement::Assertion(BooleanExpression::Lt(
+                        box FieldElementExpression::Number(FieldPrime::from(1)),
+                        box FieldElementExpression::Number(FieldPrime::from(2))
+                    )),
                     TypedStatement::Definition(
                         TypedAssignee::Identifier(Variable::with_id_and_type(
                             Identifier::from("a").version(1),

--- a/zokrates_core/src/static_analysis/unroll.rs
+++ b/zokrates_core/src/static_analysis/unroll.rs
@@ -65,13 +65,12 @@ impl<'ast> Unroller<'ast> {
 
                     match head {
                         Access::Select(head) => {
-                            statements.insert(TypedStatement::Condition(
+                            statements.insert(TypedStatement::assert_bool_eq(
                                 BooleanExpression::Lt(
                                     box head.clone(),
                                     box FieldElementExpression::Number(T::from(size)),
-                                )
-                                .into(),
-                                BooleanExpression::Value(true).into(),
+                                ),
+                                BooleanExpression::Value(true),
                             ));
 
                             ArrayExpressionInner::Value(

--- a/zokrates_core/src/typed_absy/folder.rs
+++ b/zokrates_core/src/typed_absy/folder.rs
@@ -311,6 +311,16 @@ pub fn fold_boolean_expression<'ast, T: Field, F: Folder<'ast, T>>(
             let e2 = f.fold_boolean_expression(e2);
             BooleanExpression::BoolEq(box e1, box e2)
         }
+        BooleanExpression::ArrayEq(box e1, box e2) => {
+            let e1 = f.fold_array_expression(e1);
+            let e2 = f.fold_array_expression(e2);
+            BooleanExpression::ArrayEq(box e1, box e2)
+        }
+        BooleanExpression::StructEq(box e1, box e2) => {
+            let e1 = f.fold_struct_expression(e1);
+            let e2 = f.fold_struct_expression(e2);
+            BooleanExpression::StructEq(box e1, box e2)
+        }
         BooleanExpression::Lt(box e1, box e2) => {
             let e1 = f.fold_field_expression(e1);
             let e2 = f.fold_field_expression(e2);

--- a/zokrates_core/src/typed_absy/folder.rs
+++ b/zokrates_core/src/typed_absy/folder.rs
@@ -153,9 +153,7 @@ pub fn fold_statement<'ast, T: Field, F: Folder<'ast, T>>(
             TypedStatement::Definition(f.fold_assignee(a), f.fold_expression(e))
         }
         TypedStatement::Declaration(v) => TypedStatement::Declaration(f.fold_variable(v)),
-        TypedStatement::Condition(left, right) => {
-            TypedStatement::Condition(f.fold_expression(left), f.fold_expression(right))
-        }
+        TypedStatement::Assertion(e) => TypedStatement::Assertion(f.fold_boolean_expression(e)),
         TypedStatement::For(v, from, to, statements) => TypedStatement::For(
             f.fold_variable(v),
             from,

--- a/zokrates_core/src/typed_absy/mod.rs
+++ b/zokrates_core/src/typed_absy/mod.rs
@@ -640,6 +640,11 @@ pub enum BooleanExpression<'ast, T: Field> {
         Box<BooleanExpression<'ast, T>>,
         Box<BooleanExpression<'ast, T>>,
     ),
+    ArrayEq(Box<ArrayExpression<'ast, T>>, Box<ArrayExpression<'ast, T>>),
+    StructEq(
+        Box<StructExpression<'ast, T>>,
+        Box<StructExpression<'ast, T>>,
+    ),
     Ge(
         Box<FieldElementExpression<'ast, T>>,
         Box<FieldElementExpression<'ast, T>>,
@@ -861,6 +866,8 @@ impl<'ast, T: Field> fmt::Display for BooleanExpression<'ast, T> {
             BooleanExpression::Le(ref lhs, ref rhs) => write!(f, "{} <= {}", lhs, rhs),
             BooleanExpression::FieldEq(ref lhs, ref rhs) => write!(f, "{} == {}", lhs, rhs),
             BooleanExpression::BoolEq(ref lhs, ref rhs) => write!(f, "{} == {}", lhs, rhs),
+            BooleanExpression::ArrayEq(ref lhs, ref rhs) => write!(f, "{} == {}", lhs, rhs),
+            BooleanExpression::StructEq(ref lhs, ref rhs) => write!(f, "{} == {}", lhs, rhs),
             BooleanExpression::Ge(ref lhs, ref rhs) => write!(f, "{} >= {}", lhs, rhs),
             BooleanExpression::Gt(ref lhs, ref rhs) => write!(f, "{} > {}", lhs, rhs),
             BooleanExpression::Or(ref lhs, ref rhs) => write!(f, "{} || {}", lhs, rhs),
@@ -1183,5 +1190,33 @@ impl<'ast, T: Field> Member<'ast, T> for StructExpression<'ast, T> {
         };
 
         StructExpressionInner::Member(box s, member_id).annotate(members)
+    }
+}
+
+pub trait Equal<'ast, T: Field> {
+    fn equal(left: Self, right: Self) -> BooleanExpression<'ast, T>;
+}
+
+impl<'ast, T: Field> Equal<'ast, T> for FieldElementExpression<'ast, T> {
+    fn equal(left: Self, right: Self) -> BooleanExpression<'ast, T> {
+        BooleanExpression::FieldEq(box left, box right)
+    }
+}
+
+impl<'ast, T: Field> Equal<'ast, T> for BooleanExpression<'ast, T> {
+    fn equal(left: Self, right: Self) -> BooleanExpression<'ast, T> {
+        BooleanExpression::BoolEq(box left, box right)
+    }
+}
+
+impl<'ast, T: Field> Equal<'ast, T> for ArrayExpression<'ast, T> {
+    fn equal(left: Self, right: Self) -> BooleanExpression<'ast, T> {
+        BooleanExpression::ArrayEq(box left, box right)
+    }
+}
+
+impl<'ast, T: Field> Equal<'ast, T> for StructExpression<'ast, T> {
+    fn equal(left: Self, right: Self) -> BooleanExpression<'ast, T> {
+        BooleanExpression::StructEq(box left, box right)
     }
 }

--- a/zokrates_core/src/typed_absy/mod.rs
+++ b/zokrates_core/src/typed_absy/mod.rs
@@ -325,9 +325,25 @@ pub enum TypedStatement<'ast, T: Field> {
     Return(Vec<TypedExpression<'ast, T>>),
     Definition(TypedAssignee<'ast, T>, TypedExpression<'ast, T>),
     Declaration(Variable<'ast>),
-    Condition(TypedExpression<'ast, T>, TypedExpression<'ast, T>),
+    Assertion(BooleanExpression<'ast, T>),
     For(Variable<'ast>, T, T, Vec<TypedStatement<'ast, T>>),
     MultipleDefinition(Vec<Variable<'ast>>, TypedExpressionList<'ast, T>),
+}
+
+impl<'ast, T: Field> TypedStatement<'ast, T> {
+    pub fn assert_bool_eq(
+        left: BooleanExpression<'ast, T>,
+        right: BooleanExpression<'ast, T>,
+    ) -> Self {
+        TypedStatement::Assertion(BooleanExpression::BoolEq(box left, box right))
+    }
+
+    pub fn assert_field_eq(
+        left: FieldElementExpression<'ast, T>,
+        right: FieldElementExpression<'ast, T>,
+    ) -> Self {
+        TypedStatement::Assertion(BooleanExpression::FieldEq(box left, box right))
+    }
 }
 
 impl<'ast, T: Field> fmt::Debug for TypedStatement<'ast, T> {
@@ -347,9 +363,7 @@ impl<'ast, T: Field> fmt::Debug for TypedStatement<'ast, T> {
             TypedStatement::Definition(ref lhs, ref rhs) => {
                 write!(f, "Definition({:?}, {:?})", lhs, rhs)
             }
-            TypedStatement::Condition(ref lhs, ref rhs) => {
-                write!(f, "Condition({:?}, {:?})", lhs, rhs)
-            }
+            TypedStatement::Assertion(ref e) => write!(f, "Condition({:?})", e),
             TypedStatement::For(ref var, ref start, ref stop, ref list) => {
                 write!(f, "for {:?} in {:?}..{:?} do\n", var, start, stop)?;
                 for l in list {
@@ -379,7 +393,7 @@ impl<'ast, T: Field> fmt::Display for TypedStatement<'ast, T> {
             }
             TypedStatement::Declaration(ref var) => write!(f, "{}", var),
             TypedStatement::Definition(ref lhs, ref rhs) => write!(f, "{} = {}", lhs, rhs),
-            TypedStatement::Condition(ref lhs, ref rhs) => write!(f, "{} == {}", lhs, rhs),
+            TypedStatement::Assertion(ref e) => write!(f, "{}", e),
             TypedStatement::For(ref var, ref start, ref stop, ref list) => {
                 write!(f, "for {} in {}..{} do\n", var, start, stop)?;
                 for l in list {

--- a/zokrates_stdlib/stdlib/utils/pack/unpack128.zok
+++ b/zokrates_stdlib/stdlib/utils/pack/unpack128.zok
@@ -4,12 +4,6 @@ def main(field i) -> (field[128]):
 
     field[254] b = unpack(i)
 
-    field sum = 0
-
-    for field index in 0..126 do
-    	sum = sum + b[index]
-    endfor
-
-    sum == 0
+    b[0..126] == [0; 126]
 
     return b[126..254]

--- a/zokrates_stdlib/stdlib/utils/pack/unpack128.zok
+++ b/zokrates_stdlib/stdlib/utils/pack/unpack128.zok
@@ -4,6 +4,12 @@ def main(field i) -> (field[128]):
 
     field[254] b = unpack(i)
 
-    b[0..126] == [0; 126]
+    field sum = 0
+
+    for field index in 0..126 do
+    	sum = sum + b[index]
+    endfor
+
+    sum == 0
 
     return b[126..254]


### PR DESCRIPTION
We only allow assertions of the form
```
a == b
```

Extend this to support any boolean:
```
a < b
a && (b == c)
someFunctionReturningABool()
```