### PR TITLE
Wait for tests to finish running

### DIFF
--- a/zokrates_cli/src/bin.rs
+++ b/zokrates_cli/src/bin.rs
@@ -110,6 +110,8 @@ mod tests {
                     assert_eq!(res.is_err(), should_error);
                 }
             })
+            .unwrap()
+            .join()
             .unwrap();
     }
 


### PR DESCRIPTION
The tests are just creating the handler now. This is already done in `zokrates_test`. I'm a bit surprised that there is no lint catching these kinds of things...