### PR TITLE
Use rng with random seed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -904,7 +904,20 @@ checksum = "fc587bc0ec293155d5bfa6b9891ec18a1e330c234f896ea47fbada4cadbe47e6"
 dependencies = [
  "cfg-if 0.1.10",
  "libc",
- "wasi",
+ "wasi 0.9.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9495705279e7140bf035dde1f6e750c162df8b625267cd52cc44e0b156732c8"
+dependencies = [
+ "cfg-if 1.0.0",
+ "js-sys",
+ "libc",
+ "wasi 0.10.2+wasi-snapshot-preview1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1431,7 +1444,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
 dependencies = [
- "getrandom",
+ "getrandom 0.1.15",
  "libc",
  "rand_chacha",
  "rand_core 0.5.1",
@@ -1469,7 +1482,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
 dependencies = [
- "getrandom",
+ "getrandom 0.1.15",
 ]
 
 [[package]]
@@ -1502,7 +1515,7 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de0737333e7a9502c789a36d7c7fa6092a49895d4faa31ca5df163857ded2e9d"
 dependencies = [
- "getrandom",
+ "getrandom 0.1.15",
  "redox_syscall",
  "rust-argon2",
 ]
@@ -1992,6 +2005,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
+name = "wasi"
+version = "0.10.2+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
+
+[[package]]
 name = "wasm-bindgen"
 version = "0.2.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2198,6 +2217,7 @@ dependencies = [
  "cmake",
  "csv",
  "ff_ce 0.9.0",
+ "getrandom 0.2.2",
  "git2",
  "hex",
  "lazy_static",

--- a/zokrates_core/Cargo.toml
+++ b/zokrates_core/Cargo.toml
@@ -32,6 +32,7 @@ zokrates_field = { version = "0.3.0", path = "../zokrates_field", default-featur
 zokrates_pest_ast = { version = "0.1.0", path = "../zokrates_pest_ast" }
 zokrates_common = { path = "../zokrates_common" }
 zokrates_embed = { path = "../zokrates_embed" }
+getrandom = { version = "0.2", features = ["js"] }
 rand_0_4 = { version = "0.4", package = "rand" }
 rand_0_7 = { version = "0.7", package = "rand" }
 csv = "1"

--- a/zokrates_core/src/proof_system/bellman/groth16.rs
+++ b/zokrates_core/src/proof_system/bellman/groth16.rs
@@ -133,10 +133,9 @@ mod serialization {
 mod tests {
     use zokrates_field::Bn128Field;
 
+    use super::*;
     use crate::flat_absy::FlatVariable;
     use crate::ir::{Function, Interpreter, Prog, Statement};
-
-    use super::*;
 
     #[test]
     fn verify() {

--- a/zokrates_core/src/proof_system/bellman/mod.rs
+++ b/zokrates_core/src/proof_system/bellman/mod.rs
@@ -162,8 +162,19 @@ impl<T: BellmanFieldExtensions + Field> Prog<T> {
 }
 
 impl<T: BellmanFieldExtensions + Field> Computation<T> {
+    fn get_random_seed(&self) -> Result<[u32; 8], getrandom::Error> {
+        let mut seed = [0u8; 32];
+        getrandom::getrandom(&mut seed)?;
+
+        use std::mem::transmute;
+        let seed: [u32; 8] = unsafe { transmute(seed) };
+        Ok(seed)
+    }
+
     pub fn prove(self, params: &Parameters<T::BellmanEngine>) -> Proof<T::BellmanEngine> {
-        let rng = &mut ChaChaRng::new_unseeded();
+        use rand_0_4::SeedableRng;
+        let seed = self.get_random_seed().unwrap();
+        let rng = &mut ChaChaRng::from_seed(seed.as_ref());
 
         let proof = create_random_proof(self.clone(), params, rng).unwrap();
 
@@ -186,7 +197,9 @@ impl<T: BellmanFieldExtensions + Field> Computation<T> {
     }
 
     pub fn setup(self) -> Parameters<T::BellmanEngine> {
-        let rng = &mut ChaChaRng::new_unseeded();
+        use rand_0_4::SeedableRng;
+        let seed = self.get_random_seed().unwrap();
+        let rng = &mut ChaChaRng::from_seed(seed.as_ref());
         // run setup phase
         generate_random_parameters(self, rng).unwrap()
     }

--- a/zokrates_core/src/proof_system/bellman/mod.rs
+++ b/zokrates_core/src/proof_system/bellman/mod.rs
@@ -167,6 +167,9 @@ impl<T: BellmanFieldExtensions + Field> Computation<T> {
         getrandom::getrandom(&mut seed)?;
 
         use std::mem::transmute;
+        // This is safe because we are just reinterpreting the bytes (u8[32] -> u32[8]),
+        // byte order or the actual content does not matter here as this is used
+        // as a random seed for the rng.
         let seed: [u32; 8] = unsafe { transmute(seed) };
         Ok(seed)
     }

--- a/zokrates_js/Cargo.lock
+++ b/zokrates_js/Cargo.lock
@@ -25,6 +25,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrayvec"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd9fd44efafa8690358b7408d253adf110036b88f55672a933f01d616ad9b1b9"
+dependencies = [
+ "nodrop",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -37,7 +46,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46254cf2fdcdf1badb5934448c1bcbe046a56537b3987d96c51a7afc5d03f293"
 dependencies = [
  "addr2line",
- "cfg-if",
+ "cfg-if 0.1.10",
  "libc",
  "miniz_oxide",
  "object",
@@ -52,7 +61,7 @@ checksum = "a5ca1343d8690bb4d62e0665116bd4f109e33a642f86908ed107d226a402b0ef"
 dependencies = [
  "bit-vec",
  "byteorder",
- "cfg-if",
+ "cfg-if 0.1.10",
  "futures",
  "num_cpus",
  "pairing_ce",
@@ -86,6 +95,17 @@ name = "bit-vec"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f0dc55f2d8a1a85650ac47858bb001b4c0dd73d79e3c455a842925e68d29cd3"
+
+[[package]]
+name = "blake2-rfc_bellman_edition"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdc60350286c7c3db13b98e91dbe5c8b6830a6821bc20af5b0c310ce94d74915"
+dependencies = [
+ "arrayvec",
+ "byteorder",
+ "constant_time_eq",
+]
 
 [[package]]
 name = "block-buffer"
@@ -145,14 +165,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
 name = "console_error_panic_hook"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8d976903543e0c48546a91908f21588a680a8c8f984df9a5d69feccb2b2a211"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "constant_time_eq"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
+
+[[package]]
+name = "crunchy"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "csv"
@@ -367,9 +405,22 @@ version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc587bc0ec293155d5bfa6b9891ec18a1e330c234f896ea47fbada4cadbe47e6"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "libc",
- "wasi",
+ "wasi 0.9.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9495705279e7140bf035dde1f6e750c162df8b625267cd52cc44e0b156732c8"
+dependencies = [
+ "cfg-if 1.0.0",
+ "js-sys",
+ "libc",
+ "wasi 0.10.2+wasi-snapshot-preview1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -435,7 +486,7 @@ version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
 ]
 
 [[package]]
@@ -458,6 +509,12 @@ checksum = "be0f75932c1f6cfae3c04000e40114adf955636e19040f9c0a2c380702aa1c7f"
 dependencies = [
  "adler",
 ]
+
+[[package]]
+name = "nodrop"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
 
 [[package]]
 name = "num"
@@ -703,7 +760,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
 dependencies = [
- "getrandom",
+ "getrandom 0.1.15",
  "libc",
  "rand_chacha",
  "rand_core 0.5.1",
@@ -741,7 +798,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
 dependencies = [
- "getrandom",
+ "getrandom 0.1.15",
 ]
 
 [[package]]
@@ -810,6 +867,23 @@ name = "ryu"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
+
+[[package]]
+name = "sapling-crypto_ce"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c4ff5309ec3e4bd800ad4ab3f71e9b76e9ea81c9f0eda6efa16008afbe440b3"
+dependencies = [
+ "bellman_ce",
+ "blake2-rfc_bellman_edition",
+ "byteorder",
+ "digest",
+ "rand 0.4.6",
+ "serde",
+ "serde_derive",
+ "sha2",
+ "tiny-keccak",
+]
 
 [[package]]
 name = "serde"
@@ -925,6 +999,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
+]
+
+[[package]]
 name = "typed-arena"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -979,12 +1062,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
+name = "wasi"
+version = "0.10.2+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
+
+[[package]]
 name = "wasm-bindgen"
 version = "0.2.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3edbcc9536ab7eababcc6d2374a0b7bfe13a2b6d562c5e07f370456b1a8f33d"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "serde",
  "serde_json",
  "wasm-bindgen-macro",
@@ -1068,7 +1157,7 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "zokrates_abi"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "serde",
  "serde_derive",
@@ -1083,13 +1172,14 @@ version = "0.1.0"
 
 [[package]]
 name = "zokrates_core"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "bellman_ce",
  "bincode 0.8.0",
- "cfg-if",
+ "cfg-if 0.1.10",
  "csv",
  "ff_ce 0.9.0",
+ "getrandom 0.2.2",
  "hex",
  "lazy_static",
  "num",
@@ -1103,8 +1193,17 @@ dependencies = [
  "serde_json",
  "typed-arena",
  "zokrates_common",
+ "zokrates_embed",
  "zokrates_field",
  "zokrates_pest_ast",
+]
+
+[[package]]
+name = "zokrates_embed"
+version = "0.1.1"
+dependencies = [
+ "bellman_ce",
+ "sapling-crypto_ce",
 ]
 
 [[package]]
@@ -1125,7 +1224,7 @@ dependencies = [
 
 [[package]]
 name = "zokrates_js"
-version = "1.0.26"
+version = "1.0.27"
 dependencies = [
  "bincode 1.3.1",
  "console_error_panic_hook",
@@ -1141,7 +1240,7 @@ dependencies = [
 
 [[package]]
 name = "zokrates_parser"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "pest",
  "pest_derive",
@@ -1149,7 +1248,7 @@ dependencies = [
 
 [[package]]
 name = "zokrates_pest_ast"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "from-pest",
  "lazy_static",

--- a/zokrates_js/package-lock.json
+++ b/zokrates_js/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "zokrates-js",
-  "version": "1.0.26",
+  "version": "1.0.27",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
Fix for issue https://github.com/Zokrates/ZoKrates/issues/632

We can use `getrandom` crate with `js` feature enabled to preserve [wasm compatibility](https://docs.rs/getrandom/0.2.2/getrandom/#webassembly-support) and generate a random seed which can be used with `ChaChaRng::from_seed(...)`

This is done because `bellman_ce` uses `rand 0.4` which seems to be not compatible with `rand 0.7` traits.