### PR TITLE
Build M1 on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -152,6 +152,9 @@ jobs:
       add-target:
         type: boolean
         default: false
+      build-with:
+        type: string
+        default: cross
     executor: << parameters.os >>
     steps:
       - checkout
@@ -163,8 +166,9 @@ jobs:
          steps:
            - run: rustup target add << parameters.target >>
       - run:
+          name: Build
           no_output_timeout: "30m"
-          command: cross build --target << parameters.target >> --release
+          command: << parameters.build-with >> build --target << parameters.target >> --release
       - tar_artifacts:
           target: << parameters.target >>
   publish_artifacts:
@@ -234,49 +238,45 @@ tag-only: &tag-only
 workflows:
   build-test-and-deploy:
     jobs:
-#      - build
-#      - test
-#      - cpp_format
-#      - wasm_test
-#      - integration_test
-#      - zokrates_js_build
-#      - zokrates_js_test
-#      - cross_build:
-#          <<: *tag-only
-#          pre-steps:
-#            - install_rust
-#            - install_cross
-#          matrix:
-#            alias: cross-build-linux
-#            parameters:
-#              os:
-#                - linux
-#              target:
-#                - aarch64-unknown-linux-gnu
-#                - arm-unknown-linux-gnueabi
-#                - x86_64-unknown-linux-gnu
-#                - x86_64-pc-windows-gnu
-#      - cross_build:
-#          <<: *tag-only
-#          pre-steps:
-#            - install_rust
-#            - install_cross
-#          matrix:
-#            alias: cross-build-macos
-#            parameters:
-#              os:
-#                - macos
-#              target:
-#                - x86_64-apple-darwin
+      - build
+      - test
+      - cpp_format
+      - wasm_test
+      - integration_test
+      - zokrates_js_build
+      - zokrates_js_test
       - cross_build:
-#          <<: *tag-only
+          <<: *tag-only
           pre-steps:
             - install_rust
             - install_cross
-            - run: |
-                xcodebuild -showsdks
-                export SDKROOT=$(xcrun -sdk macosx11.1 --show-sdk-path)
-                export MACOSX_DEPLOYMENT_TARGET=$(xcrun -sdk macosx11.1 --show-sdk-platform-version)
+          matrix:
+            alias: cross-build-linux
+            parameters:
+              os:
+                - linux
+              target:
+                - aarch64-unknown-linux-gnu
+                - arm-unknown-linux-gnueabi
+                - x86_64-unknown-linux-gnu
+                - x86_64-pc-windows-gnu
+      - cross_build:
+          <<: *tag-only
+          pre-steps:
+            - install_rust
+          build-with: cargo
+          matrix:
+            alias: cross-build-macos
+            parameters:
+              os:
+                - macos
+              target:
+                - x86_64-apple-darwin
+      - cross_build:
+          <<: *tag-only
+          pre-steps:
+            - install_rust
+          build-with: SDKROOT=$(xcrun -sdk macosx11.1 --show-sdk-path) MACOSX_DEPLOYMENT_TARGET=$(xcrun -sdk macosx11.1 --show-sdk-platform-version) cargo
           add-target: true
           matrix:
             alias: cross-build-apple-silicon
@@ -285,22 +285,22 @@ workflows:
                 - macos
               target:
                 - aarch64-apple-darwin
-#      - publish_artifacts:
-#          <<: *tag-only
-#          requires:
-#            - cross-build-linux
-#            - cross-build-macos
-#            - cross-build-apple-silicon
-#      - deploy:
-#          filters:
-#            branches:
-#              only:
-#                - deploy
-#          requires:
-#            - build
-#            - test
-#            - cpp_format
-#            - wasm_test
-#            - integration_test
-#            - zokrates_js_build
-#            - zokrates_js_test
+      - publish_artifacts:
+          <<: *tag-only
+          requires:
+            - cross-build-linux
+            - cross-build-macos
+            - cross-build-apple-silicon
+      - deploy:
+          filters:
+            branches:
+              only:
+                - deploy
+          requires:
+            - build
+            - test
+            - cpp_format
+            - wasm_test
+            - integration_test
+            - zokrates_js_build
+            - zokrates_js_test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -273,7 +273,10 @@ workflows:
           pre-steps:
             - install_rust
             - install_cross
-            - run: xcodebuild -showsdks
+            - run: |
+                xcodebuild -showsdks
+                export SDKROOT=$(xcrun -sdk macosx11.1 --show-sdk-path)
+                export MACOSX_DEPLOYMENT_TARGET=$(xcrun -sdk macosx11.1 --show-sdk-platform-version)
           add-target: true
           matrix:
             alias: cross-build-apple-silicon

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -149,12 +149,19 @@ jobs:
         type: executor
       target:
         type: string
+      add-target:
+        type: boolean
+        default: false
     executor: << parameters.os >>
     steps:
       - checkout
       - run:
           name: Calculate dependencies
           command: cargo generate-lockfile
+      - when:
+         condition: << parameters.add-target >>
+         steps:
+           - run: rustup target add << parameters.target >>
       - run:
           no_output_timeout: "30m"
           command: cross build --target << parameters.target >> --release
@@ -227,55 +234,70 @@ tag-only: &tag-only
 workflows:
   build-test-and-deploy:
     jobs:
-      - build
-      - test
-      - cpp_format
-      - wasm_test
-      - integration_test
-      - zokrates_js_build
-      - zokrates_js_test
+#      - build
+#      - test
+#      - cpp_format
+#      - wasm_test
+#      - integration_test
+#      - zokrates_js_build
+#      - zokrates_js_test
+#      - cross_build:
+#          <<: *tag-only
+#          pre-steps:
+#            - install_rust
+#            - install_cross
+#          matrix:
+#            alias: cross-build-linux
+#            parameters:
+#              os:
+#                - linux
+#              target:
+#                - aarch64-unknown-linux-gnu
+#                - arm-unknown-linux-gnueabi
+#                - x86_64-unknown-linux-gnu
+#                - x86_64-pc-windows-gnu
+#      - cross_build:
+#          <<: *tag-only
+#          pre-steps:
+#            - install_rust
+#            - install_cross
+#          matrix:
+#            alias: cross-build-macos
+#            parameters:
+#              os:
+#                - macos
+#              target:
+#                - x86_64-apple-darwin
       - cross_build:
-          <<: *tag-only
+#          <<: *tag-only
           pre-steps:
             - install_rust
             - install_cross
+            - run: xcodebuild -showsdks
+          add-target: true
           matrix:
-            alias: cross-build-linux
-            parameters:
-              os:
-                - linux
-              target:
-                - aarch64-unknown-linux-gnu
-                - arm-unknown-linux-gnueabi
-                - x86_64-unknown-linux-gnu
-                - x86_64-pc-windows-gnu
-      - cross_build:
-          <<: *tag-only
-          pre-steps:
-            - install_rust
-            - install_cross
-          matrix:
-            alias: cross-build-macos
+            alias: cross-build-apple-silicon
             parameters:
               os:
                 - macos
               target:
-                - x86_64-apple-darwin
-      - publish_artifacts:
-          <<: *tag-only
-          requires:
-            - cross-build-linux
-            - cross-build-macos
-      - deploy:
-          filters:
-            branches:
-              only:
-                - deploy
-          requires:
-            - build
-            - test
-            - cpp_format
-            - wasm_test
-            - integration_test
-            - zokrates_js_build
-            - zokrates_js_test
+                - aarch64-apple-darwin
+#      - publish_artifacts:
+#          <<: *tag-only
+#          requires:
+#            - cross-build-linux
+#            - cross-build-macos
+#            - cross-build-apple-silicon
+#      - deploy:
+#          filters:
+#            branches:
+#              only:
+#                - deploy
+#          requires:
+#            - build
+#            - test
+#            - cpp_format
+#            - wasm_test
+#            - integration_test
+#            - zokrates_js_build
+#            - zokrates_js_test


### PR DESCRIPTION
Add support for `aarch64-apple-darwin` (apple-silicon) cross compilation

Successful run with uploaded artifacts: https://app.circleci.com/pipelines/github/Zokrates/ZoKrates/2769/workflows/140cd93e-78f9-4cfe-9d01-232a27e0e5ab/jobs/14164

Closes https://github.com/Zokrates/ZoKrates/issues/936