### PR TITLE
Fail gracefully on variable shifts

### DIFF
--- a/zokrates_cli/examples/compile_errors/variable_shift.zok
+++ b/zokrates_cli/examples/compile_errors/variable_shift.zok
@@ -1,0 +1,2 @@
+def main(u32 a, u32 b) -> u32:
+    return a >> b

--- a/zokrates_core/src/flatten/mod.rs
+++ b/zokrates_core/src/flatten/mod.rs
@@ -1263,18 +1263,7 @@ impl<'ast, T: Field> Flattener<'ast, T> {
                     box FlatExpression::Sub(box new_left, box new_right),
                 ))
             }
-            UExpressionInner::LeftShift(box e, box by) => {
-                assert_eq!(by.bitwidth(), UBitwidth::B32);
-
-                let by = match by.into_inner() {
-                    UExpressionInner::Value(n) => n,
-                    by => unimplemented!(
-                        "Variable shifts are unimplemented, found {} << {}",
-                        e,
-                        by.annotate(UBitwidth::B32)
-                    ),
-                };
-
+            UExpressionInner::LeftShift(box e, by) => {
                 let e = self.flatten_uint_expression(statements_flattened, e);
 
                 let e_bits = e.bits.unwrap();
@@ -1292,18 +1281,7 @@ impl<'ast, T: Field> Flattener<'ast, T> {
                         .collect::<Vec<_>>(),
                 )
             }
-            UExpressionInner::RightShift(box e, box by) => {
-                assert_eq!(by.bitwidth(), UBitwidth::B32);
-
-                let by = match by.into_inner() {
-                    UExpressionInner::Value(n) => n,
-                    by => unimplemented!(
-                        "Variable shifts are unimplemented, found {} >> {}",
-                        e,
-                        by.annotate(UBitwidth::B32)
-                    ),
-                };
-
+            UExpressionInner::RightShift(box e, by) => {
                 let e = self.flatten_uint_expression(statements_flattened, e);
 
                 let e_bits = e.bits.unwrap();

--- a/zokrates_core/src/static_analysis/flatten_complex_types.rs
+++ b/zokrates_core/src/static_analysis/flatten_complex_types.rs
@@ -855,15 +855,23 @@ pub fn fold_uint_expression_inner<'ast, T: Field>(
         }
         typed_absy::UExpressionInner::LeftShift(box e, box by) => {
             let e = f.fold_uint_expression(e);
-            let by = f.fold_uint_expression(by);
 
-            zir::UExpressionInner::LeftShift(box e, box by)
+            let by = match by.as_inner() {
+                typed_absy::UExpressionInner::Value(by) => by,
+                _ => unreachable!("static analysis should have made sure that this is constant"),
+            };
+
+            zir::UExpressionInner::LeftShift(box e, *by as u32)
         }
         typed_absy::UExpressionInner::RightShift(box e, box by) => {
             let e = f.fold_uint_expression(e);
-            let by = f.fold_uint_expression(by);
 
-            zir::UExpressionInner::RightShift(box e, box by)
+            let by = match by.as_inner() {
+                typed_absy::UExpressionInner::Value(by) => by,
+                _ => unreachable!("static analysis should have made sure that this is constant"),
+            };
+
+            zir::UExpressionInner::RightShift(box e, *by as u32)
         }
         typed_absy::UExpressionInner::Not(box e) => {
             let e = f.fold_uint_expression(e);

--- a/zokrates_core/src/static_analysis/mod.rs
+++ b/zokrates_core/src/static_analysis/mod.rs
@@ -10,6 +10,7 @@ mod flatten_complex_types;
 mod propagation;
 mod redefinition;
 mod reducer;
+mod shift_checker;
 mod uint_optimizer;
 mod unconstrained_vars;
 mod variable_read_remover;
@@ -20,6 +21,7 @@ use self::flatten_complex_types::Flattener;
 use self::propagation::Propagator;
 use self::redefinition::RedefinitionOptimizer;
 use self::reducer::reduce_program;
+use self::shift_checker::ShiftChecker;
 use self::uint_optimizer::UintOptimizer;
 use self::unconstrained_vars::UnconstrainedVariableDetector;
 use self::variable_read_remover::VariableReadRemover;
@@ -85,6 +87,8 @@ impl<'ast, T: Field> TypedProgram<'ast, T> {
         let r = VariableReadRemover::apply(r);
         // check array accesses are in bounds
         let r = BoundsChecker::check(r).map_err(Error::from)?;
+        // detect non constant shifts
+        let r = ShiftChecker::check(r).map_err(Error::from)?;
         // convert to zir, removing complex types
         let zir = Flattener::flatten(r);
         // optimize uint expressions

--- a/zokrates_core/src/static_analysis/shift_checker.rs
+++ b/zokrates_core/src/static_analysis/shift_checker.rs
@@ -1,0 +1,55 @@
+use crate::typed_absy::TypedProgram;
+use crate::typed_absy::{
+    result_folder::fold_uint_expression_inner, result_folder::ResultFolder, UBitwidth,
+    UExpressionInner,
+};
+use zokrates_field::Field;
+pub struct ShiftChecker;
+
+impl ShiftChecker {
+    pub fn check<T: Field>(p: TypedProgram<T>) -> Result<TypedProgram<T>, Error> {
+        ShiftChecker.fold_program(p)
+    }
+}
+
+pub type Error = String;
+
+impl<'ast, T: Field> ResultFolder<'ast, T> for ShiftChecker {
+    type Error = Error;
+
+    fn fold_uint_expression_inner(
+        &mut self,
+        bitwidth: UBitwidth,
+        e: UExpressionInner<'ast, T>,
+    ) -> Result<UExpressionInner<'ast, T>, Error> {
+        match e {
+            UExpressionInner::LeftShift(box e, box by) => {
+                let e = self.fold_uint_expression(e)?;
+                let by = self.fold_uint_expression(by)?;
+
+                match by.as_inner() {
+                    UExpressionInner::Value(_) => Ok(UExpressionInner::LeftShift(box e, box by)),
+                    by => Err(format!(
+                        "Cannot shift by a variable value, found `{} << {}`",
+                        e,
+                        by.clone().annotate(UBitwidth::B32)
+                    )),
+                }
+            }
+            UExpressionInner::RightShift(box e, box by) => {
+                let e = self.fold_uint_expression(e)?;
+                let by = self.fold_uint_expression(by)?;
+
+                match by.as_inner() {
+                    UExpressionInner::Value(_) => Ok(UExpressionInner::RightShift(box e, box by)),
+                    by => Err(format!(
+                        "Cannot shift by a variable value, found `{} >> {}`",
+                        e,
+                        by.clone().annotate(UBitwidth::B32)
+                    )),
+                }
+            }
+            e => fold_uint_expression_inner(self, bitwidth, e),
+        }
+    }
+}

--- a/zokrates_core/src/zir/folder.rs
+++ b/zokrates_core/src/zir/folder.rs
@@ -308,17 +308,15 @@ pub fn fold_uint_expression_inner<'ast, T: Field, F: Folder<'ast, T>>(
 
             UExpressionInner::Or(box left, box right)
         }
-        UExpressionInner::LeftShift(box e, box by) => {
+        UExpressionInner::LeftShift(box e, by) => {
             let e = f.fold_uint_expression(e);
-            let by = f.fold_uint_expression(by);
 
-            UExpressionInner::LeftShift(box e, box by)
+            UExpressionInner::LeftShift(box e, by)
         }
-        UExpressionInner::RightShift(box e, box by) => {
+        UExpressionInner::RightShift(box e, by) => {
             let e = f.fold_uint_expression(e);
-            let by = f.fold_uint_expression(by);
 
-            UExpressionInner::RightShift(box e, box by)
+            UExpressionInner::RightShift(box e, by)
         }
         UExpressionInner::Not(box e) => {
             let e = f.fold_uint_expression(e);

--- a/zokrates_core/src/zir/uint.rs
+++ b/zokrates_core/src/zir/uint.rs
@@ -57,16 +57,14 @@ impl<'ast, T: Field> UExpression<'ast, T> {
         UExpressionInner::And(box self, box other).annotate(bitwidth)
     }
 
-    pub fn left_shift(self, by: UExpression<'ast, T>) -> UExpression<'ast, T> {
+    pub fn left_shift(self, by: u32) -> UExpression<'ast, T> {
         let bitwidth = self.bitwidth;
-        assert_eq!(by.bitwidth(), UBitwidth::B32);
-        UExpressionInner::LeftShift(box self, box by).annotate(bitwidth)
+        UExpressionInner::LeftShift(box self, by).annotate(bitwidth)
     }
 
-    pub fn right_shift(self, by: UExpression<'ast, T>) -> UExpression<'ast, T> {
+    pub fn right_shift(self, by: u32) -> UExpression<'ast, T> {
         let bitwidth = self.bitwidth;
-        assert_eq!(by.bitwidth(), UBitwidth::B32);
-        UExpressionInner::RightShift(box self, box by).annotate(bitwidth)
+        UExpressionInner::RightShift(box self, by).annotate(bitwidth)
     }
 }
 
@@ -170,8 +168,8 @@ pub enum UExpressionInner<'ast, T> {
     Xor(Box<UExpression<'ast, T>>, Box<UExpression<'ast, T>>),
     And(Box<UExpression<'ast, T>>, Box<UExpression<'ast, T>>),
     Or(Box<UExpression<'ast, T>>, Box<UExpression<'ast, T>>),
-    LeftShift(Box<UExpression<'ast, T>>, Box<UExpression<'ast, T>>),
-    RightShift(Box<UExpression<'ast, T>>, Box<UExpression<'ast, T>>),
+    LeftShift(Box<UExpression<'ast, T>>, u32),
+    RightShift(Box<UExpression<'ast, T>>, u32),
     Not(Box<UExpression<'ast, T>>),
     IfElse(
         Box<BooleanExpression<'ast, T>>,


### PR DESCRIPTION
Closes #790

Adds a static analyser step on `typed_absy` to check shifts are constant. Then typed -> zir conversion can crash if they aren't, and zir can use `u32` instead of any expression, which simplifies the uint optimizer.