### PR TITLE
Remove internal identifier

### DIFF
--- a/zokrates_core/src/typed_absy/identifier.rs
+++ b/zokrates_core/src/typed_absy/identifier.rs
@@ -4,7 +4,6 @@ use std::fmt;
 #[derive(Debug, PartialEq, Clone, Hash, Eq)]
 pub enum CoreIdentifier<'ast> {
     Source(&'ast str),
-    Internal(&'static str, usize),
     Call(usize),
 }
 
@@ -12,7 +11,6 @@ impl<'ast> fmt::Display for CoreIdentifier<'ast> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             CoreIdentifier::Source(s) => write!(f, "{}", s),
-            CoreIdentifier::Internal(s, i) => write!(f, "#INTERNAL#_{}_{}", s, i),
             CoreIdentifier::Call(i) => write!(f, "#CALL_RETURN_AT_INDEX_{}", i),
         }
     }

--- a/zokrates_core/src/zir/identifier.rs
+++ b/zokrates_core/src/zir/identifier.rs
@@ -6,7 +6,6 @@ use crate::typed_absy::Identifier as CoreIdentifier;
 #[derive(Debug, PartialEq, Clone, Hash, Eq)]
 pub enum Identifier<'ast> {
     Source(SourceIdentifier<'ast>),
-    Internal(&'static str, usize),
 }
 
 #[derive(Debug, PartialEq, Clone, Hash, Eq)]
@@ -30,7 +29,6 @@ impl<'ast> fmt::Display for Identifier<'ast> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             Identifier::Source(s) => write!(f, "{}", s),
-            Identifier::Internal(s, i) => write!(f, "#INTERNAL#_{}_{}", s, i),
         }
     }
 }


### PR DESCRIPTION
It is not used anywhere.