### PR TITLE
Add uint to abi doc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2269,7 +2269,7 @@ dependencies = [
 
 [[package]]
 name = "zokrates_cli"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "assert_cli",
  "bincode",
@@ -2294,7 +2294,7 @@ version = "0.1.0"
 
 [[package]]
 name = "zokrates_core"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "ark-bls12-377",
  "ark-bn254",
@@ -2335,7 +2335,7 @@ dependencies = [
 
 [[package]]
 name = "zokrates_core_test"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "zokrates_test",
  "zokrates_test_derive",
@@ -2381,7 +2381,7 @@ dependencies = [
 
 [[package]]
 name = "zokrates_parser"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "glob 0.2.11",
  "pest",
@@ -2390,7 +2390,7 @@ dependencies = [
 
 [[package]]
 name = "zokrates_pest_ast"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "from-pest",
  "glob 0.2.11",
@@ -2402,7 +2402,7 @@ dependencies = [
 
 [[package]]
 name = "zokrates_stdlib"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "fs_extra",
  "zokrates_test",

--- a/changelogs/unreleased/848-schaeff
+++ b/changelogs/unreleased/848-schaeff
@@ -1,0 +1,1 @@
+Add uint to abi docs

--- a/zokrates_book/src/toolbox/abi.md
+++ b/zokrates_book/src/toolbox/abi.md
@@ -26,7 +26,7 @@ In this example, the ABI specification is:
             "members":[
                {
                   "name":"a",
-                  "type":"field"
+                  "type":"u8"
                },
                {
                   "name":"b",
@@ -75,7 +75,7 @@ When executing a program, arguments can be passed as a JSON object of the follow
 ```json
 [
    {
-      "a":"42",
+      "a":"0x2a",
       "b":{
          "a":"42"
       }
@@ -89,5 +89,6 @@ When executing a program, arguments can be passed as a JSON object of the follow
 ```
 
 Note the following:
-- Field elements are passed as JSON strings in order to support arbitrary large numbers.
+- Field elements are passed as JSON strings in order to support arbitrary large numbers
+- Unsigned integers are passed as JSON strings containing their hexadecimal representation
 - Structs are passed as JSON objects, ignoring the struct name

--- a/zokrates_cli/examples/book/abi.zok
+++ b/zokrates_cli/examples/book/abi.zok
@@ -3,7 +3,7 @@ struct Bar {
 }
 
 struct Foo {
-    field a
+    u8 a
     Bar b
 }
 


### PR DESCRIPTION
It's not clear that uints are passed as hex strings. Make that clear.