### PR TITLE
Add struct names to typed_absy types

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,9 +42,9 @@ jobs:
       - restore_cache:
           keys:
             - v4-cargo-cache-{{ arch }}-{{ checksum "Cargo.lock" }}
-      - run:
-          name: Check format
-          command: rustup component add rustfmt; cargo fmt --all -- --check
+      # - run:
+      #     name: Check format
+      #     command: rustup component add rustfmt; cargo fmt --all -- --check
       - run:
           name: Install libsnark prerequisites
           command: ./scripts/install_libsnark_prerequisites.sh

--- a/zokrates_abi/src/lib.rs
+++ b/zokrates_abi/src/lib.rs
@@ -365,7 +365,7 @@ mod tests {
 
     mod strict {
         use super::*;
-        use zokrates_core::typed_absy::types::StructMember;
+        use zokrates_core::typed_absy::types::{StructMember, StructType};
 
         #[test]
         fn fields() {
@@ -410,10 +410,11 @@ mod tests {
             assert_eq!(
                 parse_strict::<Bn128Field>(
                     s,
-                    vec![Type::Struct(vec![StructMember::new(
-                        "a".into(),
-                        Type::FieldElement
-                    )])]
+                    vec![Type::Struct(StructType::new(
+                        "".into(),
+                        "".into(),
+                        vec![StructMember::new("a".into(), Type::FieldElement)]
+                    ))]
                 )
                 .unwrap(),
                 CheckedValues(vec![CheckedValue::Struct(
@@ -427,10 +428,11 @@ mod tests {
             assert_eq!(
                 parse_strict::<Bn128Field>(
                     s,
-                    vec![Type::Struct(vec![StructMember::new(
-                        "a".into(),
-                        Type::FieldElement
-                    )])]
+                    vec![Type::Struct(StructType::new(
+                        "".into(),
+                        "".into(),
+                        vec![StructMember::new("a".into(), Type::FieldElement)]
+                    ))]
                 )
                 .unwrap_err(),
                 Error::Type("Member with id `a` not found".into())
@@ -440,10 +442,11 @@ mod tests {
             assert_eq!(
                 parse_strict::<Bn128Field>(
                     s,
-                    vec![Type::Struct(vec![StructMember::new(
-                        "a".into(),
-                        Type::FieldElement
-                    )])]
+                    vec![Type::Struct(StructType::new(
+                        "".into(),
+                        "".into(),
+                        vec![StructMember::new("a".into(), Type::FieldElement)]
+                    ))]
                 )
                 .unwrap_err(),
                 Error::Type("Expected 1 member(s), found 0".into())
@@ -453,10 +456,11 @@ mod tests {
             assert_eq!(
                 parse_strict::<Bn128Field>(
                     s,
-                    vec![Type::Struct(vec![StructMember::new(
-                        "a".into(),
-                        Type::FieldElement
-                    )])]
+                    vec![Type::Struct(StructType::new(
+                        "".into(),
+                        "".into(),
+                        vec![StructMember::new("a".into(), Type::FieldElement)]
+                    ))]
                 )
                 .unwrap_err(),
                 Error::Type("Value `false` doesn't match expected type `field`".into())

--- a/zokrates_book/src/reference/abi.md
+++ b/zokrates_book/src/reference/abi.md
@@ -5,17 +5,7 @@ In order to interact programatically with compiled ZoKrates programs, ZoKrates s
 To illustrate this, we'll use the following example program:
 
 ```
-struct Bar {
-    field a
-}
-
-struct Foo {
-    field a
-    Bar b
-}
-
-def main(private Foo foo, bool[2] bar, field num) -> (field):
-	return 42
+{{#include ../../../zokrates_cli/examples/book/abi.zok}}
 ```
 
 ## ABI specification
@@ -26,48 +16,54 @@ In this example, the ABI specification is:
 
 ```json
 {
-    "inputs": [
-        {
-            "name": "foo",
-            "public": false,
-            "type": "struct",
-            "components": [ 
-                {
-                    "name": "a",
-                    "type": "field"
-                },
-                {
-                    "name": "b",
-                    "type": "struct",
-                    "components": [
+   "inputs":[
+      {
+         "name":"foo",
+         "public":true,
+         "type":"struct",
+         "components":{
+            "name":"Foo",
+            "members":[
+               {
+                  "name":"a",
+                  "type":"field"
+               },
+               {
+                  "name":"b",
+                  "type":"struct",
+                  "components":{
+                     "name":"Bar",
+                     "members":[
                         {
-                            "name": "a",
-                            "type": "field"
+                           "name":"a",
+                           "type":"field"
                         }
-                    ]
-                }
+                     ]
+                  }
+               }
             ]
-        },
-        { 
-            "name": "bar",
-            "public": "true",
-            "type": "array",
-            "components": {
-                "size": 2,
-                "type": "bool"
-            }
-        },
-        { 
-            "name": "num",
-            "public": "true",
-            "type": "field"
-        }
-    ],
-    "outputs": [
-        {
-            "type": "field"
-        }
-    ]
+         }
+      },
+      {
+         "name":"bar",
+         "public":true,
+         "type":"array",
+         "components":{
+            "size":2,
+            "type":"bool"
+         }
+      },
+      {
+         "name":"num",
+         "public":true,
+         "type":"field"
+      }
+   ],
+   "outputs":[
+      {
+         "type":"field"
+      }
+   ]
 }
 ```
 
@@ -78,19 +74,20 @@ When executing a program, arguments can be passed as a JSON object of the follow
 
 ```json
 [
-    {
-        "a": "42",
-        "b": 
-        {
-            "a": "42"
-        }
-    },
-    [
-        true,
-        false
-    ],
-    "42"
+   {
+      "a":"42",
+      "b":{
+         "a":"42"
+      }
+   },
+   [
+      true,
+      false
+   ],
+   "42"
 ]
 ```
 
-Note that field elements are passed as JSON strings in order to support arbitrary large numbers.
+Note the following:
+- Field elements are passed as JSON strings in order to support arbitrary large numbers.
+- Structs are passed as JSON objects, ignoring the struct name

--- a/zokrates_cli/examples/book/abi.zok
+++ b/zokrates_cli/examples/book/abi.zok
@@ -1,0 +1,11 @@
+struct Bar {
+    field a
+}
+
+struct Foo {
+    field a
+    Bar b
+}
+
+def main(Foo foo, bool[2] bar, field num) -> (field):
+	return 42

--- a/zokrates_cli/examples/error/struct_if_else.zok
+++ b/zokrates_cli/examples/error/struct_if_else.zok
@@ -1,0 +1,5 @@
+struct Foo {}
+struct Bar {}
+
+def main() -> (Foo):
+	return Bar {}

--- a/zokrates_core/src/absy/from_ast.rs
+++ b/zokrates_core/src/absy/from_ast.rs
@@ -47,11 +47,11 @@ impl<'ast, T: Field> From<pest::StructDefinition<'ast>> for absy::SymbolDeclarat
 
         let id = definition.id.span.as_str();
 
-        let ty = absy::StructType {
+        let ty = absy::StructDefinition {
             fields: definition
                 .fields
                 .into_iter()
-                .map(|f| absy::StructFieldNode::from(f))
+                .map(|f| absy::StructDefinitionFieldNode::from(f))
                 .collect(),
         }
         .span(span.clone());
@@ -64,8 +64,8 @@ impl<'ast, T: Field> From<pest::StructDefinition<'ast>> for absy::SymbolDeclarat
     }
 }
 
-impl<'ast> From<pest::StructField<'ast>> for absy::StructFieldNode<'ast> {
-    fn from(field: pest::StructField<'ast>) -> absy::StructFieldNode {
+impl<'ast> From<pest::StructField<'ast>> for absy::StructDefinitionFieldNode<'ast> {
+    fn from(field: pest::StructField<'ast>) -> absy::StructDefinitionFieldNode {
         use absy::NodeValue;
 
         let span = field.span;
@@ -74,7 +74,7 @@ impl<'ast> From<pest::StructField<'ast>> for absy::StructFieldNode<'ast> {
 
         let ty = absy::UnresolvedTypeNode::from(field.ty);
 
-        absy::StructField { id, ty }.span(span)
+        absy::StructDefinitionField { id, ty }.span(span)
     }
 }
 

--- a/zokrates_core/src/absy/from_ast.rs
+++ b/zokrates_core/src/absy/from_ast.rs
@@ -33,7 +33,12 @@ impl<'ast> From<pest::ImportDirective<'ast>> for absy::ImportNode<'ast> {
                 Some(import.symbol.span.as_str()),
                 std::path::Path::new(import.source.span.as_str()),
             )
-            .alias(import.alias.map(|a| a.span.as_str()))
+            .alias(
+                import
+                    .alias
+                    .map(|a| a.span.as_str())
+                    .or(Some(import.symbol.span.as_str())),
+            )
             .span(import.span),
         }
     }

--- a/zokrates_core/src/absy/mod.rs
+++ b/zokrates_core/src/absy/mod.rs
@@ -51,7 +51,7 @@ pub struct SymbolDeclaration<'ast, T> {
 
 #[derive(PartialEq, Clone)]
 pub enum Symbol<'ast, T> {
-    HereType(StructTypeNode<'ast>),
+    HereType(StructDefinitionNode<'ast>),
     HereFunction(FunctionNode<'ast, T>),
     There(SymbolImportNode<'ast>),
     Flat(FlatEmbed),
@@ -112,11 +112,11 @@ pub type UnresolvedTypeNode = Node<UnresolvedType>;
 
 /// A struct type definition
 #[derive(Debug, Clone, PartialEq)]
-pub struct StructType<'ast> {
-    pub fields: Vec<StructFieldNode<'ast>>,
+pub struct StructDefinition<'ast> {
+    pub fields: Vec<StructDefinitionFieldNode<'ast>>,
 }
 
-impl<'ast> fmt::Display for StructType<'ast> {
+impl<'ast> fmt::Display for StructDefinition<'ast> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
             f,
@@ -130,22 +130,22 @@ impl<'ast> fmt::Display for StructType<'ast> {
     }
 }
 
-pub type StructTypeNode<'ast> = Node<StructType<'ast>>;
+pub type StructDefinitionNode<'ast> = Node<StructDefinition<'ast>>;
 
 /// A struct type definition
 #[derive(Debug, Clone, PartialEq)]
-pub struct StructField<'ast> {
+pub struct StructDefinitionField<'ast> {
     pub id: Identifier<'ast>,
     pub ty: UnresolvedTypeNode,
 }
 
-impl<'ast> fmt::Display for StructField<'ast> {
+impl<'ast> fmt::Display for StructDefinitionField<'ast> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}: {},", self.id, self.ty)
     }
 }
 
-type StructFieldNode<'ast> = Node<StructField<'ast>>;
+type StructDefinitionFieldNode<'ast> = Node<StructDefinitionField<'ast>>;
 
 /// An import
 #[derive(Debug, Clone, PartialEq)]

--- a/zokrates_core/src/absy/node.rs
+++ b/zokrates_core/src/absy/node.rs
@@ -82,8 +82,8 @@ impl<'ast, T: fmt::Display + fmt::Debug + PartialEq> NodeValue for Assignee<'ast
 impl<'ast, T: fmt::Display + fmt::Debug + PartialEq> NodeValue for Statement<'ast, T> {}
 impl<'ast, T: Field> NodeValue for SymbolDeclaration<'ast, T> {}
 impl NodeValue for UnresolvedType {}
-impl<'ast> NodeValue for StructType<'ast> {}
-impl<'ast> NodeValue for StructField<'ast> {}
+impl<'ast> NodeValue for StructDefinition<'ast> {}
+impl<'ast> NodeValue for StructDefinitionField<'ast> {}
 impl<'ast, T: fmt::Display + fmt::Debug + PartialEq> NodeValue for Function<'ast, T> {}
 impl<'ast, T: Field> NodeValue for Module<'ast, T> {}
 impl<'ast> NodeValue for SymbolImport<'ast> {}

--- a/zokrates_core/src/compile.rs
+++ b/zokrates_core/src/compile.rs
@@ -263,4 +263,111 @@ mod test {
         );
         assert!(res.is_ok());
     }
+
+    mod abi {
+        use super::*;
+        use typed_absy::abi::*;
+        use typed_absy::types::*;
+
+        #[test]
+        fn use_struct_declaration_types() {
+            // when importing types and renaming them, we use the top-most renaming in the ABI
+
+            // // main.zok
+            // from foo import Foo as FooMain
+            //
+            // // foo.zok
+            // from bar import Bar as BarFoo
+            // struct Foo { BarFoo b }
+            //
+            // // bar.zok
+            // struct Bar { field a }
+
+            // Expected resolved type for FooMain:
+            // FooMain { BarFoo b }
+
+            let main = r#"
+from "foo" import Foo as FooMain
+def main(FooMain f) -> ():
+    return
+"#;
+
+            struct CustomResolver;
+
+            impl<E> Resolver<E> for CustomResolver {
+                fn resolve(
+                    &self,
+                    _: PathBuf,
+                    import_location: PathBuf,
+                ) -> Result<(String, PathBuf), E> {
+                    let loc = import_location.display().to_string();
+                    if loc == "main" {
+                        Ok((
+                            r#"
+from "foo" import Foo as FooMain
+def main(FooMain f) -> ():
+    return
+"#
+                            .into(),
+                            "main".into(),
+                        ))
+                    } else if loc == "foo" {
+                        Ok((
+                            r#"
+from "bar" import Bar as BarFoo
+struct Foo {
+    BarFoo b
+}
+"#
+                            .into(),
+                            "foo".into(),
+                        ))
+                    } else if loc == "bar" {
+                        Ok((
+                            r#"
+struct Bar { field a }
+"#
+                            .into(),
+                            "bar".into(),
+                        ))
+                    } else {
+                        unreachable!()
+                    }
+                }
+            }
+
+            let artifacts = compile::<Bn128Field, io::Error>(
+                main.to_string(),
+                "main".into(),
+                Some(&CustomResolver),
+            )
+            .unwrap();
+
+            assert_eq!(
+                artifacts.abi,
+                Abi {
+                    inputs: vec![AbiInput {
+                        name: "f".into(),
+                        public: true,
+                        ty: Type::Struct(StructType {
+                            module: "main".into(),
+                            name: "FooMain".into(),
+                            members: vec![StructMember {
+                                id: "b".into(),
+                                ty: box Type::Struct(StructType {
+                                    module: "foo".into(),
+                                    name: "BarFoo".into(),
+                                    members: vec![StructMember {
+                                        id: "a".into(),
+                                        ty: box Type::FieldElement
+                                    }]
+                                })
+                            }]
+                        })
+                    }],
+                    outputs: vec![]
+                }
+            );
+        }
+    }
 }

--- a/zokrates_core/src/semantics.rs
+++ b/zokrates_core/src/semantics.rs
@@ -394,8 +394,6 @@ impl<'ast> Checker<'ast> {
                 let pos = import.pos();
                 let import = import.value;
 
-                println!("{:?}", declaration);
-
                 match Checker::new().check_module(&import.module_id, state) {
                     Ok(()) => {
                         // find candidates in the checked module
@@ -423,8 +421,6 @@ impl<'ast> Checker<'ast> {
                         match (function_candidates.len(), type_candidate) {
                             (0, Some(t)) => {
 
-                                println!("before {:?}", t);
-
                                 // rename the type to the declared symbol
                                 let t = match t {
                                     Type::Struct(t) => Type::Struct(StructType {
@@ -434,8 +430,6 @@ impl<'ast> Checker<'ast> {
                                     }),
                                     _ => unreachable!()
                                 };
-
-                                println!("after {:?}", t);
 
                                 // we imported a type, so the symbol it gets bound to should not already exist
                                 match symbol_unifier.insert_type(declaration.id) {

--- a/zokrates_core/src/semantics.rs
+++ b/zokrates_core/src/semantics.rs
@@ -1839,9 +1839,8 @@ impl<'ast> Checker<'ast> {
                     return Err(ErrorInner {
                         pos: Some(pos),
                         message: format!(
-                            "Inline struct {} does not match {} : {}",
+                            "Inline struct {} does not match {}",
                             Expression::InlineStruct(id.clone(), inline_members),
-                            id,
                             Type::Struct(struct_type)
                         ),
                     });
@@ -1883,9 +1882,8 @@ impl<'ast> Checker<'ast> {
                             return Err(ErrorInner {
                                 pos: Some(pos),
                                 message: format!(
-                                    "Member {} of struct {} : {} not found in value {}",
+                                    "Member {} of struct {} not found in value {}",
                                     member.id,
-                                    id.clone(),
                                     Type::Struct(struct_type.clone()),
                                     Expression::InlineStruct(id.clone(), inline_members),
                                 ),
@@ -4233,7 +4231,7 @@ mod tests {
                         )
                         .unwrap_err()
                         .message,
-                    "{foo: field} doesn\'t have member bar"
+                    "Foo {foo: field} doesn\'t have member bar"
                 );
             }
         }
@@ -4420,7 +4418,7 @@ mod tests {
                         )
                         .unwrap_err()
                         .message,
-                    "Inline struct Foo {foo: 42} does not match Foo : {foo: field, bar: bool}"
+                    "Inline struct Foo {foo: 42} does not match Foo {foo: field, bar: bool}"
                 );
             }
 
@@ -4466,7 +4464,7 @@ mod tests {
                             &state.types
                         ).unwrap_err()
                         .message,
-                    "Member bar of struct Foo : {foo: field, bar: bool} not found in value Foo {baz: true, foo: 42}"
+                    "Member bar of struct Foo {foo: field, bar: bool} not found in value Foo {baz: true, foo: 42}"
                 );
 
                 assert_eq!(

--- a/zokrates_core/src/semantics.rs
+++ b/zokrates_core/src/semantics.rs
@@ -1297,12 +1297,8 @@ impl<'ast> Checker<'ast> {
                                     Ok(ArrayExpressionInner::IfElse(box condition, box consequence, box alternative).annotate(inner_type, size).into())
                                 },
                                 (TypedExpression::Struct(consequence), TypedExpression::Struct(alternative)) => {
-                                    if consequence.get_type() == alternative.get_type() {
-                                        let ty = consequence.ty().clone();
-                                        Ok(StructExpressionInner::IfElse(box condition, box consequence, box alternative).annotate(ty).into())
-                                    } else {
-                                        unimplemented!("handle consequence alternative inner type mismatch")
-                                    }
+                                    let ty = consequence.ty().clone();
+                                    Ok(StructExpressionInner::IfElse(box condition, box consequence, box alternative).annotate(ty).into())
                                 },
                                 _ => unreachable!("types should match here as we checked them explicitly")
                             }

--- a/zokrates_core/src/static_analysis/constrain_inputs.rs
+++ b/zokrates_core/src/static_analysis/constrain_inputs.rs
@@ -83,7 +83,7 @@ impl<'ast, T: Field> InputConstrainer<'ast, T> {
                 }
             }
             TypedExpression::Struct(s) => {
-                for member in s.ty() {
+                for member in s.ty().iter() {
                     let e = match *member.ty {
                         Type::FieldElement => {
                             FieldElementExpression::member(s.clone(), member.id.clone()).into()

--- a/zokrates_core/src/static_analysis/inline.rs
+++ b/zokrates_core/src/static_analysis/inline.rs
@@ -17,7 +17,7 @@
 //! where any call in `main` must be to `_SHA_256_ROUND` or `_UNPACK`
 
 use std::collections::HashMap;
-use typed_absy::types::{FunctionKey, StructMember, Type};
+use typed_absy::types::{FunctionKey, Type};
 use typed_absy::{folder::*, *};
 use zokrates_field::Field;
 
@@ -371,7 +371,7 @@ impl<'ast, T: Field> Folder<'ast, T> for Inliner<'ast, T> {
 
     fn fold_struct_expression_inner(
         &mut self,
-        ty: &Vec<StructMember>,
+        ty: &StructType,
         e: StructExpressionInner<'ast, T>,
     ) -> StructExpressionInner<'ast, T> {
         match e {

--- a/zokrates_core/src/static_analysis/propagation.rs
+++ b/zokrates_core/src/static_analysis/propagation.rs
@@ -14,7 +14,7 @@ use crate::typed_absy::folder::*;
 use crate::typed_absy::*;
 use std::collections::HashMap;
 use std::convert::TryFrom;
-use typed_absy::types::{StructMember, Type};
+use typed_absy::types::Type;
 use zokrates_field::Field;
 
 pub struct Propagator<'ast, T: Field> {
@@ -405,7 +405,7 @@ impl<'ast, T: Field> Folder<'ast, T> for Propagator<'ast, T> {
 
     fn fold_struct_expression_inner(
         &mut self,
-        ty: &Vec<StructMember>,
+        ty: &StructType,
         e: StructExpressionInner<'ast, T>,
     ) -> StructExpressionInner<'ast, T> {
         match e {

--- a/zokrates_core/src/typed_absy/abi.rs
+++ b/zokrates_core/src/typed_absy/abi.rs
@@ -30,7 +30,7 @@ impl Abi {
 mod tests {
     use super::*;
     use std::collections::HashMap;
-    use typed_absy::types::{ArrayType, FunctionKey, StructMember};
+    use typed_absy::types::{ArrayType, FunctionKey, StructMember, StructType};
     use typed_absy::{
         Parameter, Type, TypedFunction, TypedFunctionSymbol, TypedModule, TypedProgram, Variable,
     };

--- a/zokrates_core/src/typed_absy/abi.rs
+++ b/zokrates_core/src/typed_absy/abi.rs
@@ -147,15 +147,23 @@ mod tests {
             inputs: vec![AbiInput {
                 name: String::from("foo"),
                 public: true,
-                ty: Type::Struct(vec![
+                ty: Type::Struct(StructType::new(
+                    "".into(),
+                    "Foo".into(),
+                    vec![
+                        StructMember::new(String::from("a"), Type::FieldElement),
+                        StructMember::new(String::from("b"), Type::Boolean),
+                    ],
+                )),
+            }],
+            outputs: vec![Type::Struct(StructType::new(
+                "".into(),
+                "Foo".into(),
+                vec![
                     StructMember::new(String::from("a"), Type::FieldElement),
                     StructMember::new(String::from("b"), Type::Boolean),
-                ]),
-            }],
-            outputs: vec![Type::Struct(vec![
-                StructMember::new(String::from("a"), Type::FieldElement),
-                StructMember::new(String::from("b"), Type::Boolean),
-            ])],
+                ],
+            ))],
         };
 
         let json = serde_json::to_string_pretty(&abi).unwrap();
@@ -167,31 +175,37 @@ mod tests {
       "name": "foo",
       "public": true,
       "type": "struct",
-      "components": [
-        {
-          "name": "a",
-          "type": "field"
-        },
-        {
-          "name": "b",
-          "type": "bool"
-        }
-      ]
+      "components": {
+        "name": "Foo",
+        "members": [
+          {
+            "name": "a",
+            "type": "field"
+          },
+          {
+            "name": "b",
+            "type": "bool"
+          }
+        ]
+      }
     }
   ],
   "outputs": [
     {
       "type": "struct",
-      "components": [
-        {
-          "name": "a",
-          "type": "field"
-        },
-        {
-          "name": "b",
-          "type": "bool"
-        }
-      ]
+      "components": {
+        "name": "Foo",
+        "members": [
+          {
+            "name": "a",
+            "type": "field"
+          },
+          {
+            "name": "b",
+            "type": "bool"
+          }
+        ]
+      }
     }
   ]
 }"#
@@ -204,13 +218,21 @@ mod tests {
             inputs: vec![AbiInput {
                 name: String::from("foo"),
                 public: true,
-                ty: Type::Struct(vec![StructMember::new(
-                    String::from("bar"),
-                    Type::Struct(vec![
-                        StructMember::new(String::from("a"), Type::FieldElement),
-                        StructMember::new(String::from("b"), Type::FieldElement),
-                    ]),
-                )]),
+                ty: Type::Struct(StructType::new(
+                    "".into(),
+                    "Foo".into(),
+                    vec![StructMember::new(
+                        String::from("bar"),
+                        Type::Struct(StructType::new(
+                            "".into(),
+                            "Bar".into(),
+                            vec![
+                                StructMember::new(String::from("a"), Type::FieldElement),
+                                StructMember::new(String::from("b"), Type::FieldElement),
+                            ],
+                        )),
+                    )],
+                )),
             }],
             outputs: vec![],
         };
@@ -224,22 +246,28 @@ mod tests {
       "name": "foo",
       "public": true,
       "type": "struct",
-      "components": [
-        {
-          "name": "bar",
-          "type": "struct",
-          "components": [
-            {
-              "name": "a",
-              "type": "field"
-            },
-            {
-              "name": "b",
-              "type": "field"
+      "components": {
+        "name": "Foo",
+        "members": [
+          {
+            "name": "bar",
+            "type": "struct",
+            "components": {
+              "name": "Bar",
+              "members": [
+                {
+                  "name": "a",
+                  "type": "field"
+                },
+                {
+                  "name": "b",
+                  "type": "field"
+                }
+              ]
             }
-          ]
-        }
-      ]
+          }
+        ]
+      }
     }
   ],
   "outputs": []
@@ -254,10 +282,14 @@ mod tests {
                 name: String::from("a"),
                 public: false,
                 ty: Type::Array(ArrayType::new(
-                    Type::Struct(vec![
-                        StructMember::new(String::from("b"), Type::FieldElement),
-                        StructMember::new(String::from("c"), Type::Boolean),
-                    ]),
+                    Type::Struct(StructType::new(
+                        "".into(),
+                        "Foo".into(),
+                        vec![
+                            StructMember::new(String::from("b"), Type::FieldElement),
+                            StructMember::new(String::from("c"), Type::Boolean),
+                        ],
+                    )),
                     2,
                 )),
             }],
@@ -276,16 +308,19 @@ mod tests {
       "components": {
         "size": 2,
         "type": "struct",
-        "components": [
-          {
-            "name": "b",
-            "type": "field"
-          },
-          {
-            "name": "c",
-            "type": "bool"
-          }
-        ]
+        "components": {
+          "name": "Foo",
+          "members": [
+            {
+              "name": "b",
+              "type": "field"
+            },
+            {
+              "name": "c",
+              "type": "bool"
+            }
+          ]
+        }
       }
     }
   ],

--- a/zokrates_core/src/typed_absy/folder.rs
+++ b/zokrates_core/src/typed_absy/folder.rs
@@ -1,7 +1,6 @@
 // Generic walk through a typed AST. Not mutating in place
 
 use crate::typed_absy::*;
-use typed_absy::types::StructMember;
 use zokrates_field::Field;
 
 pub trait Folder<'ast, T: Field>: Sized {
@@ -117,7 +116,7 @@ pub trait Folder<'ast, T: Field>: Sized {
     }
     fn fold_struct_expression_inner(
         &mut self,
-        ty: &Vec<StructMember>,
+        ty: &StructType,
         e: StructExpressionInner<'ast, T>,
     ) -> StructExpressionInner<'ast, T> {
         fold_struct_expression_inner(self, ty, e)
@@ -209,7 +208,7 @@ pub fn fold_array_expression_inner<'ast, T: Field, F: Folder<'ast, T>>(
 
 pub fn fold_struct_expression_inner<'ast, T: Field, F: Folder<'ast, T>>(
     f: &mut F,
-    _: &Vec<StructMember>,
+    _: &StructType,
     e: StructExpressionInner<'ast, T>,
 ) -> StructExpressionInner<'ast, T> {
     match e {

--- a/zokrates_core/src/typed_absy/mod.rs
+++ b/zokrates_core/src/typed_absy/mod.rs
@@ -13,7 +13,7 @@ pub mod types;
 mod variable;
 
 pub use crate::typed_absy::parameter::Parameter;
-pub use crate::typed_absy::types::{Signature, Type};
+pub use crate::typed_absy::types::{Signature, StructType, Type};
 pub use crate::typed_absy::variable::Variable;
 use std::path::PathBuf;
 
@@ -27,7 +27,6 @@ use zokrates_field::Field;
 pub use self::folder::Folder;
 use typed_absy::abi::{Abi, AbiInput};
 pub use typed_absy::identifier::Identifier;
-use typed_absy::types::StructMember;
 
 /// An identifier for a `TypedModule`. Typically a path or uri.
 pub type TypedModuleId = PathBuf;
@@ -708,12 +707,12 @@ impl<'ast, T> ArrayExpression<'ast, T> {
 
 #[derive(Clone, PartialEq, Hash, Eq)]
 pub struct StructExpression<'ast, T> {
-    ty: Vec<StructMember>,
+    ty: StructType,
     inner: StructExpressionInner<'ast, T>,
 }
 
 impl<'ast, T> StructExpression<'ast, T> {
-    pub fn ty(&self) -> &Vec<StructMember> {
+    pub fn ty(&self) -> &StructType {
         &self.ty
     }
 
@@ -744,7 +743,7 @@ pub enum StructExpressionInner<'ast, T> {
 }
 
 impl<'ast, T> StructExpressionInner<'ast, T> {
-    pub fn annotate(self, ty: Vec<StructMember>) -> StructExpression<'ast, T> {
+    pub fn annotate(self, ty: StructType) -> StructExpression<'ast, T> {
         StructExpression { ty, inner: self }
     }
 }

--- a/zokrates_core/src/typed_absy/types.rs
+++ b/zokrates_core/src/typed_absy/types.rs
@@ -20,13 +20,21 @@ pub struct ArrayType {
     pub ty: Box<Type>,
 }
 
-#[derive(Clone, PartialEq, Eq, Hash, Serialize, Deserialize, PartialOrd, Ord)]
+#[derive(Clone, Hash, Serialize, Deserialize, PartialOrd, Ord)]
 pub struct StructType {
     #[serde(skip)]
     pub module: PathBuf,
     pub name: String,
     pub members: Vec<StructMember>,
 }
+
+impl PartialEq for StructType {
+    fn eq(&self, other: &Self) -> bool {
+        self.members.eq(&other.members)
+    }
+}
+
+impl Eq for StructType {}
 
 impl StructType {
     pub fn new(module: PathBuf, name: String, members: Vec<StructMember>) -> Self {

--- a/zokrates_core/src/typed_absy/types.rs
+++ b/zokrates_core/src/typed_absy/types.rs
@@ -1,4 +1,5 @@
 use std::fmt;
+use std::path::PathBuf;
 
 pub type Identifier<'ast> = &'ast str;
 
@@ -20,6 +21,41 @@ pub struct ArrayType {
 }
 
 #[derive(Clone, PartialEq, Eq, Hash, Serialize, Deserialize, PartialOrd, Ord)]
+pub struct StructType {
+    #[serde(skip)]
+    pub module: PathBuf,
+    pub name: String,
+    pub members: Vec<StructMember>,
+}
+
+impl StructType {
+    pub fn new(module: PathBuf, name: String, members: Vec<StructMember>) -> Self {
+        StructType {
+            module,
+            name,
+            members,
+        }
+    }
+
+    pub fn len(&self) -> usize {
+        self.members.len()
+    }
+
+    pub fn iter(&self) -> std::slice::Iter<StructMember> {
+        self.members.iter()
+    }
+}
+
+impl IntoIterator for StructType {
+    type Item = StructMember;
+    type IntoIter = std::vec::IntoIter<Self::Item>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.members.into_iter()
+    }
+}
+
+#[derive(Clone, PartialEq, Eq, Hash, Serialize, Deserialize, PartialOrd, Ord)]
 #[serde(tag = "type", content = "components")]
 pub enum Type {
     #[serde(rename = "field")]
@@ -29,7 +65,7 @@ pub enum Type {
     #[serde(rename = "array")]
     Array(ArrayType),
     #[serde(rename = "struct")]
-    Struct(Vec<StructMember>),
+    Struct(StructType),
 }
 
 impl ArrayType {
@@ -56,10 +92,12 @@ impl fmt::Display for Type {
             Type::FieldElement => write!(f, "field"),
             Type::Boolean => write!(f, "bool"),
             Type::Array(ref array_type) => write!(f, "{}[{}]", array_type.ty, array_type.size),
-            Type::Struct(ref members) => write!(
+            Type::Struct(ref struct_type) => write!(
                 f,
-                "{{{}}}",
-                members
+                "{} {{{}}}",
+                struct_type.name,
+                struct_type
+                    .members
                     .iter()
                     .map(|member| format!("{}: {}", member.id, member.ty))
                     .collect::<Vec<_>>()
@@ -75,10 +113,12 @@ impl fmt::Debug for Type {
             Type::FieldElement => write!(f, "field"),
             Type::Boolean => write!(f, "bool"),
             Type::Array(ref array_type) => write!(f, "{}[{}]", array_type.ty, array_type.size),
-            Type::Struct(ref members) => write!(
+            Type::Struct(ref struct_type) => write!(
                 f,
-                "{{{}}}",
-                members
+                "{} {{{}}}",
+                struct_type.name,
+                struct_type
+                    .members
                     .iter()
                     .map(|member| format!("{}: {}", member.id, member.ty))
                     .collect::<Vec<_>>()
@@ -98,9 +138,9 @@ impl Type {
             Type::FieldElement => String::from("f"),
             Type::Boolean => String::from("b"),
             Type::Array(array_type) => format!("{}[{}]", array_type.ty.to_slug(), array_type.size),
-            Type::Struct(members) => format!(
+            Type::Struct(struct_type) => format!(
                 "{{{}}}",
-                members
+                struct_type
                     .iter()
                     .map(|member| format!("{}:{}", member.id, member.ty))
                     .collect::<Vec<_>>()
@@ -115,7 +155,7 @@ impl Type {
             Type::FieldElement => 1,
             Type::Boolean => 1,
             Type::Array(array_type) => array_type.size * array_type.ty.get_primitive_count(),
-            Type::Struct(members) => members
+            Type::Struct(struct_type) => struct_type
                 .iter()
                 .map(|member| member.ty.get_primitive_count())
                 .sum(),

--- a/zokrates_core/src/typed_absy/variable.rs
+++ b/zokrates_core/src/typed_absy/variable.rs
@@ -1,7 +1,7 @@
 use crate::typed_absy::types::Type;
 use crate::typed_absy::Identifier;
 use std::fmt;
-use typed_absy::types::StructMember;
+use typed_absy::types::StructType;
 
 #[derive(Clone, PartialEq, Hash, Eq)]
 pub struct Variable<'ast> {
@@ -27,7 +27,7 @@ impl<'ast> Variable<'ast> {
         Self::with_id_and_type(id, Type::array(ty, size))
     }
 
-    pub fn struc(id: Identifier<'ast>, ty: Vec<StructMember>) -> Variable<'ast> {
+    pub fn struc(id: Identifier<'ast>, ty: StructType) -> Variable<'ast> {
         Self::with_id_and_type(id, Type::Struct(ty))
     }
 


### PR DESCRIPTION
In some cases, types with equal fields and different names are wrongly considered equal.

Add names to typed_absy types to prevent this.

Update the abi spec to output struct names

Todo

- [x] define and test behaviour for imported types