### PR TITLE
Remove space between file name and position to make VSCode experience smoother

### DIFF
--- a/changelogs/unreleased/828-schaeff
+++ b/changelogs/unreleased/828-schaeff
@@ -1,0 +1,1 @@
+Make command line errors compatible with editor cmd+click

--- a/zokrates_cli/src/ops/compile.rs
+++ b/zokrates_cli/src/ops/compile.rs
@@ -105,7 +105,7 @@ fn cli_compile<T: Field>(sub_matches: &ArgMatches) -> Result<(), String> {
     let fmt_error = |e: &CompileError| {
         let file = e.file().canonicalize().unwrap();
         format!(
-            "{}: {}",
+            "{}:{}",
             file.strip_prefix(std::env::current_dir().unwrap())
                 .unwrap_or_else(|_| file.as_path())
                 .display(),


### PR DESCRIPTION
I noticed that when the file name and line/column are joined, cmd+click on VSCode jumps to the location of the error :)