### PR TITLE
Fix flattening of uint subtraction for values smaller than the target

### DIFF
--- a/changelogs/unreleased/852-schaeff
+++ b/changelogs/unreleased/852-schaeff
@@ -1,0 +1,1 @@
+Fix treatment of uint subtraction involving constants (bug)

--- a/zokrates_core/src/flatten/mod.rs
+++ b/zokrates_core/src/flatten/mod.rs
@@ -1396,9 +1396,10 @@ impl<'ast, T: Field> Flattener<'ast, T> {
             }
             UExpressionInner::Sub(box left, box right) => {
                 // see uint optimizer for the reasoning here
-                let aux = FlatExpression::Number(
-                    T::from(2).pow(right.metadata.clone().unwrap().bitwidth() as usize),
-                );
+                let offset = FlatExpression::Number(T::from(2).pow(std::cmp::max(
+                    right.metadata.clone().unwrap().bitwidth() as usize,
+                    target_bitwidth as usize,
+                )));
 
                 let left_flattened = self
                     .flatten_uint_expression(statements_flattened, left)
@@ -1422,7 +1423,7 @@ impl<'ast, T: Field> Flattener<'ast, T> {
                 };
 
                 FlatUExpression::with_field(FlatExpression::Add(
-                    box aux,
+                    box offset,
                     box FlatExpression::Sub(box new_left, box new_right),
                 ))
             }

--- a/zokrates_core_test/tests/tests/uint/u16/sub.json
+++ b/zokrates_core_test/tests/tests/uint/u16/sub.json
@@ -1,6 +1,6 @@
 {
   "entry_point": "./tests/tests/uint/u16/sub.zok",
-  "max_constraint_count": 53,
+  "max_constraint_count": 91,
   "tests": [
     {
       "input": {
@@ -8,7 +8,7 @@
       },
       "output": {
         "Ok": {
-          "values": ["0xfffe"]
+          "values": ["0xfffe", "0xfffe", "0x0002"]
         }
       }
     },
@@ -18,7 +18,7 @@
       },
       "output": {
         "Ok": {
-          "values": ["0xffff"]
+          "values": ["0xffff", "0xffff", "0x0001"]
         }
       }
     }

--- a/zokrates_core_test/tests/tests/uint/u16/sub.zok
+++ b/zokrates_core_test/tests/tests/uint/u16/sub.zok
@@ -1,2 +1,2 @@
-def main(u16 a, u16 b) -> u16:
-    return a - b
+def main(u16 a, u16 b) -> (u16, u16, u16):
+    return a - b, a - 1, 1 - a

--- a/zokrates_core_test/tests/tests/uint/u32/sub.json
+++ b/zokrates_core_test/tests/tests/uint/u32/sub.json
@@ -1,6 +1,6 @@
 {
   "entry_point": "./tests/tests/uint/u32/sub.zok",
-  "max_constraint_count": 101,
+  "max_constraint_count": 171,
   "tests": [
     {
       "input": {
@@ -8,7 +8,7 @@
       },
       "output": {
         "Ok": {
-          "values": ["0xfffffffe"]
+          "values": ["0xfffffffe", "0xfffffffe", "0x00000002"]
         }
       }
     },
@@ -18,7 +18,7 @@
       },
       "output": {
         "Ok": {
-          "values": ["0xffffffff"]
+          "values": ["0xffffffff", "0xffffffff", "0x00000001"]
         }
       }
     }

--- a/zokrates_core_test/tests/tests/uint/u32/sub.zok
+++ b/zokrates_core_test/tests/tests/uint/u32/sub.zok
@@ -1,2 +1,2 @@
-def main(u32 a, u32 b) -> u32:
-    return a - b
+def main(u32 a, u32 b) -> (u32, u32, u32):
+    return a - b, a - 1, 1 - a

--- a/zokrates_core_test/tests/tests/uint/u64/sub.json
+++ b/zokrates_core_test/tests/tests/uint/u64/sub.json
@@ -1,6 +1,6 @@
 {
   "entry_point": "./tests/tests/uint/u64/sub.zok",
-  "max_constraint_count": 197,
+  "max_constraint_count": 331,
   "tests": [
     {
       "input": {
@@ -8,7 +8,7 @@
       },
       "output": {
         "Ok": {
-          "values": ["0xfffffffffffffffe"]
+          "values": ["0xfffffffffffffffe", "0xfffffffffffffffe", "0x0000000000000002"]
         }
       }
     },
@@ -18,7 +18,7 @@
       },
       "output": {
         "Ok": {
-          "values": ["0xffffffffffffffff"]
+          "values": ["0xffffffffffffffff", "0xffffffffffffffff", "0x0000000000000001"]
         }
       }
     }

--- a/zokrates_core_test/tests/tests/uint/u64/sub.zok
+++ b/zokrates_core_test/tests/tests/uint/u64/sub.zok
@@ -1,2 +1,2 @@
-def main(u64 a, u64 b) -> u64:
-    return a - b
+def main(u64 a, u64 b) -> (u64, u64, u64):
+    return a - b, a - 1, 1 - a

--- a/zokrates_core_test/tests/tests/uint/u8/sub.json
+++ b/zokrates_core_test/tests/tests/uint/u8/sub.json
@@ -1,6 +1,6 @@
 {
   "entry_point": "./tests/tests/uint/u8/sub.zok",
-  "max_constraint_count": 29,
+  "max_constraint_count": 51,
   "tests": [
     {
       "input": {
@@ -8,7 +8,7 @@
       },
       "output": {
         "Ok": {
-          "values": ["0xfe"]
+          "values": ["0xfe", "0xfe", "0x02"]
         }
       }
     },
@@ -18,7 +18,7 @@
       },
       "output": {
         "Ok": {
-          "values": ["0xff"]
+          "values": ["0xff", "0xff", "0x01"]
         }
       }
     }

--- a/zokrates_core_test/tests/tests/uint/u8/sub.zok
+++ b/zokrates_core_test/tests/tests/uint/u8/sub.zok
@@ -1,2 +1,2 @@
-def main(u8 a, u8 b) -> u8:
-    return a - b
+def main(u8 a, u8 b) -> (u8, u8, u8):
+    return a - b, a - 1, 1 - a


### PR DESCRIPTION
The uint optimizer uses `max(right_bitwidth, range)` but at flattening we're using just `right_bitwidth`, hence shifting by something that is not a multiple of `2**range` for constants.

Align flattening to uint optimizer, add tests.