### PR TITLE
run tests in thread with bigger stack

### DIFF
--- a/zokrates_field/src/lib.rs
+++ b/zokrates_field/src/lib.rs
@@ -60,7 +60,6 @@ pub trait Field:
     + Ord
     + Display
     + Debug
-    + Send
     + Add<Self, Output = Self>
     + for<'a> Add<&'a Self, Output = Self>
     + Sub<Self, Output = Self>
@@ -151,8 +150,6 @@ mod prime_field {
             pub struct FieldPrime {
                 value: BigInt,
             }
-
-            unsafe impl Send for FieldPrime {}
 
             impl Field for FieldPrime {
                 fn bits(&self) -> u32 {

--- a/zokrates_field/src/lib.rs
+++ b/zokrates_field/src/lib.rs
@@ -60,6 +60,7 @@ pub trait Field:
     + Ord
     + Display
     + Debug
+    + Send
     + Add<Self, Output = Self>
     + for<'a> Add<&'a Self, Output = Self>
     + Sub<Self, Output = Self>
@@ -150,6 +151,8 @@ mod prime_field {
             pub struct FieldPrime {
                 value: BigInt,
             }
+
+            unsafe impl Send for FieldPrime {}
 
             impl Field for FieldPrime {
                 fn bits(&self) -> u32 {

--- a/zokrates_test/src/lib.rs
+++ b/zokrates_test/src/lib.rs
@@ -95,14 +95,24 @@ pub fn test_inner(test_path: &str) {
 
     let curves = t.curves.clone().unwrap_or(vec![Curve::Bn128]);
 
-    for c in &curves {
-        match c {
-            Curve::Bn128 => compile_and_run::<Bn128Field>(t.clone()),
-            Curve::Bls12_381 => compile_and_run::<Bls12_381Field>(t.clone()),
-            Curve::Bls12_377 => compile_and_run::<Bls12_377Field>(t.clone()),
-            Curve::Bw6_761 => compile_and_run::<Bw6_761Field>(t.clone()),
-        }
-    }
+    // this function typically runs in a spawn thread whose stack size is small, leading to stack overflows
+    // to avoid that, run the stack-heavy bit in a thread with a larger stack (8M)
+    let builder = std::thread::Builder::new().stack_size(8388608);
+
+    builder
+        .spawn(move || {
+            for c in &curves {
+                match c {
+                    Curve::Bn128 => compile_and_run::<Bn128Field>(t.clone()),
+                    Curve::Bls12_381 => compile_and_run::<Bls12_381Field>(t.clone()),
+                    Curve::Bls12_377 => compile_and_run::<Bls12_377Field>(t.clone()),
+                    Curve::Bw6_761 => compile_and_run::<Bw6_761Field>(t.clone()),
+                }
+            }
+        })
+        .unwrap()
+        .join()
+        .unwrap();
 }
 
 fn compile_and_run<T: Field>(t: Tests) {


### PR DESCRIPTION
`cargo test` without `--release` currently leads to stack overflows. It appears that this is caused by tests running in spawn threads with a default stack size much smaller than that of the main thread.

This PR spawns threads where applicable, providing a stack size of 8M.

With this change, `cargo test` runs without overflowing on my machine.