### PR TITLE
Enforce constant range check in uint lt check

### DIFF
--- a/changelogs/unreleased/954-schaeff
+++ b/changelogs/unreleased/954-schaeff
@@ -1,0 +1,1 @@
+Fix constant range check in uint lt check

--- a/zokrates_core/src/flatten/mod.rs
+++ b/zokrates_core/src/flatten/mod.rs
@@ -984,7 +984,7 @@ impl<'ast, T: Field> Flattener<'ast, T> {
                 }
 
                 // check that the decomposition is in the field with a strict `< p` checks
-                self.constant_le_check(
+                self.enforce_constant_le_check(
                     statements_flattened,
                     &sub_bits_be,
                     &T::max_value().bit_vector_be(),

--- a/zokrates_core/src/flatten/mod.rs
+++ b/zokrates_core/src/flatten/mod.rs
@@ -215,6 +215,7 @@ impl<'ast, T: Field> Flattener<'ast, T> {
     ///                   **true => a -> 0
     ///      sizeUnkown *
     ///                   **false => a -> {0,1}
+    #[must_use]
     fn constant_le_check(
         &mut self,
         statements_flattened: &mut FlatStatements<T>,

--- a/zokrates_core/tests/out_of_range.rs
+++ b/zokrates_core/tests/out_of_range.rs
@@ -12,7 +12,7 @@ use zokrates_core::{
 use zokrates_field::Bn128Field;
 
 #[test]
-fn out_of_range() {
+fn lt_field() {
     let source = r#"
 		def main(private field a, private field b) -> field:
 	        field x = if a < b then 3333 else 4444 fi
@@ -21,7 +21,39 @@ fn out_of_range() {
 	"#
     .to_string();
 
-    // let's try to prove that "10000 < 5555" is true by exploiting
+    // let's try to prove that "10000f < 5555f" is true by exploiting
+    // the fact that `2*10000 - 2*5555` has two distinct bit decompositions
+    // we chose the one which is out of range, ie the sum check features an overflow
+
+    let res: CompilationArtifacts<Bn128Field> = compile(
+        source,
+        "./path/to/file".into(),
+        None::<&dyn Resolver<io::Error>>,
+        &CompileConfig::default(),
+    )
+    .unwrap();
+
+    let interpreter = Interpreter::try_out_of_range();
+
+    assert!(interpreter
+        .execute(
+            &res.prog(),
+            &[Bn128Field::from(10000), Bn128Field::from(5555)]
+        )
+        .is_err());
+}
+
+#[test]
+fn lt_uint() {
+    let source = r#"
+		def main(private u32 a, private u32 b):
+	        field x = if a < b then 3333 else 4444 fi
+	        assert(x == 3333)
+			return
+	"#
+    .to_string();
+
+    // let's try to prove that "10000u32 < 5555u32" is true by exploiting
     // the fact that `2*10000 - 2*5555` has two distinct bit decompositions
     // we chose the one which is out of range, ie the sum check features an overflow
 


### PR DESCRIPTION
The constant range check is not being enforced on uint variable comparisons.
Enforce it, force the returns of `constant_le_check` to be used, add test using the out of range interpreter.