### PR TITLE
precommit - exclude deleted files on git diff

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -12,7 +12,7 @@ fi
 
 files=()
 
-for file in $(git diff --name-only --cached); do
+for file in $(git diff --diff-filter=d --name-only --cached); do
     if [ ${file: -3} == ".rs" ]; then
         rustfmt +nightly --check $file &>/dev/null
         if [ $? != 0 ]; then


### PR DESCRIPTION
Added `--diff-filter=d` flag to git diff to exclude deleted files when doing rust format checking.