### PR TITLE
Fix arguments and paths in one_liner.sh

### DIFF
--- a/scripts/one_liner.sh
+++ b/scripts/one_liner.sh
@@ -318,12 +318,14 @@ main() {
 
     rm -rf $td
 
-    cat <<'EOF'
+    abspath=$(cd "$(dirname "$dest")" && pwd)/$(basename "$dest")
+
+    cat <<EOF
 
 ZoKrates was installed successfully!
 If this is the first time you're installing ZoKrates run the following:
-export PATH=$PATH:$HOME/.zokrates/bin
+export PATH=\$PATH:$abspath/bin
 EOF
 }
 
-main
+main "$@" || exit 1


### PR DESCRIPTION
- Fixed an issue with script arguments not being passed to the `main` function
- Fixed export command in post-installation output to display correct absolute path