### PR TITLE
Edits for Getting Started

### DIFF
--- a/zokrates_book/src/gettingstarted.md
+++ b/zokrates_book/src/gettingstarted.md
@@ -11,7 +11,7 @@ To write your first SNARK program, check out the ZoKrates plugin in the [Remix o
 ZoKrates is available on Dockerhub.
 
 ```bash
-docker run -ti zokrates/zokrates zokrates
+docker run zokrates/zokrates zokrates
 ```
 
 ### From source
@@ -49,15 +49,15 @@ Then run the different phases of the protocol. This is how you do it when you us
 
 ```bash
 # compile
-docker run -ti -v `pwd`:/files zokrates/zokrates /files/z compile -i root.zok
+docker run -v `pwd`:/files zokrates/zokrates /files/z compile -i root.zok
 # perform the setup phase
-docker run -ti -v `pwd`:/files zokrates/zokrates /files/z setup -b libsnark -s gm17
+docker run -v `pwd`:/files zokrates/zokrates /files/z setup -b libsnark -s gm17
 # execute the program
-docker run -ti -v `pwd`:/files zokrates/zokrates /files/z compute-witness -a 337 113569
+docker run -v `pwd`:/files zokrates/zokrates /files/z compute-witness -a 337 113569
 # generate a proof of computation
-docker run -ti -v `pwd`:/files zokrates/zokrates /files/z generate-proof -b libsnark -s gm17
+docker run -v `pwd`:/files zokrates/zokrates /files/z generate-proof -b libsnark -s gm17
 # export a solidity verifier
-zokrates export-verifier -b libsnark -s gm17
+docker run -v `pwd`:/files zokrates/zokrates /files/z export-verifier -b libsnark -s gm17
 ```
 
 The CLI commands are explained in more detail in the [CLI reference](reference/cli.md).

--- a/zokrates_book/src/gettingstarted.md
+++ b/zokrates_book/src/gettingstarted.md
@@ -11,10 +11,8 @@ To write your first SNARK program, check out the ZoKrates plugin in the [Remix o
 ZoKrates is available on Dockerhub.
 
 ```bash
-docker run -ti zokrates/zokrates /bin/bash
+docker run -ti zokrates/zokrates zokrates
 ```
-
-From there on, you can use the `zokrates` CLI.
 
 ### From source
 

--- a/zokrates_book/src/gettingstarted.md
+++ b/zokrates_book/src/gettingstarted.md
@@ -6,14 +6,6 @@
 
 To write your first SNARK program, check out the ZoKrates plugin in the [Remix online IDE](https://remix.ethereum.org)!
 
-### One-line installation
-
-We provide one-line installation for Linux, MacOS and FreeBSD:
-
-```bash
-curl -LSfs get.zokrat.es | sh
-```
-
 ### Docker
 
 ZoKrates is available on Dockerhub.

--- a/zokrates_book/src/gettingstarted.md
+++ b/zokrates_book/src/gettingstarted.md
@@ -37,19 +37,27 @@ Some observations:
 - The keyword `field` is the basic type we use, which is an element of a given prime field.
 - The keyword `private` signals that we do not want to reveal this input, but still prove that we know its value.
 
-Then run the different phases of the protocol:
+To make it easier to use `zokrates` inside docker, create this file (call it `z`):
+```bash
+#! /bin/bash
+
+cd /files
+zokrates $*
+```
+
+Then run the different phases of the protocol. This is how you do it when you use zokrates in docker.
 
 ```bash
 # compile
-zokrates compile -i root.zok
+docker run -ti -v `pwd`:/files zokrates/zokrates /files/z compile -i root.zok
 # perform the setup phase
-zokrates setup
+docker run -ti -v `pwd`:/files zokrates/zokrates /files/z setup -b libsnark -s gm17
 # execute the program
-zokrates compute-witness -a 337 113569
+docker run -ti -v `pwd`:/files zokrates/zokrates /files/z compute-witness -a 337 113569
 # generate a proof of computation
-zokrates generate-proof
+docker run -ti -v `pwd`:/files zokrates/zokrates /files/z generate-proof -b libsnark -s gm17
 # export a solidity verifier
-zokrates export-verifier
+zokrates export-verifier -b libsnark -s gm17
 ```
 
 The CLI commands are explained in more detail in the [CLI reference](reference/cli.md).


### PR DESCRIPTION
Changed to use the docker version. It makes the command line more cumbersome, but it removes the malleability warning, which I think is confusing.