### PR TITLE
Patch abi encoder struct bug

### DIFF
--- a/changelogs/unreleased/947-schaeff
+++ b/changelogs/unreleased/947-schaeff
@@ -1,0 +1,1 @@
+Fix abi encoder bug for struct values where the members are encoded in the wrong order

--- a/zokrates_abi/src/lib.rs
+++ b/zokrates_abi/src/lib.rs
@@ -14,13 +14,10 @@ impl<T: From<usize>> Encode<T> for Inputs<T> {
     }
 }
 
-use std::collections::BTreeMap;
 use std::fmt;
 use zokrates_core::typed_absy::types::{ConcreteType, UBitwidth};
 
 use zokrates_field::Field;
-
-type Map<K, V> = BTreeMap<K, V>;
 
 #[derive(Debug, PartialEq)]
 pub enum Error {
@@ -48,7 +45,7 @@ pub enum Value<T> {
     Field(T),
     Boolean(bool),
     Array(Vec<Value<T>>),
-    Struct(Map<String, Value<T>>),
+    Struct(Vec<(String, Value<T>)>),
 }
 
 #[derive(PartialEq, Debug)]

--- a/zokrates_abi/src/lib.rs
+++ b/zokrates_abi/src/lib.rs
@@ -325,7 +325,6 @@ pub fn parse_strict<T: Field>(s: &str, types: Vec<ConcreteType>) -> Result<Value
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::iter::FromIterator;
     use zokrates_core::typed_absy::types::{
         ConcreteStructMember, ConcreteStructType, ConcreteType,
     };
@@ -505,10 +504,10 @@ mod tests {
             Value::U64(5u64),
             Value::Boolean(true),
             Value::Array(vec![Value::Field(1.into()), Value::Field(2.into())]),
-            Value::Struct(BTreeMap::from_iter(vec![
+            Value::Struct(vec![
                 ("a".to_string(), Value::Field(1.into())),
                 ("b".to_string(), Value::Field(2.into())),
-            ])),
+            ]),
         ]);
 
         let serde_value = values.into_serde_json();


### PR DESCRIPTION
Struct inputs a represented as BTreeMaps, when encoding the ordering is that of the Ord trait, not that of the declared struct members.

Tested locally with

```zokrates
struct Foo {
    field b
    bool a
}

// this tests the abi, checking that the fields of a `Foo` instance get encoded in the right order
// if the the encoder reverses `a` and `b`, the boolean check ends up being done on the field value, which would fail
def main(Foo f):
    return
```

Without this change, passing: 
```json
[{
    "a":true,
    "b": "3"
}]
```

Fails as the boolean is passed first, and the boolean check applied to b == 3, failing.

With this change, this run completes as expected.