### PR TITLE
Members of groth16 Proof made public.

### DIFF
--- a/zokrates_core/src/proof_system/bellman/groth16.rs
+++ b/zokrates_core/src/proof_system/bellman/groth16.rs
@@ -27,11 +27,19 @@ pub struct ProofPoints {
 }
 
 impl ProofPoints {
-    fn into_bellman<T: Field>(self) -> BellmanProof<T::BellmanEngine> {
+    pub fn into_bellman<T: Field>(self) -> BellmanProof<T::BellmanEngine> {
         BellmanProof {
             a: serialization::to_g1::<T>(self.a),
             b: serialization::to_g2::<T>(self.b),
             c: serialization::to_g1::<T>(self.c),
+        }
+    }
+
+    pub fn from_bellman<T: Field>(proof: &BellmanProof<T::BellmanEngine>) -> Self {
+        ProofPoints {
+            a: parse_g1::<T>(&proof.a),
+            b: parse_g2::<T>(&proof.b),
+            c: parse_g1::<T>(&proof.c),
         }
     }
 }
@@ -106,12 +114,7 @@ impl<T: Field> ProofSystem<T> for G16 {
         let params = Parameters::read(proving_key.as_slice(), true).unwrap();
 
         let proof = computation.clone().prove(&params);
-
-        let proof_points = ProofPoints {
-            a: parse_g1::<T>(&proof.a),
-            b: parse_g2::<T>(&proof.b),
-            c: parse_g1::<T>(&proof.c),
-        };
+        let proof_points = ProofPoints::from_bellman::<T>(&proof);
 
         let inputs = computation
             .public_inputs_values()

--- a/zokrates_core/src/proof_system/mod.rs
+++ b/zokrates_core/src/proof_system/mod.rs
@@ -40,9 +40,9 @@ impl SolidityAbi {
 
 #[derive(Serialize, Deserialize)]
 pub struct Proof<T> {
-    proof: T,
-    inputs: Vec<String>,
-    raw: Option<String>,
+    pub proof: T,
+    pub inputs: Vec<String>,
+    pub raw: Option<String>,
 }
 
 impl<T: Serialize + DeserializeOwned> Proof<T> {


### PR DESCRIPTION
I am using ZoKrates as a Rust library and need to have direct access to members of the groth16 Proof structure.

Replacement for PR 688 https://github.com/Zokrates/ZoKrates/pull/688 (moving the change from master to develop).