### PR TITLE
Fix serialization issue in zokrates.js

### DIFF
--- a/zokrates_js/package-lock.json
+++ b/zokrates_js/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "zokrates-js",
-  "version": "1.0.27",
+  "version": "1.0.28",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/zokrates_js/package.json
+++ b/zokrates_js/package.json
@@ -2,7 +2,7 @@
   "name": "zokrates-js",
   "main": "index.js",
   "author": "Darko Macesic <darem966@gmail.com>",
-  "version": "1.0.27",
+  "version": "1.0.28",
   "keywords": [
     "zokrates",
     "wasm-bindgen",

--- a/zokrates_js/tests/tests.js
+++ b/zokrates_js/tests/tests.js
@@ -18,11 +18,11 @@ describe('tests', function() {
                 assert.ok(artifacts !== undefined);
             })
         });
-    
+
         it('should throw on invalid code', function() {
             assert.throws(() => this.zokrates.compile(":-)"));
         });
-    
+
         it('should resolve stdlib module', function() {
             const stdlib = require('../stdlib.json');
             assert.doesNotThrow(() => {
@@ -30,7 +30,7 @@ describe('tests', function() {
                 this.zokrates.compile(code);
             });
         });
-    
+
         it('should resolve user module', function() {
             assert.doesNotThrow(() => {
                 const code = 'import "test" as test\ndef main() -> field: return test()';
@@ -59,10 +59,10 @@ describe('tests', function() {
             assert.doesNotThrow(() => {
                 const code = 'def main(private field a) -> field: return a * a';
                 const artifacts = this.zokrates.compile(code);
-    
+
                 const result = this.zokrates.computeWitness(artifacts, ["2"]);
                 const output = JSON.parse(result.output);
-    
+
                 assert.deepEqual(output, ["4"]);
             });
         });
@@ -71,7 +71,7 @@ describe('tests', function() {
             assert.throws(() => {
                 const code = 'def main(private field a) -> field: return a * a';
                 const artifacts = this.zokrates.compile(code);
-    
+
                 this.zokrates.computeWitness(artifacts, ["1", "2"]);
             });
         });
@@ -80,7 +80,7 @@ describe('tests', function() {
             assert.throws(() => {
                 const code = 'def main(private field a) -> field: return a * a';
                 const artifacts = this.zokrates.compile(code);
-    
+
                 this.zokrates.computeWitness(artifacts, [true]);
             });
         });
@@ -91,7 +91,7 @@ describe('tests', function() {
             assert.doesNotThrow(() => {
                 const code = 'def main(private field a) -> field: return a * a';
                 const artifacts = this.zokrates.compile(code);
-    
+
                 this.zokrates.setup(artifacts.program);
             });
         });
@@ -137,6 +137,7 @@ describe('tests', function() {
                 assert(this.zokrates.verify(keypair.vk, proof) == true);
             })
         });
+
         it('should fail', function() {
             assert.doesNotThrow(() => {
                 const code = 'def main(private field a) -> field: return a * a';

--- a/zokrates_js/wrapper.js
+++ b/zokrates_js/wrapper.js
@@ -46,7 +46,7 @@ module.exports = (dep) => {
             };
             const { program, abi } = zokrates.compile(source, location, callback, createConfig(config));
             return {
-                program: Array.from(program),
+                program: new Uint8Array(program),
                 abi
             }
         },
@@ -54,11 +54,12 @@ module.exports = (dep) => {
             const { vk, pk } = zokrates.setup(program);
             return {
                 vk,
-                pk: Array.from(pk)
+                pk: new Uint8Array(pk)
             };
         },
         computeWitness: (artifacts, args) => {
-            return zokrates.compute_witness(artifacts, JSON.stringify(Array.from(args)));
+            const { program, abi } = artifacts;
+            return zokrates.compute_witness(program, abi, JSON.stringify(Array.from(args)));
         },
         exportSolidityVerifier: (verificationKey, abiVersion) => {
             return zokrates.export_solidity_verifier(verificationKey, abiVersion);


### PR DESCRIPTION
Issue:

To pass `Vec<u8>` back to Rust, we used a `wasm_bindgen::JsValue` type which invokes `JSON.stringify` resulting in unsupported format for `Uint8Array` (eg. `{"0": 1, "1": 2}` instead of `[1, 2]`). Although this is useful for complex types, it is very inefficient for byte arrays and such. I've noticed it is possible to expect `&[u8]` instead which will skip this whole JSON serialization thing between JavaScript and Rust.