### PR TITLE
Change endianness in keccak, sha3 and blake2s hash algorithms to big endian

### DIFF
--- a/changelogs/unreleased/906-dark64
+++ b/changelogs/unreleased/906-dark64
@@ -1,0 +1,1 @@
+Change endianness in keccak, sha3 and blake2s hash algorithms to big endian

--- a/zokrates_stdlib/stdlib/hashes/blake2/blake2s_p.zok
+++ b/zokrates_stdlib/stdlib/hashes/blake2/blake2s_p.zok
@@ -3,8 +3,16 @@
 import "utils/casts/u32_to_bits"
 import "utils/casts/u32_from_bits"
 
+// right rotation
 def rotr32<N>(u32 x) -> u32:
     return (x >> N) | (x << (32 - N))
+
+// change endianness
+def swap_u32(u32 val) -> u32:
+    return (val << 24) | \
+          ((val <<  8) & 0x00ff0000) | \
+          ((val >>  8) & 0x0000ff00) | \
+          ((val >> 24) & 0x000000ff)
 
 def blake2s_iv() -> (u32[8]):
     return [
@@ -73,8 +81,8 @@ def blake2s_init(u32[2] p) -> (u32[8]):
         iv[3],
         iv[4],
         iv[5],
-        iv[6] ^ p[0],
-        iv[7] ^ p[1]
+        iv[6] ^ swap_u32(p[0]),
+        iv[7] ^ swap_u32(p[1])
     ]
     return h
 
@@ -83,6 +91,13 @@ def main<K>(u32[K][16] input, u32[2] p) -> (u32[8]):
 
     u32 t0 = 0
     u32 t1 = 0
+
+    // change endianness of inputs from big endian to little endian
+    for u32 i in 0..K do
+        for u32 j in 0..16 do
+            input[i][j] = swap_u32(input[i][j])
+        endfor
+    endfor
 
     for u32 i in 0..K-1 do
         t0 = (i + 1) * 64
@@ -94,4 +109,10 @@ def main<K>(u32[K][16] input, u32[2] p) -> (u32[8]):
     t1 = if t0 == 0 then t1 + 1 else t1 fi
 
     h = blake2s_compression(h, input[K - 1], [t0, t1], true)
+
+    // change endianness of output from little endian to big endian
+    for u32 i in 0..8 do
+        h[i] = swap_u32(h[i])
+    endfor
+
     return h

--- a/zokrates_stdlib/stdlib/hashes/keccak/keccak.zok
+++ b/zokrates_stdlib/stdlib/hashes/keccak/keccak.zok
@@ -28,6 +28,12 @@ def rc() -> u64[24]:
 def rotl64(u64 x, u32 n) -> u64:
     return ((x << n) | (x >> (64 - n)))
 
+// change endianness
+def swap_u64(u64 val) -> u64:
+    val = ((val << 8) & 0xFF00FF00FF00FF00) | ((val >> 8) & 0x00FF00FF00FF00FF)
+    val = ((val << 16) & 0xFFFF0000FFFF0000) | ((val >> 16) & 0x0000FFFF0000FFFF)
+    return (val << 32) | (val >> 32)
+
 // compression function
 def keccakf(u64[25] st) -> u64[25]:
     u32[24] rotc = rho()
@@ -80,6 +86,11 @@ def main<N, W>(u64[N] input, u64 pad) -> u64[25]:
     u32 rate = (200 - (W / 4)) / 8
     u32 pt = 0
 
+    // change endianness of inputs from big endian to little endian
+    for u32 i in 0..N do
+        input[i] = swap_u64(input[i])
+    endfor
+
     // update
     for u32 i in 0..N do
         q[pt] = q[pt] ^ input[i]
@@ -90,6 +101,11 @@ def main<N, W>(u64[N] input, u64 pad) -> u64[25]:
     // finalize
     q[pt] = q[pt] ^ pad
     q[rate - 1] = q[rate - 1] ^ 0x8000000000000000
-
     q = keccakf(q)
+
+    // change endianness of output from little endian to big endian
+    for u32 i in 0..W/64 do
+        q[i] = swap_u64(q[i])
+    endfor
+
     return q

--- a/zokrates_stdlib/tests/tests/hashes/blake2/blake2s_1024bit.zok
+++ b/zokrates_stdlib/tests/tests/hashes/blake2/blake2s_1024bit.zok
@@ -1,6 +1,17 @@
 import "hashes/blake2/blake2s"
 
+// Python code:
+// >>> from hashlib import blake2s
+
+// >>> digest = blake2s()
+// >>> digest.update(b'\x00' * 128)
+// >>> digest.hexdigest()
+// '4e420520b981ce7bdbf4ce2c4dbadb9450079b7deb9737b5232957d323f801cb'
+
 def main():
-    u32[8] h = blake2s::<2>([[0; 16]; 2])
-    assert(h == [0x2005424E, 0x7BCE81B9, 0x2CCEF4DB, 0x94DBBA4D, 0x7D9B0750, 0xB53797EB, 0xD3572923, 0xCB01F823])
+    u32[8] h = blake2s::<2>([[0; 16]; 2]) // 2 * 16 * 32 = 1024 bit input
+    assert(h == [
+        0x4E420520, 0xB981CE7B, 0xDBF4CE2C, 0x4DBADB94,
+        0x50079B7D, 0xEB9737B5, 0x232957D3, 0x23F801CB
+    ])
     return

--- a/zokrates_stdlib/tests/tests/hashes/blake2/blake2s_1024bit.zok
+++ b/zokrates_stdlib/tests/tests/hashes/blake2/blake2s_1024bit.zok
@@ -4,14 +4,14 @@ import "hashes/blake2/blake2s"
 // >>> from hashlib import blake2s
 
 // >>> digest = blake2s()
-// >>> digest.update(b'\x00' * 128)
+// >>> digest.update(b'\x12\x34\x56\x78' * 32)
 // >>> digest.hexdigest()
-// '4e420520b981ce7bdbf4ce2c4dbadb9450079b7deb9737b5232957d323f801cb'
+// '4858b8174f8f5851ddac0507003b2490f42c33df8362770c5e79b770c84ffdb4'
 
 def main():
-    u32[8] h = blake2s::<2>([[0; 16]; 2]) // 2 * 16 * 32 = 1024 bit input
+    u32[8] h = blake2s::<2>([[0x12345678; 16]; 2]) // 2 * 16 * 32 = 1024 bit input
     assert(h == [
-        0x4E420520, 0xB981CE7B, 0xDBF4CE2C, 0x4DBADB94,
-        0x50079B7D, 0xEB9737B5, 0x232957D3, 0x23F801CB
+        0x4858B817, 0x4F8F5851, 0xDDAC0507, 0x003B2490,
+        0xF42C33DF, 0x8362770C, 0x5E79B770, 0xC84FFDB4
     ])
     return

--- a/zokrates_stdlib/tests/tests/hashes/blake2/blake2s_1536bit.zok
+++ b/zokrates_stdlib/tests/tests/hashes/blake2/blake2s_1536bit.zok
@@ -1,6 +1,17 @@
 import "hashes/blake2/blake2s"
 
+// Python code:
+// >>> from hashlib import blake2s
+
+// >>> digest = blake2s()
+// >>> digest.update(b'\x00\x00\x00\x2A' * 48)
+// >>> digest.hexdigest()
+// '2707edbde466a6632371e0611804ecdbe3e21dd683ce9d2060c50341b6fa99ed'
+
 def main():
-    u32[8] h = blake2s::<3>([[0x42424242; 16]; 3])
-    assert(h == [0x804BD0E6, 0x90AD426E, 0x6BCF0BAD, 0xCB2D22C1, 0xF717B3C3, 0x4D9CB47F, 0xEB541A97, 0x061D9ED0])
+    u32[8] h = blake2s::<3>([[42; 16]; 3]) // 3 * 16 * 32 = 1536 bit input
+    assert(h == [
+        0x2707EDBD, 0xE466A663, 0x2371E061, 0x1804ECDB,
+        0xE3E21DD6, 0x83CE9D20, 0x60C50341, 0xB6FA99ED
+    ])
     return

--- a/zokrates_stdlib/tests/tests/hashes/blake2/blake2s_1536bit.zok
+++ b/zokrates_stdlib/tests/tests/hashes/blake2/blake2s_1536bit.zok
@@ -4,14 +4,14 @@ import "hashes/blake2/blake2s"
 // >>> from hashlib import blake2s
 
 // >>> digest = blake2s()
-// >>> digest.update(b'\x00\x00\x00\x2A' * 48)
+// >>> digest.update(b'\x12\x34\x56\x78' * 48)
 // >>> digest.hexdigest()
-// '2707edbde466a6632371e0611804ecdbe3e21dd683ce9d2060c50341b6fa99ed'
+// '879043503b04cab2f3c0d7a4bb01c1db74c238c49887da84e8a619893092b6e2'
 
 def main():
-    u32[8] h = blake2s::<3>([[42; 16]; 3]) // 3 * 16 * 32 = 1536 bit input
+    u32[8] h = blake2s::<3>([[0x12345678; 16]; 3]) // 3 * 16 * 32 = 1536 bit input
     assert(h == [
-        0x2707EDBD, 0xE466A663, 0x2371E061, 0x1804ECDB,
-        0xE3E21DD6, 0x83CE9D20, 0x60C50341, 0xB6FA99ED
+        0x87904350, 0x3B04CAB2, 0xF3C0D7A4, 0xBB01C1DB,
+        0x74C238C4, 0x9887DA84, 0xE8A61989, 0x3092B6E2
     ])
     return

--- a/zokrates_stdlib/tests/tests/hashes/blake2/blake2s_512bit.zok
+++ b/zokrates_stdlib/tests/tests/hashes/blake2/blake2s_512bit.zok
@@ -1,6 +1,17 @@
 import "hashes/blake2/blake2s"
 
+// Python code:
+// >>> from hashlib import blake2s
+
+// >>> digest = blake2s()
+// >>> digest.update(b'\x00' * 64)
+// >>> digest.hexdigest()
+// 'ae09db7cd54f42b490ef09b6bc541af688e4959bb8c53f359a6f56e38ab454a3'
+
 def main():
-    u32[8] h = blake2s::<1>([[0; 16]])
-    assert(h == [0x7CDB09AE, 0xB4424FD5, 0xB609EF90, 0xF61A54BC, 0x9B95E488, 0x353FC5B8, 0xE3566F9A, 0xA354B48A])
+    u32[8] h = blake2s::<1>([[0; 16]; 1]) // 16 * 32 = 512 bit input
+    assert(h == [
+        0xAE09DB7C, 0xD54F42B4, 0x90EF09B6, 0xBC541AF6,
+        0x88E4959B, 0xB8C53F35, 0x9A6F56E3, 0x8AB454A3
+    ])
     return

--- a/zokrates_stdlib/tests/tests/hashes/blake2/blake2s_512bit.zok
+++ b/zokrates_stdlib/tests/tests/hashes/blake2/blake2s_512bit.zok
@@ -4,14 +4,14 @@ import "hashes/blake2/blake2s"
 // >>> from hashlib import blake2s
 
 // >>> digest = blake2s()
-// >>> digest.update(b'\x00' * 64)
+// >>> digest.update(b'\x12\x34\x56\x78' * 16)
 // >>> digest.hexdigest()
-// 'ae09db7cd54f42b490ef09b6bc541af688e4959bb8c53f359a6f56e38ab454a3'
+// '52af1aec3e6663bcc759d55fc7557fbb2f710219f0de138b1b52c919f5c94415'
 
 def main():
-    u32[8] h = blake2s::<1>([[0; 16]; 1]) // 16 * 32 = 512 bit input
+    u32[8] h = blake2s::<1>([[0x12345678; 16]; 1]) // 16 * 32 = 512 bit input
     assert(h == [
-        0xAE09DB7C, 0xD54F42B4, 0x90EF09B6, 0xBC541AF6,
-        0x88E4959B, 0xB8C53F35, 0x9A6F56E3, 0x8AB454A3
+        0x52AF1AEC, 0x3E6663BC, 0xC759D55F, 0xC7557FBB,
+        0x2F710219, 0xF0DE138B, 0x1B52C919, 0xF5C94415
     ])
     return

--- a/zokrates_stdlib/tests/tests/hashes/blake2/blake2s_8192bit.zok
+++ b/zokrates_stdlib/tests/tests/hashes/blake2/blake2s_8192bit.zok
@@ -1,6 +1,17 @@
 import "hashes/blake2/blake2s"
 
+// Python code:
+// >>> from hashlib import blake2s
+
+// >>> digest = blake2s()
+// >>> digest.update(b'\x00' * 1024)
+// >>> digest.hexdigest()
+// '035366632a506c045d4a51c833e8b76791d5daa9bca821b4a2732a66fb5aa22d'
+
 def main():
-    u32[8] h = blake2s::<16>([[0; 16]; 16])
-    assert(h == [0x63665303, 0x046C502A, 0xC8514A5D, 0x67B7E833, 0xA9DAD591, 0xB421A8BC, 0x662A73A2, 0x2DA25AFB])
+    u32[8] h = blake2s::<16>([[0; 16]; 16]) // 16 * 16 * 32 = 8192 bit input
+    assert(h == [
+        0x03536663, 0x2A506C04, 0x5D4A51C8, 0x33E8B767,
+        0x91D5DAA9, 0xBCA821B4, 0xA2732A66, 0xFB5AA22D
+    ])
     return

--- a/zokrates_stdlib/tests/tests/hashes/blake2/blake2s_8192bit.zok
+++ b/zokrates_stdlib/tests/tests/hashes/blake2/blake2s_8192bit.zok
@@ -4,14 +4,14 @@ import "hashes/blake2/blake2s"
 // >>> from hashlib import blake2s
 
 // >>> digest = blake2s()
-// >>> digest.update(b'\x00' * 1024)
+// >>> digest.update(b'\x12\x34\x56\x78' * 256)
 // >>> digest.hexdigest()
-// '035366632a506c045d4a51c833e8b76791d5daa9bca821b4a2732a66fb5aa22d'
+// 'b41c4704f49df139039bbc91c6e23a84198ffedc78d0b677e8b2a6a57f3460e8'
 
 def main():
-    u32[8] h = blake2s::<16>([[0; 16]; 16]) // 16 * 16 * 32 = 8192 bit input
+    u32[8] h = blake2s::<16>([[0x12345678; 16]; 16]) // 16 * 16 * 32 = 8192 bit input
     assert(h == [
-        0x03536663, 0x2A506C04, 0x5D4A51C8, 0x33E8B767,
-        0x91D5DAA9, 0xBCA821B4, 0xA2732A66, 0xFB5AA22D
+        0xB41C4704, 0xF49DF139, 0x039BBC91, 0xC6E23A84,
+        0x198FFEDC, 0x78D0B677, 0xE8B2A6A5, 0x7F3460E8
     ])
     return

--- a/zokrates_stdlib/tests/tests/hashes/blake2/blake2s_p.zok
+++ b/zokrates_stdlib/tests/tests/hashes/blake2/blake2s_p.zok
@@ -4,14 +4,14 @@ import "hashes/blake2/blake2s_p" as blake2s
 // >>> from hashlib import blake2s
 
 // >>> digest = blake2s(person=b'\x12\x34\x56\x78\x00\x00\x00\x00')
-// >>> digest.update(b'\x00' * 64)
+// >>> digest.update(b'\x12\x34\x56\x78' * 16)
 // >>> digest.hexdigest()
-// 'a6e927d1b9d50453bc6eb5e4050c443a7203a541cc06ba78a7dc00caa69fb3e9'
+// '780105bc9ca7633b1f289b3d1558dece65e04ac23f88e711dc29600fa3e0258a'
 
 def main():
-    u32[8] h = blake2s::<1>([[0; 16]; 1], [0x12345678, 0])
+    u32[8] h = blake2s::<1>([[0x12345678; 16]; 1], [0x12345678, 0])
     assert(h == [
-        0xA6E927D1, 0xB9D50453, 0xBC6EB5E4, 0x050C443A,
-        0x7203A541, 0xCC06BA78, 0xA7DC00CA, 0xA69FB3E9
+        0x780105BC, 0x9CA7633B, 0x1F289B3D, 0x1558DECE,
+        0x65E04AC2, 0x3F88E711, 0xDC29600F, 0xA3E0258A
     ])
     return

--- a/zokrates_stdlib/tests/tests/hashes/blake2/blake2s_p.zok
+++ b/zokrates_stdlib/tests/tests/hashes/blake2/blake2s_p.zok
@@ -1,6 +1,17 @@
 import "hashes/blake2/blake2s_p" as blake2s
 
+// Python code:
+// >>> from hashlib import blake2s
+
+// >>> digest = blake2s(person=b'\x12\x34\x56\x78\x00\x00\x00\x00')
+// >>> digest.update(b'\x00' * 64)
+// >>> digest.hexdigest()
+// 'a6e927d1b9d50453bc6eb5e4050c443a7203a541cc06ba78a7dc00caa69fb3e9'
+
 def main():
-    u32[8] h = blake2s::<1>([[0; 16]], [0x12345678, 0])
-    assert(h == [0xC63C8C31, 0x5FCA3E69, 0x13850D46, 0x1DE48657, 0x208D2534, 0x9AA6E0EF, 0xAFEE7610, 0xFBDFAC13])
+    u32[8] h = blake2s::<1>([[0; 16]; 1], [0x12345678, 0])
+    assert(h == [
+        0xA6E927D1, 0xB9D50453, 0xBC6EB5E4, 0x050C443A,
+        0x7203A541, 0xCC06BA78, 0xA7DC00CA, 0xA69FB3E9
+    ])
     return

--- a/zokrates_stdlib/tests/tests/hashes/keccak/256bit.zok
+++ b/zokrates_stdlib/tests/tests/hashes/keccak/256bit.zok
@@ -1,6 +1,14 @@
 import "hashes/keccak/256bit" as keccak256
 
+// Python code:
+// >>> from Crypto.Hash import keccak
+
+// >>> digest = keccak.new(digest_bits=256)
+// >>> digest.update(b'\x00\x00\x00\x00\x00\x00\x00\x2A' * 20)
+// >>> digest.hexdigest()
+// '33d0141407fee6e5d9caf6ae44e840bc67a37da55e3c845fbc2b4a6dce1f02f0'
+
 def main():
     u64[4] h = keccak256::<20>([42; 20])
-    assert(h == [0x09330DD35B609CA9, 0xDACFC1598C95602C, 0xACD911013FB018F3, 0x17233D68F05E0826])
+    assert(h == [0x33D0141407FEE6E5, 0xD9CAF6AE44E840BC, 0x67A37DA55E3C845F, 0xBC2B4A6DCE1F02F0])
     return

--- a/zokrates_stdlib/tests/tests/hashes/keccak/384bit.zok
+++ b/zokrates_stdlib/tests/tests/hashes/keccak/384bit.zok
@@ -1,6 +1,17 @@
 import "hashes/keccak/384bit" as keccak384
 
+// Python code:
+// >>> from Crypto.Hash import keccak
+
+// >>> digest = keccak.new(digest_bits=384)
+// >>> digest.update(b'\x00\x00\x00\x00\x00\x00\x00\x2A' * 20)
+// >>> digest.hexdigest()
+// 'a944b9b859c1e69d66b52d4cf1f678b24ed8a9ccb0a32bbe882af8a3a1acbd3b68eed9c628307e5d3789f1a64a50e8e7'
+
 def main():
     u64[6] h = keccak384::<20>([42; 20])
-    assert(h == [0x2E9DCE590F0A1908, 0x0C4234AB952C5598, 0xFB2DF066B44780C2, 0x717039E101D4A8DA, 0xBAD1EFE140C4B2C4, 0xFAE08DAC3438416E])
+    assert(h == [
+        0xA944B9B859C1E69D, 0x66B52D4CF1F678B2, 0x4ED8A9CCB0A32BBE,
+        0x882AF8A3A1ACBD3B, 0x68EED9C628307E5D, 0x3789F1A64A50E8E7
+    ])
     return

--- a/zokrates_stdlib/tests/tests/hashes/keccak/512bit.zok
+++ b/zokrates_stdlib/tests/tests/hashes/keccak/512bit.zok
@@ -1,9 +1,17 @@
 import "hashes/keccak/512bit" as keccak512
 
+// Python code:
+// >>> from Crypto.Hash import keccak
+
+// >>> digest = keccak.new(digest_bits=512)
+// >>> digest.update(b'\x00\x00\x00\x00\x00\x00\x00\x2A' * 20)
+// >>> digest.hexdigest()
+// '5451affca80019c7ac9a7ff647ca073b56e19d55857031df14e00bb1d36ed18a05bdac99bcc0417240dea0cf3fddd19144b8d1e9618fd3f6c8f1a79f7e489eb8'
+
 def main():
     u64[8] h = keccak512::<20>([42; 20])
     assert(h == [
-        0x2716192386255918, 0x68DFF390376BBF13, 0xBD695ADA4CD230E3, 0xF3B00388676A04D3,
-        0x484F3F1BB9F36A09, 0x9D0119067282F940, 0xDF27DE0F48072A66, 0xF5957972134160EB
+        0x5451AFFCA80019C7, 0xAC9A7FF647CA073B, 0x56E19D55857031DF, 0x14E00BB1D36ED18A,
+        0x05BDAC99BCC04172, 0x40DEA0CF3FDDD191, 0x44B8D1E9618FD3F6, 0xC8F1A79F7E489EB8
     ])
     return

--- a/zokrates_stdlib/tests/tests/hashes/sha3/256bit.zok
+++ b/zokrates_stdlib/tests/tests/hashes/sha3/256bit.zok
@@ -1,6 +1,14 @@
 import "hashes/sha3/256bit" as sha3_256
 
+// Python code:
+// >>> from Crypto.Hash import SHA3_256
+
+// >>> digest = SHA3_256.new()
+// >>> digest.update(b'\x00\x00\x00\x00\x00\x00\x00\x2A' * 20)
+// >>> digest.hexdigest()
+// '18d00c9e97cd5516243b67b243ede9e2cf0d45d3a844d33340bfc4efc9165100'
+
 def main():
     u64[4] h = sha3_256::<20>([42; 20])
-    assert(h == [0x84350A3A90DED183, 0x70518606C7DC401A, 0x2D44F39C0FCEAC92, 0x3E9533A716130C5A])
+    assert(h == [0x18D00C9E97CD5516, 0x243B67B243EDE9E2, 0xCF0D45D3A844D333, 0x40BFC4EFC9165100])
     return

--- a/zokrates_stdlib/tests/tests/hashes/sha3/384bit.zok
+++ b/zokrates_stdlib/tests/tests/hashes/sha3/384bit.zok
@@ -1,6 +1,17 @@
 import "hashes/sha3/384bit" as sha3_384
 
+// Python code:
+// >>> from Crypto.Hash import SHA3_384
+
+// >>> digest = SHA3_384.new()
+// >>> digest.update(b'\x00\x00\x00\x00\x00\x00\x00\x2A' * 20)
+// >>> digest.hexdigest()
+// 'fbb5abd69915e316836d438f0e833a3ebd0f2d8a11e17e248c96c77210b183aab0874eaaef37609d2c4a9a37a6e9740f'
+
 def main():
     u64[6] h = sha3_384::<20>([42; 20])
-    assert(h == [0x75A036FA8B615B37, 0x6C73086BB56F092C, 0x536E658916EC18AE, 0xB2F2EEE620CDF698, 0xB7E904DE62A70A31, 0x84FDAA0665836ADD])
+    assert(h == [
+        0xFBB5ABD69915E316, 0x836D438F0E833A3E, 0xBD0F2D8A11E17E24,
+        0x8C96C77210B183AA, 0xB0874EAAEF37609D, 0x2C4A9A37A6E9740F
+    ])
     return

--- a/zokrates_stdlib/tests/tests/hashes/sha3/512bit.zok
+++ b/zokrates_stdlib/tests/tests/hashes/sha3/512bit.zok
@@ -1,9 +1,17 @@
 import "hashes/sha3/512bit" as sha3_512
 
+// Python code:
+// >>> from Crypto.Hash import SHA3_512
+
+// >>> digest = SHA3_512.new()
+// >>> digest.update(b'\x00\x00\x00\x00\x00\x00\x00\x2A' * 20)
+// >>> digest.hexdigest()
+// '73a0967b68de5ce1093cbd7482fd4de9ccc9c782e2edc71b583d26fe16fb19e3322a2a024b7f6e163fbb1a15161686dd3a39233f9cf8616e7c74e91fa1aa3b2b'
+
 def main():
     u64[8] h = sha3_512::<20>([42; 20])
     assert(h == [
-        0x22DFD92B47C60DAC, 0xDA47C8C247A84FA2, 0x7C5809F122D6950A, 0x8034D41097680656,
-        0xD6D06F820B046994, 0xF62743594A554B88, 0x4966E0821CB4D667, 0x974D4391624C5619
+        0x73A0967B68DE5CE1, 0x093CBD7482FD4DE9, 0xCCC9C782E2EDC71B, 0x583D26FE16FB19E3,
+        0x322A2A024B7F6E16, 0x3FBB1A15161686DD, 0x3A39233F9CF8616E, 0x7C74E91FA1AA3B2B
     ])
     return


### PR DESCRIPTION
I've also included some python-equivalent code for test vectors.