### PR TITLE
Put expensive optimisations behind `release` compile flag

### DIFF
--- a/zokrates_core/src/compile.rs
+++ b/zokrates_core/src/compile.rs
@@ -9,7 +9,6 @@ use imports::{self, Importer};
 use ir;
 use macros;
 use macros::process_macros;
-use optimizer::Optimize;
 use semantics::{self, Checker};
 use static_analysis::Analyse;
 use std::collections::HashMap;
@@ -141,12 +140,29 @@ impl fmt::Display for CompileErrorInner {
     }
 }
 
+#[derive(Debug, Default)]
+pub struct CompileConfig {
+    is_release: bool,
+}
+
+impl CompileConfig {
+    pub fn with_is_release(mut self, is_release: bool) -> Self {
+        self.is_release = is_release;
+        self
+    }
+
+    pub fn is_release(&self) -> bool {
+        self.is_release
+    }
+}
+
 type FilePath = PathBuf;
 
 pub fn compile<T: Field, E: Into<imports::Error>>(
     source: String,
     location: FilePath,
     resolver: Option<&dyn Resolver<E>>,
+    config: &CompileConfig,
 ) -> Result<CompilationArtifacts<T>, CompileErrors> {
     let arena = Arena::new();
 
@@ -164,7 +180,7 @@ pub fn compile<T: Field, E: Into<imports::Error>>(
     let ir_prog = ir::Prog::from(program_flattened);
 
     // optimize
-    let optimized_ir_prog = ir_prog.optimize();
+    let optimized_ir_prog = ir_prog.optimize(config);
 
     // analyse (check for unused constraints)
     let optimized_ir_prog = optimized_ir_prog.analyse();
@@ -264,6 +280,7 @@ mod test {
             source,
             "./path/to/file".into(),
             None::<&dyn Resolver<io::Error>>,
+            &CompileConfig::default(),
         );
         assert!(res.unwrap_err().0[0]
             .value()
@@ -282,6 +299,7 @@ mod test {
             source,
             "./path/to/file".into(),
             None::<&dyn Resolver<io::Error>>,
+            &CompileConfig::default(),
         );
         assert!(res.is_ok());
     }
@@ -362,6 +380,7 @@ struct Bar { field a }
                 main.to_string(),
                 "main".into(),
                 Some(&CustomResolver),
+                &CompileConfig::default(),
             )
             .unwrap();
 

--- a/zokrates_core/src/optimizer/mod.rs
+++ b/zokrates_core/src/optimizer/mod.rs
@@ -11,18 +11,19 @@ mod tautology;
 use self::duplicate::DuplicateOptimizer;
 use self::redefinition::RedefinitionOptimizer;
 use self::tautology::TautologyOptimizer;
+use compile::CompileConfig;
 
 use crate::ir::Prog;
 use zokrates_field::Field;
 
-pub trait Optimize {
-    fn optimize(self) -> Self;
-}
-
-impl<T: Field> Optimize for Prog<T> {
-    fn optimize(self) -> Self {
-        // remove redefinitions
-        let r = RedefinitionOptimizer::optimize(self);
+impl<T: Field> Prog<T> {
+    pub fn optimize(self, config: &CompileConfig) -> Self {
+        let r = if config.is_release() {
+            // remove redefinitions
+            RedefinitionOptimizer::optimize(self)
+        } else {
+            self
+        };
         // remove constraints that are always satisfied
         let r = TautologyOptimizer::optimize(r);
         // remove duplicate constraints

--- a/zokrates_core/tests/out_of_range.rs
+++ b/zokrates_core/tests/out_of_range.rs
@@ -5,7 +5,7 @@ extern crate zokrates_field;
 use std::io;
 use zokrates_common::Resolver;
 use zokrates_core::{
-    compile::{compile, CompilationArtifacts},
+    compile::{compile, CompilationArtifacts, CompileConfig},
     ir::Interpreter,
 };
 use zokrates_field::Bn128Field;
@@ -28,6 +28,7 @@ fn out_of_range() {
         source,
         "./path/to/file".into(),
         None::<&dyn Resolver<io::Error>>,
+        &CompileConfig::default(),
     )
     .unwrap();
 

--- a/zokrates_js/src/lib.rs
+++ b/zokrates_js/src/lib.rs
@@ -5,7 +5,9 @@ use std::path::PathBuf;
 use wasm_bindgen::prelude::*;
 use zokrates_abi::{parse_strict, Decode, Encode, Inputs};
 use zokrates_common::Resolver;
-use zokrates_core::compile::{compile as core_compile, CompilationArtifacts, CompileError};
+use zokrates_core::compile::{
+    compile as core_compile, CompilationArtifacts, CompileConfig, CompileError,
+};
 use zokrates_core::imports::Error;
 use zokrates_core::ir;
 use zokrates_core::proof_system::{self, ProofSystem, SolidityAbi};
@@ -104,6 +106,7 @@ pub fn compile(
         source.as_string().unwrap(),
         PathBuf::from(location.as_string().unwrap()),
         Some(&resolver),
+        &CompileConfig::default().with_is_release(true),
     )
     .map_err(|ce| {
         JsValue::from_str(&format!(

--- a/zokrates_test/src/lib.rs
+++ b/zokrates_test/src/lib.rs
@@ -75,7 +75,7 @@ fn compare<T: Field>(result: ir::ExecutionResult<T>, expected: TestResult) -> Re
 }
 
 use std::io::{BufReader, Read};
-use zokrates_core::compile::compile;
+use zokrates_core::compile::{compile, CompileConfig};
 use zokrates_fs_resolver::FileSystemResolver;
 
 pub fn test_inner(test_path: &str) {
@@ -96,7 +96,13 @@ fn compile_and_run<T: Field>(t: Tests) {
     let code = std::fs::read_to_string(&t.entry_point).unwrap();
 
     let resolver = FileSystemResolver::new();
-    let artifacts = compile::<T, _>(code, t.entry_point.clone(), Some(&resolver)).unwrap();
+    let artifacts = compile::<T, _>(
+        code,
+        t.entry_point.clone(),
+        Some(&resolver),
+        &CompileConfig::default().with_is_release(true),
+    )
+    .unwrap();
 
     let bin = artifacts.prog();
 


### PR DESCRIPTION
The redefinition optimiser accounts for most of the compilation time in many cases, due to the amount of copying required when substituting variables with linear combinations. Hence, introduce a `release` flag required to enable this optimisation. In the future, if other optimisations are deemed too expensive in development mode, the same could be applied to them.

As a side effect, introduce a `CompileConfig` struct to pass a configuration at compile time. This can be useful for example to enable sourcemaps @dark64 