### PR TITLE
Add bubblesort example

### DIFF
--- a/zokrates_cli/examples/book/bubblesort.zok
+++ b/zokrates_cli/examples/book/bubblesort.zok
@@ -1,13 +1,13 @@
-def swap(u32[10] a, u32 i, u32 j) -> u32[10]:
-	u32 tmp = a[i]
-	a[i] = a[j]
-	a[j] = tmp
-	return a
+def swap(u32 a, u32 b, bool c) -> (u32, u32):
+	u32 a_prime = if c then b else a fi
+	b = if c then a else b fi
+	return a_prime, b
 
 def bubblesort<N>(u32[N] a) -> u32[N]:
 	for u32 i in 0..(N-1) do
 		for u32 j in 0..(N-1-i) do
-			a = if a[j + 1] < a[j] then swap(a, j, j + 1) else a fi
+			bool need_swap = a[j + 1] < a[j]
+			a[j], a[j + 1] = swap(a[j], a[j + 1], need_swap)
 		endfor
 	endfor
 	return a

--- a/zokrates_cli/examples/book/bubblesort.zok
+++ b/zokrates_cli/examples/book/bubblesort.zok
@@ -1,10 +1,13 @@
+def swap(u32[10] a, u32 i, u32 j) -> u32[10]:
+	u32 tmp = a[i]
+	a[i] = a[j]
+	a[j] = tmp
+	return a
+
 def bubblesort<N>(u32[N] a) -> u32[N]:
 	for u32 i in 0..(N-1) do
 		for u32 j in 0..(N-1-i) do
-			bool swap = a[j + 1] < a[j]
-			u32 tmp = a[j]
-			a[j] = if swap then a[j + 1] else a[j] fi
-			a[j + 1] = if swap then tmp else a[j + 1] fi
+			a = if a[j + 1] < a[j] then swap(a, j, j + 1) else a fi
 		endfor
 	endfor
 	return a

--- a/zokrates_cli/examples/book/bubblesort.zok
+++ b/zokrates_cli/examples/book/bubblesort.zok
@@ -1,0 +1,13 @@
+def bubblesort<N>(u32[N] a) -> u32[N]:
+	for u32 i in 0..(N-1) do
+		for u32 j in 0..(N-1-i) do
+			bool swap = a[j + 1] < a[j]
+			u32 tmp = a[j]
+			a[j] = if swap then a[j + 1] else a[j] fi
+			a[j + 1] = if swap then tmp else a[j + 1] fi
+		endfor
+	endfor
+	return a
+
+def main(u32[10] a) -> u32[10]:
+        return bubblesort(a)


### PR DESCRIPTION
This contains three different versions, in order of commits:
1. Basic version using two if statements. Compiles to 26350 constraints.
2. Version using a helper function. Compiles to 129799 constraints.
3. Using a tuple-swap function (which does not compile). See #885.

(This bubblesort example could benefit a lot from generics, but I did not do that.)

In a Leo/Aleo [paper](https://docs.zkproof.org/pages/standards/accepted-workshop4/proposal-leo.pdf) the same bubblesort using `u32[10]` claims to turn into 16115 constraints. (Figure 17)

I would be curious if there are much better approaches to implement this (some which get closer to Leo)? Not that it is inherently useful, but a good example to work on.

Also wonder if a `swap(a, b) -> (a, b)` builtin (or stdlib helper) together with tuple-based if/else could be useful in the language. One could write something like `a, b = if need_swap then swap(a, b) else nop(a, b) fi` to perform a conditional swap.
