### PR TITLE
Introduce decimal literals for uint types

### DIFF
--- a/test.zok
+++ b/test.zok
@@ -1,0 +1,2 @@
+def main(field a) -> u32:
+	return 1u32 + 0x00000001

--- a/zokrates_parser/src/lib.rs
+++ b/zokrates_parser/src/lib.rs
@@ -100,7 +100,7 @@ mod tests {
                                 expression(43, 44, [
                                     term(43, 44, [
                                         primary_expression(43, 44, [
-                                            constant(43, 44, [
+                                            literal(43, 44, [
                                                 decimal_number(43, 44)
                                             ])
                                         ])
@@ -257,7 +257,7 @@ mod tests {
                                     expression(30, 31, [
                                         term(30, 31, [
                                             primary_expression(30, 31, [
-                                                constant(30, 31, [
+                                                literal(30, 31, [
                                                     decimal_number(30, 31)
                                                 ])
                                             ])

--- a/zokrates_parser/src/zokrates.pest
+++ b/zokrates_parser/src/zokrates.pest
@@ -71,7 +71,7 @@ call_access = { "(" ~ expression_list ~ ")" }
 member_access = { "." ~ identifier }
 
 primary_expression = { identifier
-                    | constant
+                    | literal
                     }
 
 inline_struct_expression = { identifier ~ "{" ~ NEWLINE* ~ inline_struct_member_list ~ NEWLINE* ~ "}" }
@@ -82,7 +82,7 @@ inline_array_expression = { "[" ~ NEWLINE* ~ inline_array_inner ~ NEWLINE* ~ "]"
 inline_array_inner = _{(spread_or_expression ~ ("," ~ NEWLINE* ~ spread_or_expression)*)?}
 spread_or_expression = { spread | expression }
 range_or_expression = { range | expression }
-array_initializer_expression = { "[" ~ expression ~ ";" ~ constant ~ "]" }
+array_initializer_expression = { "[" ~ expression ~ ";" ~ literal ~ "]" }
 
 unary_expression = { op_unary ~ term }
 
@@ -91,13 +91,28 @@ unary_expression = { op_unary ~ term }
 assignee = { identifier ~ assignee_access* }
 assignee_access = { array_access | member_access }
 identifier = @{ ((!keyword ~ ASCII_ALPHA) | (keyword ~ (ASCII_ALPHANUMERIC | "_"))) ~ (ASCII_ALPHANUMERIC | "_")* }
-constant = { hex_number | decimal_number | boolean_literal }
+
+// Literals for all types
+
+literal = { hex_literal | decimal_literal | boolean_literal }
+
+decimal_literal = !{ decimal_number ~ decimal_suffix }
 decimal_number = @{ "0" | ASCII_NONZERO_DIGIT ~ ASCII_DIGIT* }
+decimal_suffix = { decimal_suffix_u8 | decimal_suffix_u16 | decimal_suffix_u32 | decimal_suffix_field }
+decimal_suffix_u8 = { "u8" }
+decimal_suffix_u16 = { "u16" }
+decimal_suffix_u32 = { "u32" }
+decimal_suffix_field = { "f" }
+
 boolean_literal = { "true" | "false" }
-hex_number = _{ hex_number_32 | hex_number_16 | hex_number_8 }
-hex_number_8 = @{ "0x" ~ ASCII_HEX_DIGIT{2} }
-hex_number_16 = @{ "0x" ~ ASCII_HEX_DIGIT{4} }
-hex_number_32 = @{ "0x" ~ ASCII_HEX_DIGIT{8} }
+
+hex_literal = !{ "0x" ~ hex_number }
+hex_number = { hex_number_u32 | hex_number_u16 | hex_number_u8 }
+hex_number_u8 = { ASCII_HEX_DIGIT{2} }
+hex_number_u16 = { ASCII_HEX_DIGIT{4} }
+hex_number_u32 = { ASCII_HEX_DIGIT{8} }
+
+// Operators
 
 op_or = @{"||"}
 op_and = @{"&&"}


### PR DESCRIPTION
Now:
```
u8 a = 0x01
field b = 1
```
With this change:
```
u8 a = 0x01
u8 aa = 1u8
field b = 1
field bb = 1f
```