### PR TITLE
Bugfix on 0.7.2

### DIFF
--- a/changelogs/unreleased/877-dark64
+++ b/changelogs/unreleased/877-dark64
@@ -1,0 +1,2 @@
+Remove substitution in `one_liner.sh` script which caused `Bad substitution` error with `sh`/`dash`
+Put branch isolator behind a compilation flag in the static analyzer

--- a/scripts/changelog.sh
+++ b/scripts/changelog.sh
@@ -38,9 +38,13 @@ EOT
 for file in $unreleased
 do
     IFS=$'-' read -ra entry <<< "$file"
-    contents=$(cat ${CHANGELOG_PATH}/${file} | tr '\n' ' ')
     author=$(join '-' ${entry[@]:1})
-    echo "- ${contents} (#${entry[0]}, @${author})"
+
+    IFS=$'\n' rows=$(cat ${CHANGELOG_PATH}/${file})
+    for row in $rows
+    do
+        echo "- ${row} (#${entry[0]}, @${author})"
+    done
 done
 
 echo -e "\nCopy and paste the markdown above to the appropriate CHANGELOG file."

--- a/scripts/one_liner.sh
+++ b/scripts/one_liner.sh
@@ -297,7 +297,7 @@ main() {
         cp -r $td/* $dest
       else
         read -p "ZoKrates is already installed, overwrite (y/n)? " answer
-        case ${answer:0:1} in
+        case ${answer} in
             y|Y )
                 rm -rf $dest/*
                 cp -r $td/* $dest

--- a/zokrates_cli/src/ops/check.rs
+++ b/zokrates_cli/src/ops/check.rs
@@ -5,7 +5,7 @@ use std::convert::TryFrom;
 use std::fs::File;
 use std::io::{BufReader, Read};
 use std::path::{Path, PathBuf};
-use zokrates_core::compile::{check, CompileError};
+use zokrates_core::compile::{check, CompileConfig, CompileError};
 use zokrates_field::{Bls12_377Field, Bls12_381Field, Bn128Field, Bw6_761Field, Field};
 use zokrates_fs_resolver::FileSystemResolver;
 
@@ -40,6 +40,11 @@ pub fn subcommand() -> App<'static, 'static> {
                 .required(false)
                 .possible_values(constants::CURVES)
                 .default_value(constants::BN128),
+        )
+        .arg(Arg::with_name("isolate-branches")
+            .long("isolate-branches")
+            .help("Isolate the execution of branches: a panic in a branch only makes the program panic if this branch is being logically executed")
+            .required(false)
         )
 }
 
@@ -84,8 +89,11 @@ fn cli_check<T: Field>(sub_matches: &ArgMatches) -> Result<(), String> {
         )),
     }?;
 
+    let config =
+        CompileConfig::default().isolate_branches(sub_matches.is_present("isolate-branches"));
+
     let resolver = FileSystemResolver::with_stdlib_root(stdlib_path);
-    let _ = check::<T, _>(source, path, Some(&resolver)).map_err(|e| {
+    let _ = check::<T, _>(source, path, Some(&resolver), &config).map_err(|e| {
         format!(
             "Check failed:\n\n{}",
             e.0.iter()

--- a/zokrates_cli/src/ops/compile.rs
+++ b/zokrates_cli/src/ops/compile.rs
@@ -126,10 +126,9 @@ fn cli_compile<T: Field>(sub_matches: &ArgMatches) -> Result<(), String> {
         )),
     }?;
 
-    let config = CompileConfig {
-        allow_unconstrained_variables: sub_matches.is_present("allow-unconstrained-variables"),
-        isolate_branches: sub_matches.is_present("isolate-branches"),
-    };
+    let config = CompileConfig::default()
+        .allow_unconstrained_variables(sub_matches.is_present("allow-unconstrained-variables"))
+        .isolate_branches(sub_matches.is_present("isolate-branches"));
 
     let resolver = FileSystemResolver::with_stdlib_root(stdlib_path);
     let artifacts: CompilationArtifacts<T> = compile(source, path, Some(&resolver), &config)


### PR DESCRIPTION
- Remove substitution in `one_liner.sh` script which caused `Bad substitution` error with `sh`/`dash`
- Put branch isolator behind a compilation flag in the static analyzer