### PR TITLE
Add interactive prompt for overwriting in one_liner.sh

### DIFF
--- a/changelogs/unreleased/831-dark64
+++ b/changelogs/unreleased/831-dark64
@@ -1,0 +1,1 @@
+Add interactive prompt before overwriting existing files in the `one_liner.sh` script


### PR DESCRIPTION
This change will run an interactive prompt in the `one_liner.sh` in case when an existing ZoKrates installation is found on the user's machine. This way users can overwrite old binaries without passing the `--force` flag. If the `--force` flag is passed, the script will not run an interactive prompt and will force as before to not break any external pipelines.

https://github.com/Zokrates/ZoKrates/issues/817