### PR TITLE
Fix empty spread propagation

### DIFF
--- a/changelogs/unreleased/987-schaeff
+++ b/changelogs/unreleased/987-schaeff
@@ -1,0 +1,1 @@
+Fix incorrect propagation of spreads

--- a/zokrates_cli/examples/empty_spread_propagation.zok
+++ b/zokrates_cli/examples/empty_spread_propagation.zok
@@ -1,0 +1,16 @@
+def func<N>() -> bool:
+    for u32 i in 0..N do
+    endfor
+
+    u64[N] y = [...[0; N-1], 1] // the rhs should *not* be reduced to [1] because the spread is not empty
+    u64 q = 0
+
+    for u32 i in 0..N do
+        q = y[i]
+    endfor
+
+    return true
+
+def main():
+    assert(func::<2>())
+    return

--- a/zokrates_core/src/static_analysis/propagation.rs
+++ b/zokrates_core/src/static_analysis/propagation.rs
@@ -1078,7 +1078,11 @@ impl<'ast, 'a, T: Field> ResultFolder<'ast, T> for Propagator<'ast, 'a, T> {
                         })
                         // ignore spreads over empty arrays
                         .filter_map(|e| match e {
-                            TypedExpressionOrSpread::Spread(s) if s.array.size() == 0 => None,
+                            TypedExpressionOrSpread::Spread(s)
+                                if s.array.size() == UExpression::from(0u32) =>
+                            {
+                                None
+                            }
                             e => Some(e),
                         })
                         .collect(),


### PR DESCRIPTION
We incorrectly use `PartialEq<usize>` which isn't strict enough for any non constant expression. Use `PartialEq<UExpression>` instead.

closes #981 