### PR TITLE
Align error format

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2269,7 +2269,7 @@ dependencies = [
 
 [[package]]
 name = "zokrates_cli"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "assert_cli",
  "bincode",
@@ -2294,7 +2294,7 @@ version = "0.1.0"
 
 [[package]]
 name = "zokrates_core"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "ark-bls12-377",
  "ark-bn254",
@@ -2335,7 +2335,7 @@ dependencies = [
 
 [[package]]
 name = "zokrates_core_test"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "zokrates_test",
  "zokrates_test_derive",
@@ -2381,7 +2381,7 @@ dependencies = [
 
 [[package]]
 name = "zokrates_parser"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "glob 0.2.11",
  "pest",
@@ -2390,7 +2390,7 @@ dependencies = [
 
 [[package]]
 name = "zokrates_pest_ast"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "from-pest",
  "glob 0.2.11",
@@ -2402,7 +2402,7 @@ dependencies = [
 
 [[package]]
 name = "zokrates_stdlib"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "fs_extra",
  "zokrates_test",

--- a/changelogs/unreleased/843-schaeff
+++ b/changelogs/unreleased/843-schaeff
@@ -1,0 +1,1 @@
+Make error formatting consistent

--- a/zokrates_core/src/compile.rs
+++ b/zokrates_core/src/compile.rs
@@ -140,12 +140,12 @@ impl From<static_analysis::Error> for CompileErrorInner {
 impl fmt::Display for CompileErrorInner {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
-            CompileErrorInner::ParserError(ref e) => write!(f, "{}", e),
-            CompileErrorInner::MacroError(ref e) => write!(f, "{}", e),
+            CompileErrorInner::ParserError(ref e) => write!(f, "\n\t{}", e),
+            CompileErrorInner::MacroError(ref e) => write!(f, "\n\t{}", e),
             CompileErrorInner::SemanticError(ref e) => write!(f, "{}", e),
-            CompileErrorInner::ReadError(ref e) => write!(f, "{}", e),
-            CompileErrorInner::ImportError(ref e) => write!(f, "{}", e),
-            CompileErrorInner::AnalysisError(ref e) => write!(f, "{}", e),
+            CompileErrorInner::ReadError(ref e) => write!(f, "\n\t{}", e),
+            CompileErrorInner::ImportError(ref e) => write!(f, "\n\t{}", e),
+            CompileErrorInner::AnalysisError(ref e) => write!(f, "\n\t{}", e),
         }
     }
 }

--- a/zokrates_core/src/compile.rs
+++ b/zokrates_core/src/compile.rs
@@ -142,7 +142,13 @@ impl fmt::Display for CompileErrorInner {
         match *self {
             CompileErrorInner::ParserError(ref e) => write!(f, "\n\t{}", e),
             CompileErrorInner::MacroError(ref e) => write!(f, "\n\t{}", e),
-            CompileErrorInner::SemanticError(ref e) => write!(f, "{}", e),
+            CompileErrorInner::SemanticError(ref e) => {
+                let location = e
+                    .pos()
+                    .map(|p| format!("{}", p.0))
+                    .unwrap_or_else(|| "".to_string());
+                write!(f, "{}\n\t{}", location, e.message())
+            }
             CompileErrorInner::ReadError(ref e) => write!(f, "\n\t{}", e),
             CompileErrorInner::ImportError(ref e) => write!(f, "\n\t{}", e),
             CompileErrorInner::AnalysisError(ref e) => write!(f, "\n\t{}", e),

--- a/zokrates_core/src/semantics.rs
+++ b/zokrates_core/src/semantics.rs
@@ -38,6 +38,14 @@ pub struct Error {
 }
 
 impl ErrorInner {
+    pub fn pos(&self) -> &Option<(Position, Position)> {
+        &self.pos
+    }
+
+    pub fn message(&self) -> &str {
+        &self.message
+    }
+
     fn in_file(self, id: &ModuleId) -> Error {
         Error {
             inner: self,
@@ -137,16 +145,6 @@ impl<'ast, T: Field> State<'ast, T> {
             types: HashMap::new(),
             constants: HashMap::new(),
         }
-    }
-}
-
-impl fmt::Display for ErrorInner {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let location = self
-            .pos
-            .map(|p| format!("{}", p.0))
-            .unwrap_or_else(|| "?".to_string());
-        write!(f, "{}\n\t{}", location, self.message)
     }
 }
 


### PR DESCRIPTION
Semantic errors and other errors have a different formatting now. Fix that.