### PR TITLE
Stop encoding call identifier counter in ssa version

### DIFF
--- a/zokrates_core/src/static_analysis/inline.rs
+++ b/zokrates_core/src/static_analysis/inline.rs
@@ -351,11 +351,14 @@ impl<'ast, T: Field> Folder<'ast, T> for Inliner<'ast, T> {
                     Err((key, expressions)) => {
                         let tys = key.signature.outputs.clone();
                         let id = Identifier {
-                            id: CoreIdentifier::Call(key.clone()),
-                            version: *self
-                                .call_count
-                                .get(&(self.module_id().clone(), key.clone()))
-                                .unwrap(),
+                            id: CoreIdentifier::Call(
+                                key.clone(),
+                                *self
+                                    .call_count
+                                    .get(&(self.module_id().clone(), key.clone()))
+                                    .unwrap(),
+                            ),
+                            version: 0,
                             stack: self.stack.clone(),
                         };
                         self.statement_buffer
@@ -388,11 +391,14 @@ impl<'ast, T: Field> Folder<'ast, T> for Inliner<'ast, T> {
                     Err((key, expressions)) => {
                         let tys = key.signature.outputs.clone();
                         let id = Identifier {
-                            id: CoreIdentifier::Call(key.clone()),
-                            version: *self
-                                .call_count
-                                .get(&(self.module_id().clone(), key.clone()))
-                                .unwrap(),
+                            id: CoreIdentifier::Call(
+                                key.clone(),
+                                *self
+                                    .call_count
+                                    .get(&(self.module_id().clone(), key.clone()))
+                                    .unwrap(),
+                            ),
+                            version: 0,
                             stack: self.stack.clone(),
                         };
                         self.statement_buffer
@@ -440,11 +446,14 @@ impl<'ast, T: Field> Folder<'ast, T> for Inliner<'ast, T> {
                     Err((embed_key, expressions)) => {
                         let tys = key.signature.outputs.clone();
                         let id = Identifier {
-                            id: CoreIdentifier::Call(key.clone()),
-                            version: *self
-                                .call_count
-                                .get(&(self.module_id().clone(), embed_key.clone()))
-                                .unwrap(),
+                            id: CoreIdentifier::Call(
+                                key.clone(),
+                                *self
+                                    .call_count
+                                    .get(&(self.module_id().clone(), key.clone()))
+                                    .unwrap(),
+                            ),
+                            version: 0,
                             stack: self.stack.clone(),
                         };
                         self.statement_buffer
@@ -493,11 +502,14 @@ impl<'ast, T: Field> Folder<'ast, T> for Inliner<'ast, T> {
                     Err((key, expressions)) => {
                         let tys = key.signature.outputs.clone();
                         let id = Identifier {
-                            id: CoreIdentifier::Call(key.clone()),
-                            version: *self
-                                .call_count
-                                .get(&(self.module_id().clone(), key.clone()))
-                                .unwrap(),
+                            id: CoreIdentifier::Call(
+                                key.clone(),
+                                *self
+                                    .call_count
+                                    .get(&(self.module_id().clone(), key.clone()))
+                                    .unwrap(),
+                            ),
+                            version: 0,
                             stack: self.stack.clone(),
                         };
                         self.statement_buffer
@@ -531,11 +543,14 @@ impl<'ast, T: Field> Folder<'ast, T> for Inliner<'ast, T> {
                     Err((embed_key, expressions)) => {
                         let tys = key.signature.outputs.clone();
                         let id = Identifier {
-                            id: CoreIdentifier::Call(key.clone()),
-                            version: *self
-                                .call_count
-                                .get(&(self.module_id().clone(), embed_key.clone()))
-                                .unwrap(),
+                            id: CoreIdentifier::Call(
+                                key.clone(),
+                                *self
+                                    .call_count
+                                    .get(&(self.module_id().clone(), key.clone()))
+                                    .unwrap(),
+                            ),
+                            version: 0,
                             stack: self.stack.clone(),
                         };
                         self.statement_buffer

--- a/zokrates_core/src/static_analysis/mod.rs
+++ b/zokrates_core/src/static_analysis/mod.rs
@@ -39,6 +39,7 @@ impl<'ast, T: Field> TypedProgram<'ast, T> {
     pub fn analyse(self) -> ZirProgram<'ast, T> {
         // propagated unrolling
         let r = PropagatedUnroller::unroll(self).unwrap_or_else(|e| panic!(e));
+
         // return binding
         let r = ReturnBinder::bind(r);
 

--- a/zokrates_core/src/typed_absy/identifier.rs
+++ b/zokrates_core/src/typed_absy/identifier.rs
@@ -6,7 +6,7 @@ use typed_absy::TypedModuleId;
 pub enum CoreIdentifier<'ast> {
     Source(&'ast str),
     Internal(&'static str, usize),
-    Call(FunctionKey<'ast>),
+    Call(FunctionKey<'ast>, usize),
 }
 
 impl<'ast> fmt::Display for CoreIdentifier<'ast> {
@@ -14,7 +14,7 @@ impl<'ast> fmt::Display for CoreIdentifier<'ast> {
         match self {
             CoreIdentifier::Source(s) => write!(f, "{}", s),
             CoreIdentifier::Internal(s, i) => write!(f, "#INTERNAL#_{}_{}", s, i),
-            CoreIdentifier::Call(k) => write!(f, "{}", k.to_slug()),
+            CoreIdentifier::Call(k, i) => write!(f, "{}_{}", k.to_slug(), i),
         }
     }
 }


### PR DESCRIPTION
This is a logic bug in the way we register the number of an embed call.
It's not serious now as it happens after unrolling, but by using the ssa index to register different calls to embed functions, we break the meaning of ssa: only one version of a variable should be available in a given expression

```
a = foo() + foo()
```

If `foo` is an embed function, we turn this into (ignoring memoization)

```
foo_0 = foo()
foo_1 = foo()
a = foo_0 + foo_1
```

In the last line, we access two "versions" of the identifier `foo`, which doesn't make sense.

Instead, encode the counter in the CoreIdentifier itself, as it's already done for internal identifiers.