### PR TITLE
Fix strip_prefix unwrapping in fmt_error

### DIFF
--- a/zokrates_cli/src/bin.rs
+++ b/zokrates_cli/src/bin.rs
@@ -271,13 +271,11 @@ fn cli_compile<T: Field>(sub_matches: &ArgMatches) -> Result<(), String> {
     reader.read_to_string(&mut source).unwrap();
 
     let fmt_error = |e: &CompileError| {
+        let file = e.file().canonicalize().unwrap();
         format!(
             "{}:{}",
-            e.file()
-                .canonicalize()
-                .unwrap()
-                .strip_prefix(std::env::current_dir().unwrap())
-                .unwrap()
+            file.strip_prefix(std::env::current_dir().unwrap())
+                .unwrap_or(file.as_path())
                 .display(),
             e.value()
         )
@@ -360,13 +358,11 @@ fn cli_check<T: Field>(sub_matches: &ArgMatches) -> Result<(), String> {
     reader.read_to_string(&mut source).unwrap();
 
     let fmt_error = |e: &CompileError| {
+        let file = e.file().canonicalize().unwrap();
         format!(
             "{}:{}",
-            e.file()
-                .canonicalize()
-                .unwrap()
-                .strip_prefix(std::env::current_dir().unwrap())
-                .unwrap()
+            file.strip_prefix(std::env::current_dir().unwrap())
+                .unwrap_or(file.as_path())
                 .display(),
             e.value()
         )


### PR DESCRIPTION
Unwraps normally if prefix is current directory path, otherwise returns canonicalized path 

Fixes issue https://github.com/Zokrates/ZoKrates/issues/625