### PR TITLE
Remove cast to usize causing wrong values in wasm environment

### DIFF
--- a/changelogs/unreleased/998-dark64
+++ b/changelogs/unreleased/998-dark64
@@ -1,0 +1,1 @@
+Fix invalid cast to `usize` which caused wrong values in 32-bit environments

--- a/zokrates_core/src/flatten/mod.rs
+++ b/zokrates_core/src/flatten/mod.rs
@@ -1465,7 +1465,7 @@ impl<'ast, T: Field> Flattener<'ast, T> {
 
         let res = match expr.into_inner() {
             UExpressionInner::Value(x) => {
-                FlatUExpression::with_field(FlatExpression::Number(T::from(x as usize)))
+                FlatUExpression::with_field(FlatExpression::Number(T::from(x)))
             } // force to be a field element
             UExpressionInner::Identifier(x) => {
                 let field = FlatExpression::Identifier(*self.layout.get(&x).unwrap());


### PR DESCRIPTION
`u64` type seems to be broken in wasm environments: `x as usize` rounds any uint number bigger than `u32` down to `u32` because in web assembly  `usize` is equal to `u32`. This means the `u64` type is unusable in `zokrates-js <= 1.0.35` :eyes: