### PR TITLE
Rename master to deploy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -134,7 +134,7 @@ workflows:
           filters:
             branches:
               only:
-                - master
+                - deploy
           requires:
             - build
             - test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
-https://github.com/Zokrates/ZoKrates/compare/master...develop
+https://github.com/Zokrates/ZoKrates/compare/latest...develop
 
 ## [0.6.4] - 2021-03-19
 ### Release

--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 # ZoKrates
 
 [![Join the chat at https://gitter.im/ZoKrates/Lobby](https://badges.gitter.im/ZoKrates/Lobby.svg)](https://gitter.im/ZoKrates/Lobby?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
-[![CircleCI master](https://img.shields.io/circleci/project/github/Zokrates/ZoKrates/master.svg?label=master)](https://circleci.com/gh/Zokrates/ZoKrates/tree/master)
 [![CircleCI develop](https://img.shields.io/circleci/project/github/Zokrates/ZoKrates/develop.svg?label=develop)](https://circleci.com/gh/Zokrates/ZoKrates/tree/develop)
 
 ZoKrates is a toolbox for zkSNARKs on Ethereum.

--- a/zokrates_book/src/rng_tutorial.md
+++ b/zokrates_book/src/rng_tutorial.md
@@ -56,9 +56,9 @@ Witness:
 Pick your own value and store it somewhere.
 
 ### Detailed explanation
-This line imports a Zokrates function from the [standard library](https://github.com/Zokrates/ZoKrates/tree/master/zokrates_stdlib/stdlib). 
+This line imports a Zokrates function from the [standard library](https://github.com/Zokrates/ZoKrates/tree/latest/zokrates_stdlib/stdlib). 
 You can see the specific function we are importing 
-[here](https://github.com/Zokrates/ZoKrates/blob/master/zokrates_stdlib/stdlib/hashes/sha256/512bit.zok). It will be
+[here](https://github.com/Zokrates/ZoKrates/blob/latest/zokrates_stdlib/stdlib/hashes/sha256/512bit.zok). It will be
 called `sha256`.
 ```javascript
 import "hashes/sha256/512bit" as sha256
@@ -80,7 +80,7 @@ def main(u32[16] hashMe) -> u32[8]:
 
 This line does several things. First, `u32[8] h` defines a variable called `h`, whose type is an array of eight 32-bit unsigned integers.
 This variable is initialized using `sha256`, the function we 
-[imported from the standard library](https://github.com/Zokrates/ZoKrates/blob/master/zokrates_stdlib/stdlib/hashes/sha256/512bit.zok).
+[imported from the standard library](https://github.com/Zokrates/ZoKrates/blob/latest/zokrates_stdlib/stdlib/hashes/sha256/512bit.zok).
 The `sha256` function expects to get two arrays of eight values each, so we use a [slice `..`](https://zokrates.github.io/language/types.html#slices)
 to divide `hashMe` into two arrays.
 


### PR DESCRIPTION
Closes #780 once 
- this is merged to develop
- `master` is renamed to `deploy`
- develop is made default on github

This uses the `latest` for cases where we currently refer to master. `deploy` is now merely used to trigger deployment.