### PR TITLE
Allow underscore before type suffix

### DIFF
--- a/changelogs/unreleased/800-dark64
+++ b/changelogs/unreleased/800-dark64
@@ -1,0 +1,1 @@
+Allow optional underscore before type suffix (e.g. `42_u32`)

--- a/zokrates_cli/examples/decimal_literal.zok
+++ b/zokrates_cli/examples/decimal_literal.zok
@@ -1,0 +1,4 @@
+def main() -> field:
+    field a = 1f
+    field b = 1_f // allow underscore between the literal and the suffix
+    return a + b

--- a/zokrates_parser/src/ace_mode/index.js
+++ b/zokrates_parser/src/ace_mode/index.js
@@ -45,8 +45,9 @@ ace.define("ace/mode/zokrates_highlight_rules",["require","exports","module","ac
         }, "identifier");
 
         var decimalInteger = "(?:(?:[1-9]\\d*)|(?:0))";
+        var decimalSuffix = "(?:_?(?:f|u(?:8|16|32|64)))?";
         var hexInteger = "(?:0[xX][\\dA-Fa-f]+)";
-        var integer = "(?:" + decimalInteger + "|" + hexInteger + ")\\b";
+        var integer = "(?:" + decimalInteger + decimalSuffix "|" + hexInteger + ")\\b";
 
         this.$rules = {
             "start": [

--- a/zokrates_parser/src/zokrates.pest
+++ b/zokrates_parser/src/zokrates.pest
@@ -106,7 +106,7 @@ identifier = @{ ((!keyword ~ ASCII_ALPHA) | (keyword ~ (ASCII_ALPHANUMERIC | "_"
 
 literal = { hex_literal | decimal_literal | boolean_literal }
 
-decimal_literal = ${ decimal_number ~ decimal_suffix? }
+decimal_literal = ${ decimal_number ~ ("_"? ~ decimal_suffix)? }
 decimal_number = @{ "0" | ASCII_NONZERO_DIGIT ~ ASCII_DIGIT* }
 decimal_suffix = { decimal_suffix_u8 | decimal_suffix_u16 | decimal_suffix_u32 | decimal_suffix_u64 | decimal_suffix_field }
 decimal_suffix_u8 = { "u8" }


### PR DESCRIPTION
Adds an optional underscore before type suffix, `42_u32` is the same as `42u32`

Closes https://github.com/Zokrates/ZoKrates/issues/784