### PR TITLE
Fix integer inference on repeat operator

### DIFF
--- a/changelogs/unreleased/834-schaeff
+++ b/changelogs/unreleased/834-schaeff
@@ -1,0 +1,1 @@
+Fix integer inference on repeat operators

--- a/zokrates_cli/examples/arrays/multi_init.zok
+++ b/zokrates_cli/examples/arrays/multi_init.zok
@@ -1,0 +1,5 @@
+def identity<N>(field[N][N] t) -> field[N][N]:
+    return t
+
+def main() -> field[1][1]:
+    return identity([[0]; 1])

--- a/zokrates_core/src/typed_absy/integer.rs
+++ b/zokrates_core/src/typed_absy/integer.rs
@@ -515,7 +515,7 @@ impl<'ast, T: Field> ArrayExpression<'ast, T> {
                 match target_inner_ty.clone() {
                     Type::Int => Ok(ArrayExpressionInner::Repeat(box e, box count)
                         .annotate(Type::Int, array_ty.size)),
-                    // try to convert the repeated element to the target type
+                    // try to align the repeated element to the target type
                     t => TypedExpression::align_to_type(e, t)
                         .map(|e| {
                             let ty = e.get_type().clone();

--- a/zokrates_core/src/typed_absy/integer.rs
+++ b/zokrates_core/src/typed_absy/integer.rs
@@ -476,7 +476,7 @@ impl<'ast, T: Field> ArrayExpression<'ast, T> {
         }
     }
 
-    // precondition: `array` is only made of inline arrays unless it does not contain the Integer type
+    // precondition: `array` is only made of inline arrays and repeat constructs unless it does not contain the Integer type
     pub fn try_from_int(
         array: Self,
         target_inner_ty: Type<'ast, T>,
@@ -518,8 +518,10 @@ impl<'ast, T: Field> ArrayExpression<'ast, T> {
                     // try to convert the repeated element to the target type
                     t => TypedExpression::align_to_type(e, t)
                         .map(|e| {
+                            let ty = e.get_type().clone();
+
                             ArrayExpressionInner::Repeat(box e, box count)
-                                .annotate(target_inner_ty, array_ty.size)
+                                .annotate(ty, array_ty.size)
                         })
                         .map_err(|(e, _)| e),
                 }


### PR DESCRIPTION
The type of the repeated element should be the inferred type, not the target type.

Closes #804 