### PR TITLE
[wip] Optimize CI for zokrates.js

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,12 +114,15 @@ jobs:
           command: ./scripts/release.sh
   zokrates_js_build:
     docker:
-      - image: circleci/node
+      - image: rustlang/rust:nightly
     steps:
       - checkout
-      - setup_remote_docker
       - run:
-          command: ./zokrates_js/build.sh
+          name: Install wasm-pack
+          command: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+      - run:
+          name: Build
+          command: cd zokrates_js && wasm-pack build --release
   zokrates_js_test:
     docker:
       - image: circleci/node

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,15 +114,12 @@ jobs:
           command: ./scripts/release.sh
   zokrates_js_build:
     docker:
-      - image: rustlang/rust:nightly
+      - image: dark64/rust-wasm-env:latest
     steps:
       - checkout
       - run:
-          name: Install wasm-pack
-          command: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
-      - run:
           name: Build
-          command: cd zokrates_js && wasm-pack build --release
+          command: cd zokrates_js && npm run build
   zokrates_js_test:
     docker:
       - image: circleci/node

--- a/zokrates_js/Cargo.toml
+++ b/zokrates_js/Cargo.toml
@@ -19,3 +19,7 @@ zokrates_abi = { path = "../zokrates_abi" }
 
 [target."cfg(debug_assertions)".dependencies]
 console_error_panic_hook = "0.1.5"
+
+# workaround until wasm-opt is fixed
+[package.metadata.wasm-pack.profile.release]
+wasm-opt = false

--- a/zokrates_js/Cargo.toml
+++ b/zokrates_js/Cargo.toml
@@ -16,10 +16,4 @@ wasm-bindgen = { version = "0.2.46", features = ["serde-serialize"] }
 zokrates_core = { path = "../zokrates_core", features = ["wasm"] }
 zokrates_field = { path = "../zokrates_field" }
 zokrates_abi = { path = "../zokrates_abi" }
-
-[target."cfg(debug_assertions)".dependencies]
 console_error_panic_hook = "0.1.5"
-
-# workaround until wasm-opt is fixed
-[package.metadata.wasm-pack.profile.release]
-wasm-opt = false

--- a/zokrates_js/Dockerfile
+++ b/zokrates_js/Dockerfile
@@ -1,15 +1,8 @@
-FROM rustlang/rust:nightly as build
-
-RUN curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh -s -- -y
+FROM dark64/rust-wasm-env:latest
 
 COPY . src
-RUN cd src/zokrates_js && wasm-pack build --out-name index --release --target bundler && rm -rf target/
+RUN cd src/zokrates_js && npm run build && rm -rf target/
 
-FROM node:10-alpine
-
-COPY --from=build src/zokrates_js src/zokrates_js
-COPY --from=build src/zokrates_stdlib src/zokrates_stdlib
-
-RUN cd src/zokrates_js && npm run setup \
-    && cd / && mkdir build && mv src/zokrates_js/* /build \
+RUN cd / && mkdir build \
+    && mv src/zokrates_js/* /build \
     && rm -rf src

--- a/zokrates_js/Dockerfile.env
+++ b/zokrates_js/Dockerfile.env
@@ -19,4 +19,4 @@ RUN set -eux; \
     cargo --version; \
     rustc --version;
 
-RUN curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh -s -- -y
+RUN cargo install wasm-pack --version 0.8.1

--- a/zokrates_js/Dockerfile.env
+++ b/zokrates_js/Dockerfile.env
@@ -1,0 +1,22 @@
+FROM node:10
+SHELL ["/bin/bash", "-c"]
+
+ENV RUSTUP_HOME=/usr/local/rustup \
+    CARGO_HOME=/usr/local/cargo \
+    PATH=/usr/local/cargo/bin:$PATH
+
+RUN set -eux; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends \
+        ca-certificates \
+        gcc \
+        libc6-dev \
+        ; \
+    \
+    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --no-modify-path --default-toolchain nightly; \
+    chmod -R a+w $RUSTUP_HOME $CARGO_HOME; \
+    rustup --version; \
+    cargo --version; \
+    rustc --version;
+
+RUN curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh -s -- -y

--- a/zokrates_js/Dockerfile.env
+++ b/zokrates_js/Dockerfile.env
@@ -1,6 +1,9 @@
 FROM node:10
 SHELL ["/bin/bash", "-c"]
 
+ARG RUST_VERSION=nightly
+ARG WASM_PACK_VERSION=0.8.1
+
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH
@@ -13,10 +16,10 @@ RUN set -eux; \
         libc6-dev \
         ; \
     \
-    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --no-modify-path --default-toolchain nightly; \
+    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --no-modify-path --default-toolchain $RUST_VERSION; \
     chmod -R a+w $RUSTUP_HOME $CARGO_HOME; \
     rustup --version; \
     cargo --version; \
     rustc --version;
 
-RUN cargo install wasm-pack --version 0.8.1
+RUN cargo install wasm-pack --version $WASM_PACK_VERSION

--- a/zokrates_js/package.json
+++ b/zokrates_js/package.json
@@ -22,8 +22,8 @@
     "cargo:build": "cargo build --target=wasm32-unknown-unknown",
     "wasm-pack:build": "wasm-pack build --out-name index --release --target bundler",
     "setup": "npm install && gulp stdlib",
-    "prebuild": "rimraf pkg && npm run setup",
-    "build": "npm run wasm-pack:build",
+    "prebuild": "npm run setup",
+    "build": "rimraf pkg && npm run wasm-pack:build",
     "pretest": "npm run setup",
     "test": "mocha --require esm --recursive tests"
   },


### PR DESCRIPTION
**Some notes:**
Usually the build step includes bundling stdlib to a json file. This file represents the whole stdlib folder structure and is not really needed for building rust related code, but it needs to be bundled for everything to work properly (importing stdlib modules). This process requires both rust and node images to build everything. There are two possible solutions for this; create docker image manually that will contain all dependencies needed for whole process to work (rust nightly, wasm-pack, node and npm) and use that image in the CI step. Downside to this solution is that rust version is then static and needs to be updated manually on each new nightly version. Other solution is to use multi-stage builds inside docker but this takes a lot of time for builds (10min+) as there is no way to use circleci cache in this context as far as I know of. On each push it needs to download base images and install dependencies before starting the build process.

This PR uses the first solution proposed above. If proposed solution is accepted, we should push [environment image](https://github.com/dark64/ZoKrates/blob/ci-patch/zokrates_js/Dockerfile.env) to official zokrates dockerhub account.