### PR TITLE
Fix variable index write when isolating branches

### DIFF
--- a/changelogs/unreleased/904-schaeff
+++ b/changelogs/unreleased/904-schaeff
@@ -1,0 +1,1 @@
+Fix variable write remover when isolating branches

--- a/zokrates_core/src/static_analysis/variable_write_remover.rs
+++ b/zokrates_core/src/static_analysis/variable_write_remover.rs
@@ -310,12 +310,13 @@ impl<'ast, T: Field> Folder<'ast, T> for VariableWriteRemover {
     fn fold_statement(&mut self, s: TypedStatement<'ast, T>) -> Vec<TypedStatement<'ast, T>> {
         match s {
             TypedStatement::Definition(assignee, expr) => {
+                let expr = self.fold_expression(expr);
+
                 if is_constant(&assignee) {
                     vec![TypedStatement::Definition(assignee, expr)]
                 } else {
                     // Note: here we redefine the whole object, ideally we would only redefine some of it
                     // Example: `a[0][i] = 42` we redefine `a` but we could redefine just `a[0]`
-                    let expr = self.fold_expression(expr);
 
                     let (variable, indices) = linear(assignee);
 


### PR DESCRIPTION
As expressions can now be blocks, they can contain statements. Therefore, the expressions need to be visited when removing variable write accesses.

closes #891 