### PR TITLE
Use `remap-path-prefix` to remove circleci paths from release build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -168,7 +168,7 @@ jobs:
       - run:
           name: Build
           no_output_timeout: "30m"
-          command: << parameters.build-with >> build --target << parameters.target >> --release
+          command: RUSTFLAGS="--remap-path-prefix=$PWD=" << parameters.build-with >> build --target << parameters.target >> --release
       - tar_artifacts:
           target: << parameters.target >>
   publish_artifacts:

--- a/build_release.sh
+++ b/build_release.sh
@@ -2,6 +2,7 @@
 
 # Exit if any subcommand fails
 set -e
+export RUSTFLAGS="--remap-path-prefix=$PWD="
 
 if [ -n "$WITH_LIBSNARK" ]; then
 	cargo build --release --package zokrates_cli --features="libsnark"


### PR DESCRIPTION
This will remove `/home/circleci/project` path from the release builds in case of unexpected errors.