### PR TITLE
Reduce the size of the verifier for schemes G16 and PGHR13

### DIFF
--- a/changelogs/unreleased/1008-m1cm1c
+++ b/changelogs/unreleased/1008-m1cm1c
@@ -1,0 +1,1 @@
+Reduce the deployment cost of the g16 and pghr13 verifiers

--- a/zokrates_core/src/proof_system/scheme/gm17.rs
+++ b/zokrates_core/src/proof_system/scheme/gm17.rs
@@ -49,7 +49,7 @@ impl Scheme<Bw6_761Field> for GM17 {
 impl<T: SolidityCompatibleField + NotBw6_761Field> SolidityCompatibleScheme<T> for GM17 {
     fn export_solidity_verifier(vk: <GM17 as Scheme<T>>::VerificationKey) -> String {
         let (mut template_text, solidity_pairing_lib) =
-            (String::from(CONTRACT_TEMPLATE), solidity_pairing_lib(false));
+            (String::from(CONTRACT_TEMPLATE), solidity_pairing_lib(true));
 
         // replace things in template
         let vk_regex = Regex::new(r#"(<%vk_[^i%]*%>)"#).unwrap();

--- a/zokrates_core/src/proof_system/scheme/gm17.rs
+++ b/zokrates_core/src/proof_system/scheme/gm17.rs
@@ -48,10 +48,8 @@ impl Scheme<Bw6_761Field> for GM17 {
 
 impl<T: SolidityCompatibleField + NotBw6_761Field> SolidityCompatibleScheme<T> for GM17 {
     fn export_solidity_verifier(vk: <GM17 as Scheme<T>>::VerificationKey) -> String {
-        let (mut template_text, solidity_pairing_lib) = (
-            String::from(CONTRACT_TEMPLATE),
-            String::from(solidity_pairing_lib(false)),
-        );
+        let (mut template_text, solidity_pairing_lib) =
+            (String::from(CONTRACT_TEMPLATE), solidity_pairing_lib(false));
 
         // replace things in template
         let vk_regex = Regex::new(r#"(<%vk_[^i%]*%>)"#).unwrap();

--- a/zokrates_core/src/proof_system/scheme/gm17.rs
+++ b/zokrates_core/src/proof_system/scheme/gm17.rs
@@ -1,5 +1,5 @@
 use crate::proof_system::scheme::{NonUniversalScheme, Scheme};
-use crate::proof_system::solidity::{SOLIDITY_G2_ADDITION_LIB, SOLIDITY_PAIRING_LIB};
+use crate::proof_system::solidity::{solidity_pairing_lib, SOLIDITY_G2_ADDITION_LIB};
 use crate::proof_system::{
     G1Affine, G2Affine, G2AffineFq, SolidityCompatibleField, SolidityCompatibleScheme,
 };
@@ -50,7 +50,7 @@ impl<T: SolidityCompatibleField + NotBw6_761Field> SolidityCompatibleScheme<T> f
     fn export_solidity_verifier(vk: <GM17 as Scheme<T>>::VerificationKey) -> String {
         let (mut template_text, solidity_pairing_lib) = (
             String::from(CONTRACT_TEMPLATE),
-            String::from(SOLIDITY_PAIRING_LIB),
+            String::from(solidity_pairing_lib(false)),
         );
 
         // replace things in template

--- a/zokrates_core/src/proof_system/scheme/groth16.rs
+++ b/zokrates_core/src/proof_system/scheme/groth16.rs
@@ -1,5 +1,5 @@
 use crate::proof_system::scheme::{NonUniversalScheme, Scheme};
-use crate::proof_system::solidity::{SOLIDITY_PAIRING_LIB_SANS_BN256G2};
+use crate::proof_system::solidity::SOLIDITY_PAIRING_LIB_SANS_BN256G2;
 use crate::proof_system::{G1Affine, G2Affine, SolidityCompatibleField, SolidityCompatibleScheme};
 use regex::Regex;
 use serde::{Deserialize, Serialize};
@@ -122,10 +122,7 @@ impl<T: SolidityCompatibleField> SolidityCompatibleScheme<T> for G16 {
         let re = Regex::new(r"(?P<v>0[xX][0-9a-fA-F]{64})").unwrap();
         template_text = re.replace_all(&template_text, "uint256($v)").to_string();
 
-        format!(
-            "{}{}",
-            solidity_pairing_lib_sans_bn256g2, template_text
-        )
+        format!("{}{}", solidity_pairing_lib_sans_bn256g2, template_text)
     }
 }
 

--- a/zokrates_core/src/proof_system/scheme/groth16.rs
+++ b/zokrates_core/src/proof_system/scheme/groth16.rs
@@ -1,5 +1,5 @@
 use crate::proof_system::scheme::{NonUniversalScheme, Scheme};
-use crate::proof_system::solidity::SOLIDITY_PAIRING_LIB_SANS_BN256G2;
+use crate::proof_system::solidity::solidity_pairing_lib;
 use crate::proof_system::{G1Affine, G2Affine, SolidityCompatibleField, SolidityCompatibleScheme};
 use regex::Regex;
 use serde::{Deserialize, Serialize};
@@ -34,7 +34,7 @@ impl<T: SolidityCompatibleField> SolidityCompatibleScheme<T> for G16 {
     fn export_solidity_verifier(vk: <G16 as Scheme<T>>::VerificationKey) -> String {
         let (mut template_text, solidity_pairing_lib_sans_bn256g2) = (
             String::from(CONTRACT_TEMPLATE),
-            String::from(SOLIDITY_PAIRING_LIB_SANS_BN256G2),
+            String::from(solidity_pairing_lib(false)),
         );
 
         let vk_regex = Regex::new(r#"(<%vk_[^i%]*%>)"#).unwrap();

--- a/zokrates_core/src/proof_system/scheme/groth16.rs
+++ b/zokrates_core/src/proof_system/scheme/groth16.rs
@@ -1,5 +1,5 @@
 use crate::proof_system::scheme::{NonUniversalScheme, Scheme};
-use crate::proof_system::solidity::{SOLIDITY_G2_ADDITION_LIB, SOLIDITY_PAIRING_LIB};
+use crate::proof_system::solidity::{SOLIDITY_PAIRING_LIB_SANS_BN256G2};
 use crate::proof_system::{G1Affine, G2Affine, SolidityCompatibleField, SolidityCompatibleScheme};
 use regex::Regex;
 use serde::{Deserialize, Serialize};
@@ -32,9 +32,9 @@ impl<T: Field> NonUniversalScheme<T> for G16 {}
 
 impl<T: SolidityCompatibleField> SolidityCompatibleScheme<T> for G16 {
     fn export_solidity_verifier(vk: <G16 as Scheme<T>>::VerificationKey) -> String {
-        let (mut template_text, solidity_pairing_lib) = (
+        let (mut template_text, solidity_pairing_lib_sans_bn256g2) = (
             String::from(CONTRACT_TEMPLATE),
-            String::from(SOLIDITY_PAIRING_LIB),
+            String::from(SOLIDITY_PAIRING_LIB_SANS_BN256G2),
         );
 
         let vk_regex = Regex::new(r#"(<%vk_[^i%]*%>)"#).unwrap();
@@ -123,8 +123,8 @@ impl<T: SolidityCompatibleField> SolidityCompatibleScheme<T> for G16 {
         template_text = re.replace_all(&template_text, "uint256($v)").to_string();
 
         format!(
-            "{}{}{}",
-            SOLIDITY_G2_ADDITION_LIB, solidity_pairing_lib, template_text
+            "{}{}",
+            solidity_pairing_lib_sans_bn256g2, template_text
         )
     }
 }

--- a/zokrates_core/src/proof_system/scheme/groth16.rs
+++ b/zokrates_core/src/proof_system/scheme/groth16.rs
@@ -32,10 +32,8 @@ impl<T: Field> NonUniversalScheme<T> for G16 {}
 
 impl<T: SolidityCompatibleField> SolidityCompatibleScheme<T> for G16 {
     fn export_solidity_verifier(vk: <G16 as Scheme<T>>::VerificationKey) -> String {
-        let (mut template_text, solidity_pairing_lib_sans_bn256g2) = (
-            String::from(CONTRACT_TEMPLATE),
-            String::from(solidity_pairing_lib(false)),
-        );
+        let (mut template_text, solidity_pairing_lib_sans_bn256g2) =
+            (String::from(CONTRACT_TEMPLATE), solidity_pairing_lib(false));
 
         let vk_regex = Regex::new(r#"(<%vk_[^i%]*%>)"#).unwrap();
         let vk_gamma_abc_len_regex = Regex::new(r#"(<%vk_gamma_abc_length%>)"#).unwrap();

--- a/zokrates_core/src/proof_system/scheme/pghr13.rs
+++ b/zokrates_core/src/proof_system/scheme/pghr13.rs
@@ -41,10 +41,8 @@ impl<T: Field> NonUniversalScheme<T> for PGHR13 {}
 
 impl<T: SolidityCompatibleField> SolidityCompatibleScheme<T> for PGHR13 {
     fn export_solidity_verifier(vk: <PGHR13 as Scheme<T>>::VerificationKey) -> String {
-        let (mut template_text, solidity_pairing_lib) = (
-            String::from(CONTRACT_TEMPLATE),
-            String::from(solidity_pairing_lib(false)),
-        );
+        let (mut template_text, solidity_pairing_lib) =
+            (String::from(CONTRACT_TEMPLATE), solidity_pairing_lib(false));
 
         // replace things in template
         let vk_regex = Regex::new(r#"(<%vk_[^i%]*%>)"#).unwrap();

--- a/zokrates_core/src/proof_system/scheme/pghr13.rs
+++ b/zokrates_core/src/proof_system/scheme/pghr13.rs
@@ -1,5 +1,5 @@
 use crate::proof_system::scheme::{NonUniversalScheme, Scheme};
-use crate::proof_system::solidity::{solidity_pairing_lib, SOLIDITY_G2_ADDITION_LIB};
+use crate::proof_system::solidity::solidity_pairing_lib;
 use crate::proof_system::{G1Affine, G2Affine, SolidityCompatibleField, SolidityCompatibleScheme};
 use regex::Regex;
 use serde::{Deserialize, Serialize};
@@ -136,10 +136,7 @@ impl<T: SolidityCompatibleField> SolidityCompatibleScheme<T> for PGHR13 {
         let re = Regex::new(r"(?P<v>0[xX][0-9a-fA-F]{64})").unwrap();
         template_text = re.replace_all(&template_text, "uint256($v)").to_string();
 
-        format!(
-            "{}{}{}",
-            SOLIDITY_G2_ADDITION_LIB, solidity_pairing_lib, template_text
-        )
+        format!("{}{}", solidity_pairing_lib, template_text)
     }
 }
 

--- a/zokrates_core/src/proof_system/scheme/pghr13.rs
+++ b/zokrates_core/src/proof_system/scheme/pghr13.rs
@@ -1,5 +1,5 @@
 use crate::proof_system::scheme::{NonUniversalScheme, Scheme};
-use crate::proof_system::solidity::{SOLIDITY_G2_ADDITION_LIB, SOLIDITY_PAIRING_LIB};
+use crate::proof_system::solidity::{solidity_pairing_lib, SOLIDITY_G2_ADDITION_LIB};
 use crate::proof_system::{G1Affine, G2Affine, SolidityCompatibleField, SolidityCompatibleScheme};
 use regex::Regex;
 use serde::{Deserialize, Serialize};
@@ -43,7 +43,7 @@ impl<T: SolidityCompatibleField> SolidityCompatibleScheme<T> for PGHR13 {
     fn export_solidity_verifier(vk: <PGHR13 as Scheme<T>>::VerificationKey) -> String {
         let (mut template_text, solidity_pairing_lib) = (
             String::from(CONTRACT_TEMPLATE),
-            String::from(SOLIDITY_PAIRING_LIB),
+            String::from(solidity_pairing_lib(false)),
         );
 
         // replace things in template

--- a/zokrates_core/src/proof_system/solidity.rs
+++ b/zokrates_core/src/proof_system/solidity.rs
@@ -564,7 +564,12 @@ library Pairing {
     let pairing_lib = if !with_g2_addition {
         [pairing_lib_beginning, pairing_lib_ending].join("\n")
     } else {
-        [pairing_lib_beginning, pairing_lib_g2_addition, pairing_lib_ending].join("\n")
+        [
+            pairing_lib_beginning,
+            pairing_lib_g2_addition,
+            pairing_lib_ending,
+        ]
+        .join("\n")
     };
     return pairing_lib;
 }

--- a/zokrates_core/src/proof_system/solidity.rs
+++ b/zokrates_core/src/proof_system/solidity.rs
@@ -407,7 +407,7 @@ library BN256G2 {
 "#;
 
 pub fn solidity_pairing_lib(with_g2_addition: bool) -> String {
-    let pairingLibBeginning = r#"// This file is MIT Licensed.
+    let pairing_lib_beginning = r#"// This file is MIT Licensed.
 //
 // Copyright 2017 Christian Reitwiessner
 // Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
@@ -462,14 +462,14 @@ library Pairing {
     }
 "#;
 
-    let pairingLibG2Addition = r#"
+    let pairing_lib_g2_addition = r#"
     /// @return r the sum of two points of G2
     function addition(G2Point memory p1, G2Point memory p2) internal view returns (G2Point memory r) {
         (r.X[0], r.X[1], r.Y[0], r.Y[1]) = BN256G2.ECTwistAdd(p1.X[0],p1.X[1],p1.Y[0],p1.Y[1],p2.X[0],p2.X[1],p2.Y[0],p2.Y[1]);
     }
 "#;
 
-    let pairingLibEnding = r#"
+    let pairing_lib_ending = r#"
     /// @return r the product of a point on G1 and a scalar, i.e.
     /// p == p.scalar_mul(1) and p.addition(p) == p.scalar_mul(2) for all points p.
     function scalar_mul(G1Point memory p, uint s) internal view returns (G1Point memory r) {
@@ -561,10 +561,10 @@ library Pairing {
 }
 "#;
 
-    let pairingLib = if (!with_g2_addition) {
-        [pairingLibBeginning, pairingLibEnding].join("\n")
+    let pairing_lib = if !with_g2_addition {
+        [pairing_lib_beginning, pairing_lib_ending].join("\n")
     } else {
-        [pairingLibBeginning, pairingLibG2Addition, pairingLibEnding].join("\n")
+        [pairing_lib_beginning, pairing_lib_g2_addition, pairing_lib_ending].join("\n")
     };
-    return pairingLib;
+    return pairing_lib;
 }

--- a/zokrates_core/src/proof_system/solidity.rs
+++ b/zokrates_core/src/proof_system/solidity.rs
@@ -553,3 +553,147 @@ library Pairing {
     }
 }
 "#;
+
+pub const SOLIDITY_PAIRING_LIB_SANS_BN256G2: &str = r#"// This file is MIT Licensed.
+//
+// Copyright 2017 Christian Reitwiessner
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+pragma solidity ^0.8.0;
+library Pairing {
+    struct G1Point {
+        uint X;
+        uint Y;
+    }
+    // Encoding of field elements is: X[0] * z + X[1]
+    struct G2Point {
+        uint[2] X;
+        uint[2] Y;
+    }
+    /// @return the generator of G1
+    function P1() pure internal returns (G1Point memory) {
+        return G1Point(1, 2);
+    }
+    /// @return the generator of G2
+    function P2() pure internal returns (G2Point memory) {
+        return G2Point(
+            [10857046999023057135944570762232829481370756359578518086990519993285655852781,
+             11559732032986387107991004021392285783925812861821192530917403151452391805634],
+            [8495653923123431417604973247489272438418190587263600148770280649306958101930,
+             4082367875863433681332203403145435568316851327593401208105741076214120093531]
+        );
+    }
+    /// @return the negation of p, i.e. p.addition(p.negate()) should be zero.
+    function negate(G1Point memory p) pure internal returns (G1Point memory) {
+        // The prime q in the base field F_q for G1
+        uint q = 21888242871839275222246405745257275088696311157297823662689037894645226208583;
+        if (p.X == 0 && p.Y == 0)
+            return G1Point(0, 0);
+        return G1Point(p.X, q - (p.Y % q));
+    }
+    /// @return r the sum of two points of G1
+    function addition(G1Point memory p1, G1Point memory p2) internal view returns (G1Point memory r) {
+        uint[4] memory input;
+        input[0] = p1.X;
+        input[1] = p1.Y;
+        input[2] = p2.X;
+        input[3] = p2.Y;
+        bool success;
+        assembly {
+            success := staticcall(sub(gas(), 2000), 6, input, 0xc0, r, 0x60)
+            // Use "invalid" to make gas estimation work
+            switch success case 0 { invalid() }
+        }
+        require(success);
+    }
+    /// @return r the product of a point on G1 and a scalar, i.e.
+    /// p == p.scalar_mul(1) and p.addition(p) == p.scalar_mul(2) for all points p.
+    function scalar_mul(G1Point memory p, uint s) internal view returns (G1Point memory r) {
+        uint[3] memory input;
+        input[0] = p.X;
+        input[1] = p.Y;
+        input[2] = s;
+        bool success;
+        assembly {
+            success := staticcall(sub(gas(), 2000), 7, input, 0x80, r, 0x60)
+            // Use "invalid" to make gas estimation work
+            switch success case 0 { invalid() }
+        }
+        require (success);
+    }
+    /// @return the result of computing the pairing check
+    /// e(p1[0], p2[0]) *  .... * e(p1[n], p2[n]) == 1
+    /// For example pairing([P1(), P1().negate()], [P2(), P2()]) should
+    /// return true.
+    function pairing(G1Point[] memory p1, G2Point[] memory p2) internal view returns (bool) {
+        require(p1.length == p2.length);
+        uint elements = p1.length;
+        uint inputSize = elements * 6;
+        uint[] memory input = new uint[](inputSize);
+        for (uint i = 0; i < elements; i++)
+        {
+            input[i * 6 + 0] = p1[i].X;
+            input[i * 6 + 1] = p1[i].Y;
+            input[i * 6 + 2] = p2[i].X[1];
+            input[i * 6 + 3] = p2[i].X[0];
+            input[i * 6 + 4] = p2[i].Y[1];
+            input[i * 6 + 5] = p2[i].Y[0];
+        }
+        uint[1] memory out;
+        bool success;
+        assembly {
+            success := staticcall(sub(gas(), 2000), 8, add(input, 0x20), mul(inputSize, 0x20), out, 0x20)
+            // Use "invalid" to make gas estimation work
+            switch success case 0 { invalid() }
+        }
+        require(success);
+        return out[0] != 0;
+    }
+    /// Convenience method for a pairing check for two pairs.
+    function pairingProd2(G1Point memory a1, G2Point memory a2, G1Point memory b1, G2Point memory b2) internal view returns (bool) {
+        G1Point[] memory p1 = new G1Point[](2);
+        G2Point[] memory p2 = new G2Point[](2);
+        p1[0] = a1;
+        p1[1] = b1;
+        p2[0] = a2;
+        p2[1] = b2;
+        return pairing(p1, p2);
+    }
+    /// Convenience method for a pairing check for three pairs.
+    function pairingProd3(
+            G1Point memory a1, G2Point memory a2,
+            G1Point memory b1, G2Point memory b2,
+            G1Point memory c1, G2Point memory c2
+    ) internal view returns (bool) {
+        G1Point[] memory p1 = new G1Point[](3);
+        G2Point[] memory p2 = new G2Point[](3);
+        p1[0] = a1;
+        p1[1] = b1;
+        p1[2] = c1;
+        p2[0] = a2;
+        p2[1] = b2;
+        p2[2] = c2;
+        return pairing(p1, p2);
+    }
+    /// Convenience method for a pairing check for four pairs.
+    function pairingProd4(
+            G1Point memory a1, G2Point memory a2,
+            G1Point memory b1, G2Point memory b2,
+            G1Point memory c1, G2Point memory c2,
+            G1Point memory d1, G2Point memory d2
+    ) internal view returns (bool) {
+        G1Point[] memory p1 = new G1Point[](4);
+        G2Point[] memory p2 = new G2Point[](4);
+        p1[0] = a1;
+        p1[1] = b1;
+        p1[2] = c1;
+        p1[3] = d1;
+        p2[0] = a2;
+        p2[1] = b2;
+        p2[2] = c2;
+        p2[3] = d2;
+        return pairing(p1, p2);
+    }
+}
+"#;

--- a/zokrates_core/src/proof_system/solidity.rs
+++ b/zokrates_core/src/proof_system/solidity.rs
@@ -561,7 +561,7 @@ library Pairing {
 }
 "#;
 
-    let pairing_lib = if !with_g2_addition {
+    if !with_g2_addition {
         [pairing_lib_beginning, pairing_lib_ending].join("\n")
     } else {
         [
@@ -570,6 +570,5 @@ library Pairing {
             pairing_lib_ending,
         ]
         .join("\n")
-    };
-    return pairing_lib;
+    }
 }

--- a/zokrates_core/src/proof_system/solidity.rs
+++ b/zokrates_core/src/proof_system/solidity.rs
@@ -406,7 +406,8 @@ library BN256G2 {
 }
 "#;
 
-pub const SOLIDITY_PAIRING_LIB: &str = r#"// This file is MIT Licensed.
+pub fn solidity_pairing_lib(with_g2_addition: bool) -> String {
+    let pairingLibBeginning = r#"// This file is MIT Licensed.
 //
 // Copyright 2017 Christian Reitwiessner
 // Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
@@ -459,10 +460,16 @@ library Pairing {
         }
         require(success);
     }
+"#;
+
+    let pairingLibG2Addition = r#"
     /// @return r the sum of two points of G2
     function addition(G2Point memory p1, G2Point memory p2) internal view returns (G2Point memory r) {
         (r.X[0], r.X[1], r.Y[0], r.Y[1]) = BN256G2.ECTwistAdd(p1.X[0],p1.X[1],p1.Y[0],p1.Y[1],p2.X[0],p2.X[1],p2.Y[0],p2.Y[1]);
     }
+"#;
+
+    let pairingLibEnding = r#"
     /// @return r the product of a point on G1 and a scalar, i.e.
     /// p == p.scalar_mul(1) and p.addition(p) == p.scalar_mul(2) for all points p.
     function scalar_mul(G1Point memory p, uint s) internal view returns (G1Point memory r) {
@@ -554,146 +561,10 @@ library Pairing {
 }
 "#;
 
-pub const SOLIDITY_PAIRING_LIB_SANS_BN256G2: &str = r#"// This file is MIT Licensed.
-//
-// Copyright 2017 Christian Reitwiessner
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-pragma solidity ^0.8.0;
-library Pairing {
-    struct G1Point {
-        uint X;
-        uint Y;
-    }
-    // Encoding of field elements is: X[0] * z + X[1]
-    struct G2Point {
-        uint[2] X;
-        uint[2] Y;
-    }
-    /// @return the generator of G1
-    function P1() pure internal returns (G1Point memory) {
-        return G1Point(1, 2);
-    }
-    /// @return the generator of G2
-    function P2() pure internal returns (G2Point memory) {
-        return G2Point(
-            [10857046999023057135944570762232829481370756359578518086990519993285655852781,
-             11559732032986387107991004021392285783925812861821192530917403151452391805634],
-            [8495653923123431417604973247489272438418190587263600148770280649306958101930,
-             4082367875863433681332203403145435568316851327593401208105741076214120093531]
-        );
-    }
-    /// @return the negation of p, i.e. p.addition(p.negate()) should be zero.
-    function negate(G1Point memory p) pure internal returns (G1Point memory) {
-        // The prime q in the base field F_q for G1
-        uint q = 21888242871839275222246405745257275088696311157297823662689037894645226208583;
-        if (p.X == 0 && p.Y == 0)
-            return G1Point(0, 0);
-        return G1Point(p.X, q - (p.Y % q));
-    }
-    /// @return r the sum of two points of G1
-    function addition(G1Point memory p1, G1Point memory p2) internal view returns (G1Point memory r) {
-        uint[4] memory input;
-        input[0] = p1.X;
-        input[1] = p1.Y;
-        input[2] = p2.X;
-        input[3] = p2.Y;
-        bool success;
-        assembly {
-            success := staticcall(sub(gas(), 2000), 6, input, 0xc0, r, 0x60)
-            // Use "invalid" to make gas estimation work
-            switch success case 0 { invalid() }
-        }
-        require(success);
-    }
-    /// @return r the product of a point on G1 and a scalar, i.e.
-    /// p == p.scalar_mul(1) and p.addition(p) == p.scalar_mul(2) for all points p.
-    function scalar_mul(G1Point memory p, uint s) internal view returns (G1Point memory r) {
-        uint[3] memory input;
-        input[0] = p.X;
-        input[1] = p.Y;
-        input[2] = s;
-        bool success;
-        assembly {
-            success := staticcall(sub(gas(), 2000), 7, input, 0x80, r, 0x60)
-            // Use "invalid" to make gas estimation work
-            switch success case 0 { invalid() }
-        }
-        require (success);
-    }
-    /// @return the result of computing the pairing check
-    /// e(p1[0], p2[0]) *  .... * e(p1[n], p2[n]) == 1
-    /// For example pairing([P1(), P1().negate()], [P2(), P2()]) should
-    /// return true.
-    function pairing(G1Point[] memory p1, G2Point[] memory p2) internal view returns (bool) {
-        require(p1.length == p2.length);
-        uint elements = p1.length;
-        uint inputSize = elements * 6;
-        uint[] memory input = new uint[](inputSize);
-        for (uint i = 0; i < elements; i++)
-        {
-            input[i * 6 + 0] = p1[i].X;
-            input[i * 6 + 1] = p1[i].Y;
-            input[i * 6 + 2] = p2[i].X[1];
-            input[i * 6 + 3] = p2[i].X[0];
-            input[i * 6 + 4] = p2[i].Y[1];
-            input[i * 6 + 5] = p2[i].Y[0];
-        }
-        uint[1] memory out;
-        bool success;
-        assembly {
-            success := staticcall(sub(gas(), 2000), 8, add(input, 0x20), mul(inputSize, 0x20), out, 0x20)
-            // Use "invalid" to make gas estimation work
-            switch success case 0 { invalid() }
-        }
-        require(success);
-        return out[0] != 0;
-    }
-    /// Convenience method for a pairing check for two pairs.
-    function pairingProd2(G1Point memory a1, G2Point memory a2, G1Point memory b1, G2Point memory b2) internal view returns (bool) {
-        G1Point[] memory p1 = new G1Point[](2);
-        G2Point[] memory p2 = new G2Point[](2);
-        p1[0] = a1;
-        p1[1] = b1;
-        p2[0] = a2;
-        p2[1] = b2;
-        return pairing(p1, p2);
-    }
-    /// Convenience method for a pairing check for three pairs.
-    function pairingProd3(
-            G1Point memory a1, G2Point memory a2,
-            G1Point memory b1, G2Point memory b2,
-            G1Point memory c1, G2Point memory c2
-    ) internal view returns (bool) {
-        G1Point[] memory p1 = new G1Point[](3);
-        G2Point[] memory p2 = new G2Point[](3);
-        p1[0] = a1;
-        p1[1] = b1;
-        p1[2] = c1;
-        p2[0] = a2;
-        p2[1] = b2;
-        p2[2] = c2;
-        return pairing(p1, p2);
-    }
-    /// Convenience method for a pairing check for four pairs.
-    function pairingProd4(
-            G1Point memory a1, G2Point memory a2,
-            G1Point memory b1, G2Point memory b2,
-            G1Point memory c1, G2Point memory c2,
-            G1Point memory d1, G2Point memory d2
-    ) internal view returns (bool) {
-        G1Point[] memory p1 = new G1Point[](4);
-        G2Point[] memory p2 = new G2Point[](4);
-        p1[0] = a1;
-        p1[1] = b1;
-        p1[2] = c1;
-        p1[3] = d1;
-        p2[0] = a2;
-        p2[1] = b2;
-        p2[2] = c2;
-        p2[3] = d2;
-        return pairing(p1, p2);
-    }
+    let pairingLib = if (!with_g2_addition) {
+        [pairingLibBeginning, pairingLibEnding].join("\n")
+    } else {
+        [pairingLibBeginning, pairingLibG2Addition, pairingLibEnding].join("\n")
+    };
+    return pairingLib;
 }
-"#;


### PR DESCRIPTION
Reduces the size of the verifier for schemes G16 and PGHR13 by 400 LOC (e.g. from 595 LOC to 195 LOC for a small proof).