### PR TITLE
Fix struct member type mismatch crash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2269,7 +2269,7 @@ dependencies = [
 
 [[package]]
 name = "zokrates_cli"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "assert_cli",
  "bincode",
@@ -2294,7 +2294,7 @@ version = "0.1.0"
 
 [[package]]
 name = "zokrates_core"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "ark-bls12-377",
  "ark-bn254",
@@ -2335,7 +2335,7 @@ dependencies = [
 
 [[package]]
 name = "zokrates_core_test"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "zokrates_test",
  "zokrates_test_derive",
@@ -2381,7 +2381,7 @@ dependencies = [
 
 [[package]]
 name = "zokrates_parser"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "glob 0.2.11",
  "pest",
@@ -2390,7 +2390,7 @@ dependencies = [
 
 [[package]]
 name = "zokrates_pest_ast"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "from-pest",
  "glob 0.2.11",
@@ -2402,7 +2402,7 @@ dependencies = [
 
 [[package]]
 name = "zokrates_stdlib"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "fs_extra",
  "zokrates_test",

--- a/changelogs/unreleased/846-schaeff
+++ b/changelogs/unreleased/846-schaeff
@@ -1,0 +1,1 @@
+Fix crash on struct member type mismatch

--- a/zokrates_cli/examples/compile_errors/struct_member_type_mismatch_field.zok
+++ b/zokrates_cli/examples/compile_errors/struct_member_type_mismatch_field.zok
@@ -1,0 +1,17 @@
+struct Foo {
+	field[2] values
+}
+
+struct Bar {
+	Foo foo
+	field bar
+}
+
+def main():
+	Bar s = Bar {
+		foo: Foo { values: [1] },
+		bar: 0,
+	}
+    field b = s.bar
+
+	return

--- a/zokrates_cli/examples/compile_errors/struct_member_type_mismatch_u8.zok
+++ b/zokrates_cli/examples/compile_errors/struct_member_type_mismatch_u8.zok
@@ -1,0 +1,17 @@
+struct Foo {
+	u8[2] values
+}
+
+struct Bar {
+	Foo foo
+	u8 bar
+}
+
+def main():
+	Bar s = Bar {
+		foo: Foo { values: [1] },
+		bar: 0,
+	}
+    u8 b = s.bar
+
+	return

--- a/zokrates_cli/examples/compile_errors/struct_member_type_mismatch_u8.zok
+++ b/zokrates_cli/examples/compile_errors/struct_member_type_mismatch_u8.zok
@@ -9,7 +9,7 @@ struct Bar {
 
 def main():
 	Bar s = Bar {
-		foo: Foo { values: [1] },
+		foo: Foo { values: [1] }, // notice the size mismatch here
 		bar: 0,
 	}
     u8 b = s.bar


### PR DESCRIPTION
```
struct Foo {
	u8[2] values
}

struct Bar {
	Foo foo
	u8 bar
}

def main():
	Bar s = Bar {
		foo: Foo { values: [1] }, // notice the size mismatch here
		bar: 0,
	}
    u8 b = s.bar

	return
```

should fail gracefully