### PR TITLE
Fix import context

### DIFF
--- a/PROJECT/dep/dep/foo.zok
+++ b/PROJECT/dep/dep/foo.zok
@@ -1,2 +1,0 @@
-def foo() -> (field):
-	return 1

--- a/PROJECT/dep/foo.zok
+++ b/PROJECT/dep/foo.zok
@@ -1,4 +1,0 @@
-from "./dep/foo.zok" import foo as bar
-
-def foo() -> (field):
-	return 2 + bar()

--- a/PROJECT/main.zok
+++ b/PROJECT/main.zok
@@ -1,4 +1,0 @@
-from "./dep/foo.zok" import foo
-
-def main() -> (field):
-	return foo()

--- a/dep.zok
+++ b/dep.zok
@@ -1,3 +1,0 @@
-def foo() -> ():
-	field a = true
-	return

--- a/dep.zok
+++ b/dep.zok
@@ -1,0 +1,3 @@
+def foo() -> ():
+	field a = true
+	return

--- a/test.zok
+++ b/test.zok
@@ -1,5 +1,0 @@
-from "./dep.zok" import foo
-
-def main(field i) -> ():
-	return foo()
-	

--- a/test.zok
+++ b/test.zok
@@ -1,0 +1,5 @@
+from "./dep.zok" import foo
+
+def main(field i) -> ():
+	return foo()
+	

--- a/zokrates_cli/src/bin.rs
+++ b/zokrates_cli/src/bin.rs
@@ -271,13 +271,7 @@ fn cli() -> Result<(), String> {
 
             let path = PathBuf::from(sub_matches.value_of("input").unwrap());
 
-            let location = path
-                .parent()
-                .unwrap()
-                .to_path_buf()
-                .into_os_string()
-                .into_string()
-                .unwrap();
+            let location = path.to_path_buf().into_os_string().into_string().unwrap();
 
             let light = sub_matches.occurrences_of("light") > 0;
 

--- a/zokrates_cli/src/bin.rs
+++ b/zokrates_cli/src/bin.rs
@@ -678,19 +678,12 @@ mod tests {
             let file = File::open(path.clone()).unwrap();
 
             let mut reader = BufReader::new(file);
-            let location = path
-                .parent()
-                .unwrap()
-                .to_path_buf()
-                .into_os_string()
-                .into_string()
-                .unwrap();
 
             let mut source = String::new();
             reader.read_to_string(&mut source).unwrap();
 
             let _: CompilationArtifacts<FieldPrime> =
-                compile(source, location, Some(&fs_resolve)).unwrap();
+                compile(source, path, Some(&fs_resolve)).unwrap();
         }
     }
 
@@ -706,20 +699,12 @@ mod tests {
 
             let file = File::open(path.clone()).unwrap();
 
-            let location = path
-                .parent()
-                .unwrap()
-                .to_path_buf()
-                .into_os_string()
-                .into_string()
-                .unwrap();
-
             let mut reader = BufReader::new(file);
             let mut source = String::new();
             reader.read_to_string(&mut source).unwrap();
 
             let artifacts: CompilationArtifacts<FieldPrime> =
-                compile(source, location, Some(&fs_resolve)).unwrap();
+                compile(source, path, Some(&fs_resolve)).unwrap();
 
             let _ = artifacts
                 .prog()
@@ -741,20 +726,12 @@ mod tests {
 
             let file = File::open(path.clone()).unwrap();
 
-            let location = path
-                .parent()
-                .unwrap()
-                .to_path_buf()
-                .into_os_string()
-                .into_string()
-                .unwrap();
-
             let mut reader = BufReader::new(file);
             let mut source = String::new();
             reader.read_to_string(&mut source).unwrap();
 
             let artifacts: CompilationArtifacts<FieldPrime> =
-                compile(source, location, Some(&fs_resolve)).unwrap();
+                compile(source, path, Some(&fs_resolve)).unwrap();
 
             let _ = artifacts
                 .prog()

--- a/zokrates_cli/src/bin.rs
+++ b/zokrates_cli/src/bin.rs
@@ -279,22 +279,22 @@ fn cli() -> Result<(), String> {
 
             let hr_output_path = bin_output_path.to_path_buf().with_extension("ztf");
 
-            let file = File::open(path.clone()).map_err(|why| format!("Couldn't open input file {}: {}", path.display(), why))?;
+            let file = File::open(path.clone())
+                .map_err(|why| format!("Couldn't open input file {}: {}", path.display(), why))?;
 
             let mut reader = BufReader::new(file);
             let mut source = String::new();
-            reader
-                .read_to_string(&mut source).unwrap();
+            reader.read_to_string(&mut source).unwrap();
 
             let fmt_error = |e: &CompileError| {
                 format!(
                     "{}:{}",
-                    e.file().display(),
-                    // .canonicalize()
-                    // .unwrap()
-                    // .strip_prefix(std::env::current_dir().unwrap())
-                    // .unwrap()
-                    // .display(),
+                    e.file()
+                        .canonicalize()
+                        .unwrap()
+                        .strip_prefix(std::env::current_dir().unwrap())
+                        .unwrap()
+                        .display(),
                     e.value()
                 )
             };

--- a/zokrates_cli/src/bin.rs
+++ b/zokrates_cli/src/bin.rs
@@ -279,13 +279,12 @@ fn cli() -> Result<(), String> {
 
             let hr_output_path = bin_output_path.to_path_buf().with_extension("ztf");
 
-            let file = File::open(path.clone()).unwrap();
+            let file = File::open(path.clone()).map_err(|why| format!("Couldn't open input file {}: {}", path.display(), why))?;
 
             let mut reader = BufReader::new(file);
             let mut source = String::new();
             reader
-                .read_to_string(&mut source)
-                .map_err(|why| format!("couldn't open input file {}: {}", path.display(), why))?;
+                .read_to_string(&mut source).unwrap();
 
             let fmt_error = |e: &CompileError| {
                 format!(
@@ -318,7 +317,7 @@ fn cli() -> Result<(), String> {
 
             // serialize flattened program and write to binary file
             let bin_output_file = File::create(&bin_output_path)
-                .map_err(|why| format!("couldn't create {}: {}", bin_output_path.display(), why))?;
+                .map_err(|why| format!("Couldn't create {}: {}", bin_output_path.display(), why))?;
 
             let mut writer = BufWriter::new(bin_output_file);
 
@@ -327,7 +326,7 @@ fn cli() -> Result<(), String> {
 
             // serialize ABI spec and write to JSON file
             let abi_spec_file = File::create(&abi_spec_path)
-                .map_err(|why| format!("couldn't create {}: {}", abi_spec_path.display(), why))?;
+                .map_err(|why| format!("Couldn't create {}: {}", abi_spec_path.display(), why))?;
 
             let abi = artifacts.abi();
 

--- a/zokrates_cli/src/bin.rs
+++ b/zokrates_cli/src/bin.rs
@@ -290,12 +290,12 @@ fn cli() -> Result<(), String> {
             let fmt_error = |e: &CompileError| {
                 format!(
                     "{}:{}",
-                    e.file()
-                        .canonicalize()
-                        .unwrap()
-                        .strip_prefix(std::env::current_dir().unwrap())
-                        .unwrap()
-                        .display(),
+                    e.file().display(),
+                    // .canonicalize()
+                    // .unwrap()
+                    // .strip_prefix(std::env::current_dir().unwrap())
+                    // .unwrap()
+                    // .display(),
                     e.value()
                 )
             };

--- a/zokrates_core/src/compile.rs
+++ b/zokrates_core/src/compile.rs
@@ -228,13 +228,10 @@ mod test {
 			   return foo()
 		"#
         .to_string();
-        let res: Result<CompilationArtifacts<FieldPrime>, CompileErrors> = compile(
-            source,
-            String::from("./path/to/file"),
-            None::<Resolve<io::Error>>,
-        );
-        assert!(res
-            .unwrap_err()
+        let res: Result<CompilationArtifacts<FieldPrime>, CompileErrors> =
+            compile(source, "./path/to/file".into(), None::<Resolve<io::Error>>);
+        assert!(res.unwrap_err().0[0]
+            .value()
             .to_string()
             .contains(&"Can't resolve import without a resolver"));
     }
@@ -246,11 +243,8 @@ mod test {
 			   return 1
 		"#
         .to_string();
-        let res: Result<CompilationArtifacts<FieldPrime>, CompileErrors> = compile(
-            source,
-            String::from("./path/to/file"),
-            None::<Resolve<io::Error>>,
-        );
+        let res: Result<CompilationArtifacts<FieldPrime>, CompileErrors> =
+            compile(source, "./path/to/file".into(), None::<Resolve<io::Error>>);
         assert!(res.is_ok());
     }
 }

--- a/zokrates_core/src/compile.rs
+++ b/zokrates_core/src/compile.rs
@@ -44,20 +44,6 @@ impl From<CompileError> for CompileErrors {
     }
 }
 
-impl fmt::Display for CompileErrors {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(
-            f,
-            "{}",
-            self.0
-                .iter()
-                .map(|e| format!("{}", e))
-                .collect::<Vec<_>>()
-                .join("\n\n")
-        )
-    }
-}
-
 #[derive(Debug)]
 pub enum CompileErrorInner {
     ParserError(pest::Error),
@@ -81,6 +67,16 @@ pub struct CompileError {
     value: CompileErrorInner,
 }
 
+impl CompileError {
+    pub fn file(&self) -> &PathBuf {
+        &self.file
+    }
+
+    pub fn value(&self) -> &CompileErrorInner {
+        &self.value
+    }
+}
+
 impl CompileErrors {
     pub fn with_context(self, file: PathBuf) -> Self {
         CompileErrors(
@@ -91,22 +87,6 @@ impl CompileErrors {
                     ..e
                 })
                 .collect(),
-        )
-    }
-}
-
-impl fmt::Display for CompileError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(
-            f,
-            "{}:{}",
-            self.file
-                .canonicalize()
-                .unwrap()
-                .strip_prefix(std::env::current_dir().unwrap())
-                .unwrap()
-                .display(),
-            self.value
         )
     }
 }
@@ -140,13 +120,12 @@ impl From<semantics::Error> for CompileError {
 
 impl fmt::Display for CompileErrorInner {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let res = match *self {
-            CompileErrorInner::ParserError(ref e) => format!("{}", e),
-            CompileErrorInner::SemanticError(ref e) => format!("{}", e),
-            CompileErrorInner::ReadError(ref e) => format!("{}", e),
-            CompileErrorInner::ImportError(ref e) => format!("{}", e),
-        };
-        write!(f, "{}", res)
+        match *self {
+            CompileErrorInner::ParserError(ref e) => write!(f, "{}", e),
+            CompileErrorInner::SemanticError(ref e) => write!(f, "{}", e),
+            CompileErrorInner::ReadError(ref e) => write!(f, "{}", e),
+            CompileErrorInner::ImportError(ref e) => write!(f, "{}", e),
+        }
     }
 }
 

--- a/zokrates_core/src/compile.rs
+++ b/zokrates_core/src/compile.rs
@@ -129,6 +129,7 @@ impl fmt::Display for CompileErrorInner {
     }
 }
 
+// See zokrates_fs_resolver for the spec
 pub type Resolve<'a, E> = &'a dyn Fn(PathBuf, PathBuf) -> Result<(String, PathBuf), E>;
 
 type FilePath = PathBuf;

--- a/zokrates_core/src/imports.rs
+++ b/zokrates_core/src/imports.rs
@@ -180,7 +180,6 @@ impl Importer {
                 }
             } else {
                 // to resolve imports, we need a resolver
-                let folder = location.clone().parent().unwrap();
                 match resolve_option {
                     Some(resolve) => match resolve(location.clone(), import.source.to_path_buf()) {
                         Ok((source, new_location)) => {

--- a/zokrates_core/src/imports.rs
+++ b/zokrates_core/src/imports.rs
@@ -261,10 +261,10 @@ mod tests {
     #[test]
     fn create_with_no_alias() {
         assert_eq!(
-            Import::new(None, "./foo/bar/baz.zok"),
+            Import::new(None, Path::new("./foo/bar/baz.zok")),
             Import {
                 symbol: None,
-                source: "./foo/bar/baz.zok",
+                source: Path::new("./foo/bar/baz.zok"),
                 alias: None,
             }
         );
@@ -273,10 +273,10 @@ mod tests {
     #[test]
     fn create_with_alias() {
         assert_eq!(
-            Import::new_with_alias(None, "./foo/bar/baz.zok", &"myalias"),
+            Import::new_with_alias(None, Path::new("./foo/bar/baz.zok"), &"myalias"),
             Import {
                 symbol: None,
-                source: "./foo/bar/baz.zok",
+                source: Path::new("./foo/bar/baz.zok"),
                 alias: Some("myalias"),
             }
         );

--- a/zokrates_core/src/imports.rs
+++ b/zokrates_core/src/imports.rs
@@ -172,8 +172,9 @@ impl Importer {
                 }
             } else {
                 // to resolve imports, we need a resolver
+                let folder = std::path::PathBuf::from(location.clone()).parent().unwrap().to_path_buf().into_os_string().into_string().unwrap();
                 match resolve_option {
-                    Some(resolve) => match resolve(location.clone(), import.source.to_string()) {
+                    Some(resolve) => match resolve(folder, import.source.to_string()) {
                         Ok((source, location)) => {
                             let source = arena.alloc(source);
 

--- a/zokrates_core/src/semantics.rs
+++ b/zokrates_core/src/semantics.rs
@@ -2007,7 +2007,7 @@ mod tests {
         #[test]
         fn element_type_mismatch() {
             let types = HashMap::new();
-            let module_id = String::from("");
+            let module_id = "".into();
             // [3, true]
             let a = Expression::InlineArray(vec![
                 Expression::FieldConstant(FieldPrime::from(3)).mock().into(),
@@ -2169,19 +2169,16 @@ mod tests {
             };
 
             let mut state = State::new(
-                vec![(String::from("foo"), foo), (String::from("bar"), bar)]
+                vec![("foo".into(), foo), ("bar".into(), bar)]
                     .into_iter()
                     .collect(),
             );
 
             let mut checker = Checker::new();
 
+            assert_eq!(checker.check_module(&"bar".into(), &mut state), Ok(()));
             assert_eq!(
-                checker.check_module(&String::from("bar"), &mut state),
-                Ok(())
-            );
-            assert_eq!(
-                state.typed_modules.get(&String::from("bar")),
+                state.typed_modules.get(&"bar".to_string()),
                 Some(&TypedModule {
                     functions: vec![(
                         FunctionKey::with_id("main").signature(Signature::new()),
@@ -2221,13 +2218,14 @@ mod tests {
                 imports: vec![],
             };
 
-            let mut state = State::new(vec![(MODULE_ID.to_string(), module)].into_iter().collect());
+            let mut state = State::new(vec![(MODULE_ID.into(), module)].into_iter().collect());
 
             let mut checker = Checker::new();
             assert_eq!(
                 checker
-                    .check_module(&MODULE_ID.to_string(), &mut state)
+                    .check_module(&MODULE_ID.into(), &mut state)
                     .unwrap_err()[0]
+                    .inner
                     .message,
                 "foo conflicts with another symbol"
             );
@@ -2258,13 +2256,10 @@ mod tests {
                 imports: vec![],
             };
 
-            let mut state = State::new(vec![(MODULE_ID.to_string(), module)].into_iter().collect());
+            let mut state = State::new(vec![(MODULE_ID.into(), module)].into_iter().collect());
 
             let mut checker = Checker::new();
-            assert_eq!(
-                checker.check_module(&MODULE_ID.to_string(), &mut state),
-                Ok(())
-            );
+            assert_eq!(checker.check_module(&MODULE_ID.into(), &mut state), Ok(()));
             assert!(state
                 .typed_modules
                 .get(&MODULE_ID.to_string())
@@ -2305,13 +2300,14 @@ mod tests {
                 imports: vec![],
             };
 
-            let mut state = State::new(vec![(String::from("main"), module)].into_iter().collect());
+            let mut state = State::new(vec![("main".into(), module)].into_iter().collect());
 
             let mut checker = Checker::new();
             assert_eq!(
                 checker
-                    .check_module(&String::from("main"), &mut state)
+                    .check_module(&"main".into(), &mut state)
                     .unwrap_err()[0]
+                    .inner
                     .message,
                 "foo conflicts with another symbol"
             );
@@ -2341,13 +2337,14 @@ mod tests {
                 imports: vec![],
             };
 
-            let mut state = State::new(vec![(String::from("main"), module)].into_iter().collect());
+            let mut state = State::new(vec![("main".into(), module)].into_iter().collect());
 
             let mut checker = Checker::new();
             assert_eq!(
                 checker
-                    .check_module(&String::from("main"), &mut state)
+                    .check_module(&"main".into(), &mut state)
                     .unwrap_err()[0]
+                    .inner
                     .message,
                 "foo conflicts with another symbol"
             );
@@ -2377,7 +2374,7 @@ mod tests {
                     SymbolDeclaration {
                         id: "foo",
                         symbol: Symbol::There(
-                            SymbolImport::with_id_in_module("main", "bar".to_string()).mock(),
+                            SymbolImport::with_id_in_module("main", "bar").mock(),
                         ),
                     }
                     .mock(),
@@ -2391,7 +2388,7 @@ mod tests {
             };
 
             let mut state = State::new(
-                vec![(MODULE_ID.to_string(), main), ("bar".to_string(), bar)]
+                vec![(MODULE_ID.into(), main), ("bar".into(), bar)]
                     .into_iter()
                     .collect(),
             );
@@ -2399,8 +2396,9 @@ mod tests {
             let mut checker = Checker::new();
             assert_eq!(
                 checker
-                    .check_module(&MODULE_ID.to_string(), &mut state)
+                    .check_module(&MODULE_ID.into(), &mut state)
                     .unwrap_err()[0]
+                    .inner
                     .message,
                 "foo conflicts with another symbol"
             );
@@ -2432,7 +2430,7 @@ mod tests {
                     SymbolDeclaration {
                         id: "foo",
                         symbol: Symbol::There(
-                            SymbolImport::with_id_in_module("main", "bar".to_string()).mock(),
+                            SymbolImport::with_id_in_module("main", "bar").mock(),
                         ),
                     }
                     .mock(),
@@ -2441,7 +2439,7 @@ mod tests {
             };
 
             let mut state = State::new(
-                vec![(MODULE_ID.to_string(), main), ("bar".to_string(), bar)]
+                vec![(MODULE_ID.into(), main), ("bar".into(), bar)]
                     .into_iter()
                     .collect(),
             );
@@ -2449,8 +2447,9 @@ mod tests {
             let mut checker = Checker::new();
             assert_eq!(
                 checker
-                    .check_module(&MODULE_ID.to_string(), &mut state)
+                    .check_module(&MODULE_ID.into(), &mut state)
                     .unwrap_err()[0]
+                    .inner
                     .message,
                 "foo conflicts with another symbol"
             );
@@ -2480,14 +2479,14 @@ mod tests {
         .mock();
 
         let types = HashMap::new();
-        let module_id = String::from("");
+        let module_id = "".into();
 
         let mut checker = Checker::new();
         assert_eq!(
             checker.check_statement(statement, &module_id, &types),
             Err(vec![ErrorInner {
                 pos: Some((Position::mock(), Position::mock())),
-                message: "Identifier \"b\" is undefined".to_string()
+                message: "Identifier \"b\" is undefined".into()
             }])
         );
     }
@@ -2503,7 +2502,7 @@ mod tests {
         .mock();
 
         let types = HashMap::new();
-        let module_id = String::from("");
+        let module_id = "".into();
 
         let mut scope = HashSet::new();
         scope.insert(ScopedVariable {
@@ -2589,14 +2588,17 @@ mod tests {
             imports: vec![],
         };
 
-        let mut state = State::new(vec![(String::from("main"), module)].into_iter().collect());
+        let mut state = State::new(vec![("main".into(), module)].into_iter().collect());
 
         let mut checker = Checker::new();
         assert_eq!(
-            checker.check_module(&String::from("main"), &mut state),
-            Err(vec![ErrorInner {
-                pos: Some((Position::mock(), Position::mock())),
-                message: "Identifier \"a\" is undefined".to_string()
+            checker.check_module(&"main".into(), &mut state),
+            Err(vec![Error {
+                inner: ErrorInner {
+                    pos: Some((Position::mock(), Position::mock())),
+                    message: "Identifier \"a\" is undefined".into()
+                },
+                module_id: "main".into()
             }])
         );
     }
@@ -2704,12 +2706,10 @@ mod tests {
             imports: vec![],
         };
 
-        let mut state = State::new(vec![(String::from("main"), module)].into_iter().collect());
+        let mut state = State::new(vec![("main".into(), module)].into_iter().collect());
 
         let mut checker = Checker::new();
-        assert!(checker
-            .check_module(&String::from("main"), &mut state)
-            .is_ok());
+        assert!(checker.check_module(&"main".into(), &mut state).is_ok());
     }
 
     #[test]
@@ -2746,14 +2746,14 @@ mod tests {
         .mock();
 
         let types = HashMap::new();
-        let module_id = String::from("");
+        let module_id = "".into();
 
         let mut checker = Checker::new();
         assert_eq!(
             checker.check_function(foo, &module_id, &types),
             Err(vec![ErrorInner {
                 pos: Some((Position::mock(), Position::mock())),
-                message: "Identifier \"i\" is undefined".to_string()
+                message: "Identifier \"i\" is undefined".into()
             }])
         );
     }
@@ -2821,7 +2821,7 @@ mod tests {
         };
 
         let types = HashMap::new();
-        let module_id = String::from("");
+        let module_id = "".into();
 
         let mut checker = Checker::new();
         assert_eq!(
@@ -2870,7 +2870,7 @@ mod tests {
         .mock();
 
         let types = HashMap::new();
-        let module_id = String::from("");
+        let module_id = "".into();
 
         let mut checker = new_with_args(HashSet::new(), 0, functions);
         assert_eq!(
@@ -2879,7 +2879,7 @@ mod tests {
                 pos: Some((Position::mock(), Position::mock())),
                 message:
                     "Function definition for function foo with signature () -> (field) not found."
-                        .to_string()
+                        .into()
             }])
         );
     }
@@ -2918,7 +2918,7 @@ mod tests {
         .mock();
 
         let types = HashMap::new();
-        let module_id = String::from("");
+        let module_id = "".into();
 
         let mut checker = new_with_args(HashSet::new(), 0, functions);
         assert_eq!(
@@ -2926,7 +2926,7 @@ mod tests {
             Err(vec![ErrorInner {
                 pos: Some((Position::mock(), Position::mock())),
                 message: "Function definition for function foo with signature () -> (_) not found."
-                    .to_string()
+                    .into()
             }])
         );
     }
@@ -2959,7 +2959,7 @@ mod tests {
         .mock();
 
         let types = HashMap::new();
-        let module_id = String::from("");
+        let module_id = "".into();
 
         let mut checker = new_with_args(HashSet::new(), 0, HashSet::new());
         assert_eq!(
@@ -2969,7 +2969,7 @@ mod tests {
 
                 message:
                     "Function definition for function foo with signature () -> (field) not found."
-                        .to_string()
+                        .into()
             }])
         );
     }
@@ -3063,14 +3063,17 @@ mod tests {
             imports: vec![],
         };
 
-        let mut state = State::new(vec![(String::from("main"), module)].into_iter().collect());
+        let mut state = State::new(vec![("main".into(), module)].into_iter().collect());
 
         let mut checker = new_with_args(HashSet::new(), 0, HashSet::new());
         assert_eq!(
-            checker.check_module(&String::from("main"), &mut state),
-            Err(vec![ErrorInner {
-                pos: Some((Position::mock(), Position::mock())),
-                message: "Identifier \"x\" is undefined".to_string()
+            checker.check_module(&"main".into(), &mut state),
+            Err(vec![Error {
+                inner: ErrorInner {
+                    pos: Some((Position::mock(), Position::mock())),
+                    message: "Identifier \"x\" is undefined".into()
+                },
+                module_id: "main".into()
             }])
         );
     }
@@ -3097,7 +3100,7 @@ mod tests {
         .mock();
 
         let types = HashMap::new();
-        let module_id = String::from("");
+        let module_id = "".into();
 
         let mut checker = new_with_args(HashSet::new(), 0, HashSet::new());
         assert_eq!(
@@ -3106,7 +3109,7 @@ mod tests {
                 pos: Some((Position::mock(), Position::mock())),
 
                 message: "Function definition for function foo with signature () -> (_) not found."
-                    .to_string()
+                    .into()
             }])
         );
     }
@@ -3141,14 +3144,14 @@ mod tests {
         .mock();
 
         let types = HashMap::new();
-        let module_id = String::from("");
+        let module_id = "".into();
 
         let mut checker = new_with_args(HashSet::new(), 0, HashSet::new());
         assert_eq!(
             checker.check_function(bar, &module_id, &types),
             Err(vec![ErrorInner {
                 pos: Some((Position::mock(), Position::mock())),
-                message: "Identifier \"a\" is undefined".to_string()
+                message: "Identifier \"a\" is undefined".into()
             }])
         );
     }
@@ -3246,7 +3249,7 @@ mod tests {
         };
 
         let types = HashMap::new();
-        let module_id = String::from("");
+        let module_id = "".into();
 
         let mut checker = new_with_args(HashSet::new(), 0, functions);
         assert_eq!(
@@ -3326,18 +3329,19 @@ mod tests {
         };
 
         let program = Program {
-            modules: vec![(String::from("main"), main_module)]
-                .into_iter()
-                .collect(),
-            main: String::from("main"),
+            modules: vec![("main".into(), main_module)].into_iter().collect(),
+            main: "main".into(),
         };
 
         let mut checker = Checker::new();
         assert_eq!(
             checker.check_program(program),
-            Err(vec![ErrorInner {
-                pos: None,
-                message: "Only one main function allowed, found 2".to_string()
+            Err(vec![Error {
+                inner: ErrorInner {
+                    pos: None,
+                    message: "Only one main function allowed, found 2".into()
+                },
+                module_id: "main".into()
             }])
         );
     }
@@ -3350,7 +3354,7 @@ mod tests {
         // should fail
 
         let types = HashMap::new();
-        let module_id = String::from("");
+        let module_id = "".into();
         let mut checker = Checker::new();
         let _: Result<TypedStatement<FieldPrime>, Vec<ErrorInner>> = checker.check_statement(
             Statement::Declaration(
@@ -3373,7 +3377,7 @@ mod tests {
             s2_checked,
             Err(vec![ErrorInner {
                 pos: Some((Position::mock(), Position::mock())),
-                message: "Duplicate declaration for variable named a".to_string()
+                message: "Duplicate declaration for variable named a".into()
             }])
         );
     }
@@ -3386,7 +3390,7 @@ mod tests {
         // should fail
 
         let types = HashMap::new();
-        let module_id = String::from("");
+        let module_id = "".into();
 
         let mut checker = Checker::new();
         let _: Result<TypedStatement<FieldPrime>, Vec<ErrorInner>> = checker.check_statement(
@@ -3410,7 +3414,7 @@ mod tests {
             s2_checked,
             Err(vec![ErrorInner {
                 pos: Some((Position::mock(), Position::mock())),
-                message: "Duplicate declaration for variable named a".to_string()
+                message: "Duplicate declaration for variable named a".into()
             }])
         );
     }
@@ -3422,7 +3426,7 @@ mod tests {
         fn create_module_with_foo(
             s: StructType<'static>,
         ) -> (Checker<'static>, State<'static, FieldPrime>) {
-            let module_id = "".to_string();
+            let module_id: PathBuf = "".into();
 
             let module: Module<FieldPrime> = Module {
                 imports: vec![],
@@ -3449,7 +3453,7 @@ mod tests {
             #[test]
             fn empty_def() {
                 // an empty struct should be allowed to be defined
-                let module_id = "".to_string();
+                let module_id = "".into();
                 let types = HashMap::new();
                 let declaration = StructType { fields: vec![] }.mock();
 
@@ -3464,7 +3468,7 @@ mod tests {
             #[test]
             fn valid_def() {
                 // a valid struct should be allowed to be defined
-                let module_id = "".to_string();
+                let module_id = "".into();
                 let types = HashMap::new();
                 let declaration = StructType {
                     fields: vec![
@@ -3483,8 +3487,8 @@ mod tests {
                 .mock();
 
                 let expected_type = Type::Struct(vec![
-                    StructMember::new("foo".to_string(), Type::FieldElement),
-                    StructMember::new("bar".to_string(), Type::Boolean),
+                    StructMember::new("foo".into(), Type::FieldElement),
+                    StructMember::new("bar".into(), Type::Boolean),
                 ]);
 
                 assert_eq!(
@@ -3496,7 +3500,7 @@ mod tests {
             #[test]
             fn preserve_order() {
                 // two structs with inverted members are not equal
-                let module_id = "".to_string();
+                let module_id = "".into();
                 let types = HashMap::new();
 
                 let declaration0 = StructType {
@@ -3540,7 +3544,7 @@ mod tests {
             #[test]
             fn duplicate_member_def() {
                 // definition of a struct with a duplicate member should be rejected
-                let module_id = "".to_string();
+                let module_id = "".into();
                 let types = HashMap::new();
 
                 let declaration = StructType {
@@ -3575,7 +3579,7 @@ mod tests {
                 // struct Foo = { foo: field }
                 // struct Bar = { foo: Foo }
 
-                let module_id = "".to_string();
+                let module_id: PathBuf = "".into();
 
                 let module: Module<FieldPrime> = Module {
                     imports: vec![],
@@ -3600,7 +3604,7 @@ mod tests {
                                 StructType {
                                     fields: vec![StructField {
                                         id: "foo",
-                                        ty: UnresolvedType::User("Foo".to_string()).mock(),
+                                        ty: UnresolvedType::User("Foo".into()).mock(),
                                     }
                                     .mock()],
                                 }
@@ -3617,16 +3621,13 @@ mod tests {
                 assert_eq!(
                     state
                         .types
-                        .get(&"".to_string())
+                        .get(&module_id)
                         .unwrap()
                         .get(&"Bar".to_string())
                         .unwrap(),
                     &Type::Struct(vec![StructMember::new(
-                        "foo".to_string(),
-                        Type::Struct(vec![StructMember::new(
-                            "foo".to_string(),
-                            Type::FieldElement
-                        )])
+                        "foo".into(),
+                        Type::Struct(vec![StructMember::new("foo".into(), Type::FieldElement)])
                     )])
                 );
             }
@@ -3637,7 +3638,7 @@ mod tests {
 
                 // struct Bar = { foo: Foo }
 
-                let module_id = "".to_string();
+                let module_id: PathBuf = "".into();
 
                 let module: Module<FieldPrime> = Module {
                     imports: vec![],
@@ -3647,7 +3648,7 @@ mod tests {
                             StructType {
                                 fields: vec![StructField {
                                     id: "foo",
-                                    ty: UnresolvedType::User("Foo".to_string()).mock(),
+                                    ty: UnresolvedType::User("Foo".into()).mock(),
                                 }
                                 .mock()],
                             }
@@ -3668,7 +3669,7 @@ mod tests {
 
                 // struct Foo = { foo: Foo }
 
-                let module_id = "".to_string();
+                let module_id: PathBuf = "".into();
 
                 let module: Module<FieldPrime> = Module {
                     imports: vec![],
@@ -3678,7 +3679,7 @@ mod tests {
                             StructType {
                                 fields: vec![StructField {
                                     id: "foo",
-                                    ty: UnresolvedType::User("Foo".to_string()).mock(),
+                                    ty: UnresolvedType::User("Foo".into()).mock(),
                                 }
                                 .mock()],
                             }
@@ -3700,7 +3701,7 @@ mod tests {
                 // struct Foo = { bar: Bar }
                 // struct Bar = { foo: Foo }
 
-                let module_id = "".to_string();
+                let module_id: PathBuf = "".into();
 
                 let module: Module<FieldPrime> = Module {
                     imports: vec![],
@@ -3711,7 +3712,7 @@ mod tests {
                                 StructType {
                                     fields: vec![StructField {
                                         id: "bar",
-                                        ty: UnresolvedType::User("Bar".to_string()).mock(),
+                                        ty: UnresolvedType::User("Bar".into()).mock(),
                                     }
                                     .mock()],
                                 }
@@ -3725,7 +3726,7 @@ mod tests {
                                 StructType {
                                     fields: vec![StructField {
                                         id: "foo",
-                                        ty: UnresolvedType::User("Foo".to_string()).mock(),
+                                        ty: UnresolvedType::User("Foo".into()).mock(),
                                     }
                                     .mock()],
                                 }
@@ -3765,12 +3766,12 @@ mod tests {
 
                 assert_eq!(
                     checker.check_type(
-                        UnresolvedType::User("Foo".to_string()).mock(),
-                        &MODULE_ID.to_string(),
+                        UnresolvedType::User("Foo".into()).mock(),
+                        &MODULE_ID.into(),
                         &state.types
                     ),
                     Ok(Type::Struct(vec![StructMember::new(
-                        "foo".to_string(),
+                        "foo".into(),
                         Type::FieldElement
                     )]))
                 );
@@ -3778,8 +3779,8 @@ mod tests {
                 assert_eq!(
                     checker
                         .check_type(
-                            UnresolvedType::User("Bar".to_string()).mock(),
-                            &MODULE_ID.to_string(),
+                            UnresolvedType::User("Bar".into()).mock(),
+                            &MODULE_ID.into(),
                             &state.types
                         )
                         .unwrap_err()
@@ -3805,24 +3806,19 @@ mod tests {
                 assert_eq!(
                     checker.check_parameter(
                         absy::Parameter {
-                            id: absy::Variable::new(
-                                "a",
-                                UnresolvedType::User("Foo".to_string()).mock(),
-                            )
-                            .mock(),
+                            id:
+                                absy::Variable::new("a", UnresolvedType::User("Foo".into()).mock(),)
+                                    .mock(),
                             private: true,
                         }
                         .mock(),
-                        &MODULE_ID.to_string(),
+                        &MODULE_ID.into(),
                         &state.types,
                     ),
                     Ok(Parameter {
                         id: Variable::with_id_and_type(
                             "a".into(),
-                            Type::Struct(vec![StructMember::new(
-                                "foo".to_string(),
-                                Type::FieldElement
-                            )])
+                            Type::Struct(vec![StructMember::new("foo".into(), Type::FieldElement)])
                         ),
                         private: true
                     })
@@ -3834,13 +3830,13 @@ mod tests {
                             absy::Parameter {
                                 id: absy::Variable::new(
                                     "a",
-                                    UnresolvedType::User("Bar".to_string()).mock(),
+                                    UnresolvedType::User("Bar".into()).mock(),
                                 )
                                 .mock(),
                                 private: true,
                             }
                             .mock(),
-                            &MODULE_ID.to_string(),
+                            &MODULE_ID.into(),
                             &state.types,
                         )
                         .unwrap_err()[0]
@@ -3866,22 +3862,16 @@ mod tests {
                 assert_eq!(
                     checker.check_statement::<FieldPrime>(
                         Statement::Declaration(
-                            absy::Variable::new(
-                                "a",
-                                UnresolvedType::User("Foo".to_string()).mock(),
-                            )
-                            .mock()
+                            absy::Variable::new("a", UnresolvedType::User("Foo".into()).mock(),)
+                                .mock()
                         )
                         .mock(),
-                        &MODULE_ID.to_string(),
+                        &MODULE_ID.into(),
                         &state.types,
                     ),
                     Ok(TypedStatement::Declaration(Variable::with_id_and_type(
                         "a".into(),
-                        Type::Struct(vec![StructMember::new(
-                            "foo".to_string(),
-                            Type::FieldElement
-                        )])
+                        Type::Struct(vec![StructMember::new("foo".into(), Type::FieldElement)])
                     )))
                 );
 
@@ -3891,13 +3881,13 @@ mod tests {
                             absy::Parameter {
                                 id: absy::Variable::new(
                                     "a",
-                                    UnresolvedType::User("Bar".to_string()).mock(),
+                                    UnresolvedType::User("Bar".into()).mock(),
                                 )
                                 .mock(),
                                 private: true,
                             }
                             .mock(),
-                            &MODULE_ID.to_string(),
+                            &MODULE_ID.into(),
                             &state.types,
                         )
                         .unwrap_err()[0]
@@ -3930,7 +3920,7 @@ mod tests {
                     checker.check_expression(
                         Expression::Member(
                             box Expression::InlineStruct(
-                                "Foo".to_string(),
+                                "Foo".into(),
                                 vec![(
                                     "foo",
                                     Expression::FieldConstant(FieldPrime::from(42)).mock()
@@ -3940,7 +3930,7 @@ mod tests {
                             "foo".into()
                         )
                         .mock(),
-                        &MODULE_ID.to_string(),
+                        &MODULE_ID.into(),
                         &state.types
                     ),
                     Ok(FieldElementExpression::Member(
@@ -3948,11 +3938,8 @@ mod tests {
                             FieldPrime::from(42)
                         )
                         .into()])
-                        .annotate(vec![StructMember::new(
-                            "foo".to_string(),
-                            Type::FieldElement
-                        )]),
-                        "foo".to_string()
+                        .annotate(vec![StructMember::new("foo".into(), Type::FieldElement)]),
+                        "foo".into()
                     )
                     .into())
                 );
@@ -3978,7 +3965,7 @@ mod tests {
                         .check_expression(
                             Expression::Member(
                                 box Expression::InlineStruct(
-                                    "Foo".to_string(),
+                                    "Foo".into(),
                                     vec![(
                                         "foo",
                                         Expression::FieldConstant(FieldPrime::from(42)).mock()
@@ -3988,7 +3975,7 @@ mod tests {
                                 "bar".into()
                             )
                             .mock(),
-                            &MODULE_ID.to_string(),
+                            &MODULE_ID.into(),
                             &state.types
                         )
                         .unwrap_err()
@@ -4018,14 +4005,14 @@ mod tests {
                     checker
                         .check_expression(
                             Expression::InlineStruct(
-                                "Bar".to_string(),
+                                "Bar".into(),
                                 vec![(
                                     "foo",
                                     Expression::FieldConstant(FieldPrime::from(42)).mock()
                                 )]
                             )
                             .mock(),
-                            &MODULE_ID.to_string(),
+                            &MODULE_ID.into(),
                             &state.types
                         )
                         .unwrap_err()
@@ -4059,7 +4046,7 @@ mod tests {
                 assert_eq!(
                     checker.check_expression(
                         Expression::InlineStruct(
-                            "Foo".to_string(),
+                            "Foo".into(),
                             vec![
                                 (
                                     "foo",
@@ -4069,7 +4056,7 @@ mod tests {
                             ]
                         )
                         .mock(),
-                        &MODULE_ID.to_string(),
+                        &MODULE_ID.into(),
                         &state.types
                     ),
                     Ok(StructExpressionInner::Value(vec![
@@ -4077,8 +4064,8 @@ mod tests {
                         BooleanExpression::Value(true).into()
                     ])
                     .annotate(vec![
-                        StructMember::new("foo".to_string(), Type::FieldElement),
-                        StructMember::new("bar".to_string(), Type::Boolean)
+                        StructMember::new("foo".into(), Type::FieldElement),
+                        StructMember::new("bar".into(), Type::Boolean)
                     ])
                     .into())
                 );
@@ -4109,7 +4096,7 @@ mod tests {
                 assert_eq!(
                     checker.check_expression(
                         Expression::InlineStruct(
-                            "Foo".to_string(),
+                            "Foo".into(),
                             vec![
                                 ("bar", Expression::BooleanConstant(true).mock()),
                                 (
@@ -4119,7 +4106,7 @@ mod tests {
                             ]
                         )
                         .mock(),
-                        &MODULE_ID.to_string(),
+                        &MODULE_ID.into(),
                         &state.types
                     ),
                     Ok(StructExpressionInner::Value(vec![
@@ -4127,8 +4114,8 @@ mod tests {
                         BooleanExpression::Value(true).into()
                     ])
                     .annotate(vec![
-                        StructMember::new("foo".to_string(), Type::FieldElement),
-                        StructMember::new("bar".to_string(), Type::Boolean)
+                        StructMember::new("foo".into(), Type::FieldElement),
+                        StructMember::new("bar".into(), Type::Boolean)
                     ])
                     .into())
                 );
@@ -4160,14 +4147,14 @@ mod tests {
                     checker
                         .check_expression(
                             Expression::InlineStruct(
-                                "Foo".to_string(),
+                                "Foo".into(),
                                 vec![(
                                     "foo",
                                     Expression::FieldConstant(FieldPrime::from(42)).mock()
                                 )]
                             )
                             .mock(),
-                            &MODULE_ID.to_string(),
+                            &MODULE_ID.into(),
                             &state.types
                         )
                         .unwrap_err()
@@ -4204,7 +4191,7 @@ mod tests {
                     checker
                         .check_expression(
                             Expression::InlineStruct(
-                                "Foo".to_string(),
+                                "Foo".into(),
                                 vec![(
                                     "baz",
                                     Expression::BooleanConstant(true).mock()
@@ -4214,7 +4201,7 @@ mod tests {
                                 )]
                             )
                             .mock(),
-                            &MODULE_ID.to_string(),
+                            &MODULE_ID.into(),
                             &state.types
                         ).unwrap_err()
                         .message,
@@ -4225,7 +4212,7 @@ mod tests {
                     checker
                         .check_expression(
                             Expression::InlineStruct(
-                                "Foo".to_string(),
+                                "Foo".into(),
                                 vec![
                                     (
                                         "bar",
@@ -4238,7 +4225,7 @@ mod tests {
                                 ]
                             )
                             .mock(),
-                            &MODULE_ID.to_string(),
+                            &MODULE_ID.into(),
                             &state.types
                         )
                         .unwrap_err()
@@ -4258,7 +4245,7 @@ mod tests {
             let a = Assignee::Identifier::<FieldPrime>("a").mock();
 
             let types = HashMap::new();
-            let module_id = String::from("");
+            let module_id = "".into();
             let mut checker: Checker = Checker::new();
             checker
                 .check_statement::<FieldPrime>(
@@ -4292,7 +4279,7 @@ mod tests {
             .mock();
 
             let types = HashMap::new();
-            let module_id = String::from("");
+            let module_id = "".into();
 
             let mut checker: Checker = Checker::new();
             checker
@@ -4341,7 +4328,7 @@ mod tests {
             .mock();
 
             let types = HashMap::new();
-            let module_id = String::from("");
+            let module_id = "".into();
             let mut checker: Checker = Checker::new();
             checker
                 .check_statement::<FieldPrime>(

--- a/zokrates_core/src/static_analysis/propagate_unroll.rs
+++ b/zokrates_core/src/static_analysis/propagate_unroll.rs
@@ -78,7 +78,7 @@ mod tests {
 
         let p = TypedProgram {
             modules: vec![(
-                "main".to_string(),
+                "main".into(),
                 TypedModule {
                     functions: vec![(
                         FunctionKey::with_id("main"),
@@ -94,7 +94,7 @@ mod tests {
             )]
             .into_iter()
             .collect(),
-            main: "main".to_string(),
+            main: "main".into(),
         };
 
         assert!(PropagatedUnroller::unroll(p).is_err());
@@ -203,7 +203,7 @@ mod tests {
 
         let p = TypedProgram {
             modules: vec![(
-                "main".to_string(),
+                "main".into(),
                 TypedModule {
                     functions: vec![(
                         FunctionKey::with_id("main"),
@@ -219,11 +219,12 @@ mod tests {
             )]
             .into_iter()
             .collect(),
-            main: "main".to_string(),
+            main: "main".into(),
         };
 
-        let statements = match PropagatedUnroller::unroll(p).unwrap().modules["main"].functions
-            [&FunctionKey::with_id("main")]
+        let statements = match PropagatedUnroller::unroll(p).unwrap().modules
+            [std::path::Path::new("main")]
+        .functions[&FunctionKey::with_id("main")]
             .clone()
         {
             TypedFunctionSymbol::Here(f) => f.statements,

--- a/zokrates_core/src/typed_absy/abi.rs
+++ b/zokrates_core/src/typed_absy/abi.rs
@@ -69,10 +69,10 @@ mod tests {
         );
 
         let mut modules = HashMap::new();
-        modules.insert(String::from("main"), TypedModule { functions });
+        modules.insert("main".into(), TypedModule { functions });
 
         let typed_ast: TypedProgram<FieldPrime> = TypedProgram {
-            main: String::from("main"),
+            main: "main".into(),
             modules,
         };
 

--- a/zokrates_core/src/typed_absy/mod.rs
+++ b/zokrates_core/src/typed_absy/mod.rs
@@ -14,6 +14,7 @@ mod variable;
 pub use crate::typed_absy::parameter::Parameter;
 pub use crate::typed_absy::types::{Signature, Type};
 pub use crate::typed_absy::variable::Variable;
+use std::path::PathBuf;
 
 use crate::typed_absy::types::{FunctionKey, MemberId};
 use embed::FlatEmbed;
@@ -38,7 +39,7 @@ pub struct Identifier<'ast> {
 }
 
 /// An identifier for a `TypedModule`. Typically a path or uri.
-pub type TypedModuleId = String;
+pub type TypedModuleId = PathBuf;
 
 /// A collection of `TypedModule`s
 pub type TypedModules<'ast, T> = HashMap<TypedModuleId, TypedModule<'ast, T>>;
@@ -90,7 +91,7 @@ impl<'ast, T: Field> fmt::Display for TypedProgram<'ast, T> {
             writeln!(
                 f,
                 "| {}: |{}",
-                module_id,
+                module_id.display(),
                 if *module_id == self.main {
                     "<---- main"
                 } else {
@@ -123,7 +124,12 @@ impl<'ast> fmt::Display for Identifier<'ast> {
                 "{}_{}_{}",
                 self.stack
                     .iter()
-                    .map(|(name, sig, count)| format!("{}_{}_{}", name, sig.to_slug(), count))
+                    .map(|(name, sig, count)| format!(
+                        "{}_{}_{}",
+                        name.display(),
+                        sig.to_slug(),
+                        count
+                    ))
                     .collect::<Vec<_>>()
                     .join("_"),
                 self.id,
@@ -189,7 +195,10 @@ impl<'ast, T: Field> fmt::Display for TypedModule<'ast, T> {
                 TypedFunctionSymbol::Here(ref function) => format!("def {}{}", key.id, function),
                 TypedFunctionSymbol::There(ref fun_key, ref module_id) => format!(
                     "import {} from \"{}\" as {} // with signature {}",
-                    fun_key.id, module_id, key.id, key.signature
+                    fun_key.id,
+                    module_id.display(),
+                    key.id,
+                    key.signature
                 ),
                 TypedFunctionSymbol::Flat(ref flat_fun) => {
                     format!("def {}{}:\n\t// hidden", key.id, flat_fun.signature::<T>())

--- a/zokrates_core_test/tests/tests/import/dep/foo.zok
+++ b/zokrates_core_test/tests/tests/import/dep/foo.zok
@@ -1,4 +1,4 @@
-from "./dep/foo.zok" import foo as bar
+from "./dep/foo" import foo as bar
 
 def foo() -> (field):
 	return 2 + bar()

--- a/zokrates_core_test/tests/tests/import/import.zok
+++ b/zokrates_core_test/tests/tests/import/import.zok
@@ -1,4 +1,4 @@
-from "./dep/foo.zok" import foo
+from "./dep/foo" import foo
 
 def main() -> (field):
 	return foo()

--- a/zokrates_fs_resolver/src/lib.rs
+++ b/zokrates_fs_resolver/src/lib.rs
@@ -14,12 +14,6 @@ pub fn resolve<'a>(
     current_location: CurrentLocation,
     import_location: ImportLocation<'a>,
 ) -> Result<(SourceCode, CurrentLocation), io::Error> {
-    println!(
-        "get file {} {}",
-        current_location.display(),
-        import_location.display()
-    );
-
     let source = Path::new(&import_location);
 
     // paths starting with `./` or `../` are interpreted relative to the current file

--- a/zokrates_fs_resolver/src/lib.rs
+++ b/zokrates_fs_resolver/src/lib.rs
@@ -54,32 +54,31 @@ mod tests {
         let file_path = folder.path().join("bar.zok");
         let mut file = File::create(file_path).unwrap();
         writeln!(file, "some code").unwrap();
-        let (_, next_location) =
-            resolve(folder.path().to_str().unwrap().to_string(), "./bar".into()).unwrap();
-        assert_eq!(next_location, folder.path().to_str().unwrap().to_string());
+        let (_, next_location) = resolve(folder.path().to_path_buf(), "./bar".into()).unwrap();
+        assert_eq!(next_location, folder.path());
     }
 
     #[test]
     fn non_existing_file() {
-        let res = resolve(String::from("./src"), "./rubbish".into());
+        let res = resolve("./src".into(), "./rubbish".into());
         assert!(res.is_err());
     }
 
     #[test]
     fn invalid_location() {
-        let res = resolve(String::from(",8!-$2abc"), "./foo".into());
+        let res = resolve(",8!-$2abc".into(), "./foo".into());
         assert!(res.is_err());
     }
 
     #[test]
     fn not_a_file() {
-        let res = resolve(String::from("."), "./src/".into());
+        let res = resolve(".".into(), "./src/".into());
         assert!(res.is_err());
     }
 
     #[test]
     fn no_parent() {
-        let res = resolve(String::from("."), ".".into());
+        let res = resolve(".".into(), ".".into());
         assert!(res.is_err());
     }
 
@@ -102,14 +101,7 @@ mod tests {
         // assign HOME folder to ZOKRATES_HOME
         std::env::set_var(ZOKRATES_HOME, zokrates_home_folder.path());
 
-        let result = resolve(
-            source_folder
-                .path()
-                .to_path_buf()
-                .to_string_lossy()
-                .to_string(),
-            "./bar.zok".into(),
-        );
+        let result = resolve(source_folder.path().to_path_buf(), "./bar.zok".into());
         assert!(result.is_ok());
         // the imported file should be the user's
         assert_eq!(result.unwrap().0, String::from("<user code>\n"));
@@ -134,14 +126,7 @@ mod tests {
         // assign HOME folder to ZOKRATES_HOME
         std::env::set_var(ZOKRATES_HOME, zokrates_home_folder.path());
 
-        let result = resolve(
-            source_folder
-                .path()
-                .to_path_buf()
-                .to_string_lossy()
-                .to_string(),
-            "bar.zok".into(),
-        );
+        let result = resolve(source_folder.path().to_path_buf(), "bar.zok".into());
         assert!(result.is_ok());
         // the imported file should be the user's
         assert_eq!(result.unwrap().0, String::from("<stdlib code>\n"));
@@ -158,14 +143,7 @@ mod tests {
         let mut file = File::create(file_path).unwrap();
         writeln!(file, "<user code>").unwrap();
 
-        let result = resolve(
-            source_subfolder
-                .path()
-                .to_path_buf()
-                .to_string_lossy()
-                .to_string(),
-            "../bar.zok".into(),
-        );
+        let result = resolve(source_subfolder.path().to_path_buf(), "../bar.zok".into());
         assert!(result.is_ok());
         // the imported file should be the user's
         assert_eq!(result.unwrap().0, String::from("<user code>\n"));
@@ -184,14 +162,14 @@ mod tests {
         // assign HOME folder to ZOKRATES_HOME
         std::env::set_var(ZOKRATES_HOME, zokrates_home_folder.path());
 
-        let result = resolve("/path/to/user/folder".to_string(), "./bar.zok".into());
+        let result = resolve("/path/to/user/folder".into(), "./bar.zok".into());
         assert!(result.is_err());
     }
 
     #[test]
     fn fail_if_not_found_in_std() {
         std::env::set_var(ZOKRATES_HOME, "");
-        let result = resolve("/path/to/source".to_string(), "bar.zok".into());
+        let result = resolve("/path/to/source".into(), "bar.zok".into());
         assert!(result.is_err());
     }
 
@@ -199,6 +177,6 @@ mod tests {
     #[should_panic]
     fn panic_if_home_not_set() {
         std::env::remove_var(ZOKRATES_HOME);
-        let _ = resolve("/path/to/source".to_string(), "bar.zok".into());
+        let _ = resolve("/path/to/source".into(), "bar.zok".into());
     }
 }

--- a/zokrates_fs_resolver/src/lib.rs
+++ b/zokrates_fs_resolver/src/lib.rs
@@ -19,11 +19,15 @@ type SourceCode = String;
 /// * `current_location` - Path to the file we're importing into
 /// * `import_location` - Path to the file we're importing from
 ///
+/// # Returns
+/// * The content of the file we're importing from
+/// * The path to the file we're importing from
+///
 /// # Remarks
 ///
 /// * `current_location* must point to a file
-/// * `import_location` is relative to the directory in which `current_location` is, unless it's an absolute
-/// path, in which case it's relative to the root of the ZoKrates stdlib at `$ZOKRATES_HOME`
+/// * `import_location` and the returned path are both relative to the directory in which `current_location` is, unless it's an absolute
+/// path, in which case they are relative to the root of the ZoKrates stdlib at `$ZOKRATES_HOME`
 ///
 pub fn resolve<'a>(
     current_location: CurrentLocation,

--- a/zokrates_fs_resolver/src/lib.rs
+++ b/zokrates_fs_resolver/src/lib.rs
@@ -12,29 +12,57 @@ type CurrentLocation = PathBuf;
 type ImportLocation<'a> = PathBuf;
 type SourceCode = String;
 
+/// Returns the source code and the new location from a file path and import path
+///
+/// # Arguments
+///
+/// * `current_location` - Path to the file we're importing into
+/// * `import_location` - Path to the file we're importing from
+///
+/// # Remarks
+///
+/// * `current_location* must point to a file
+/// * `import_location` is relative to the directory in which `current_location` is, unless it's an absolute
+/// path, in which case it's relative to the root of the ZoKrates stdlib at `$ZOKRATES_HOME`
+///
 pub fn resolve<'a>(
     current_location: CurrentLocation,
     import_location: ImportLocation<'a>,
 ) -> Result<(SourceCode, CurrentLocation), io::Error> {
     let source = Path::new(&import_location);
 
+    if !current_location.is_file() {
+        return Err(io::Error::new(
+            io::ErrorKind::Other,
+            format!("{} was expected to be a file", current_location.display()),
+        ));
+    }
+
     // paths starting with `./` or `../` are interpreted relative to the current file
     // other paths `abc/def` are interpreted relative to $ZOKRATES_HOME
     let base = match source.components().next() {
         Some(Component::CurDir) | Some(Component::ParentDir) => {
-            PathBuf::from(current_location).parent().unwrap().into()
+            Ok(PathBuf::from(current_location).parent().unwrap().into())
         }
-        _ => PathBuf::from(
-            std::env::var(ZOKRATES_HOME).expect("$ZOKRATES_HOME is not set, please set it"),
-        ),
-    };
+        _ => std::env::var(ZOKRATES_HOME)
+            .map_err(|_| {
+                io::Error::new(
+                    io::ErrorKind::Other,
+                    "$ZOKRATES_HOME is not set, please set it",
+                )
+            })
+            .map(PathBuf::from),
+    }?;
 
     let path_owned = base
-        .join(PathBuf::from(import_location))
+        .join(PathBuf::from(import_location.clone()))
         .with_extension("zok");
 
-    if path_owned.is_dir() {
-        return Err(io::Error::new(io::ErrorKind::Other, "Not a file"));
+    if !path_owned.is_file() {
+        return Err(io::Error::new(
+            io::ErrorKind::Other,
+            format!("No file found at {}", import_location.display()),
+        ));
     }
 
     let source = read_to_string(&path_owned)?;
@@ -150,6 +178,8 @@ mod tests {
         let file_path = source_folder.path().join("bar.zok");
         let mut file = File::create(file_path).unwrap();
         writeln!(file, "<user code>").unwrap();
+        let origin_path = source_subfolder.path().join("foo.zok");
+        File::create(origin_path).unwrap();
 
         let result = resolve(
             source_subfolder.path().to_path_buf().join("foo.zok"),
@@ -185,9 +215,9 @@ mod tests {
     }
 
     #[test]
-    #[should_panic]
     fn panic_if_home_not_set() {
         std::env::remove_var(ZOKRATES_HOME);
-        let _ = resolve("/path/to/source.zok".into(), "bar.zok".into());
+        let result = resolve("/path/to/source.zok".into(), "bar.zok".into());
+        assert!(result.is_err());
     }
 }


### PR DESCRIPTION
Imports aren't processed correctly in some cases involving different files having the same relative paths: one file ends up overwriting the other when resolving imports, which leads to a semantic-time panic.

Add test.
Fix this.

Also, since semantic checks happen on the whole tree rather than a single file, errors found in dependencies were wrongly linked back to the entry point file. Fix this.