### PR TITLE
Bump zokrates-js version

### DIFF
--- a/zokrates_js/Cargo.lock
+++ b/zokrates_js/Cargo.lock
@@ -1175,7 +1175,7 @@ version = "0.1.0"
 
 [[package]]
 name = "zokrates_core"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "bellman_ce",
  "bincode 0.8.0",
@@ -1221,7 +1221,7 @@ dependencies = [
 
 [[package]]
 name = "zokrates_js"
-version = "1.0.25"
+version = "1.0.26"
 dependencies = [
  "bincode 1.3.1",
  "console_error_panic_hook",

--- a/zokrates_js/Cargo.toml
+++ b/zokrates_js/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zokrates_js"
-version = "1.0.25"
+version = "1.0.26"
 authors = ["Darko Macesic"]
 edition = "2018"
 

--- a/zokrates_js/package-lock.json
+++ b/zokrates_js/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "zokrates-js",
-  "version": "1.0.25",
+  "version": "1.0.26",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/zokrates_js/package.json
+++ b/zokrates_js/package.json
@@ -2,7 +2,7 @@
   "name": "zokrates-js",
   "main": "index.js",
   "author": "Darko Macesic <darem966@gmail.com>",
-  "version": "1.0.25",
+  "version": "1.0.26",
   "keywords": [
     "zokrates",
     "wasm-bindgen",


### PR DESCRIPTION
Bumped zokrates-js version from `1.0.25` to `1.0.26`. The package has been published manually.