### PR TITLE
Make operators table more clear in the book

### DIFF
--- a/changelogs/unreleased/1017-dark64
+++ b/changelogs/unreleased/1017-dark64
@@ -1,1 +1,1 @@
-Add a book section on supported arithmetic operations for the `field` type
+Make operators table more clear in the book

--- a/changelogs/unreleased/1017-dark64
+++ b/changelogs/unreleased/1017-dark64
@@ -1,0 +1,1 @@
+Add a book section on supported arithmetic operations for the `field` type

--- a/zokrates_book/.gitignore
+++ b/zokrates_book/.gitignore
@@ -1,1 +1,2 @@
 book
+mdbook

--- a/zokrates_book/src/language/operators.md
+++ b/zokrates_book/src/language/operators.md
@@ -2,21 +2,21 @@
 
 The following table lists the precedence and associativity of all operators. Operators are listed top to bottom, in ascending precedence. Operators in the same cell have the same precedence. Operators are binary, unless the syntax is provided.
 
-| Operator                      | Description                                                   | `field`                      | `u8/u16` `u32/u64`            | `bool`                      | Associativity | Remarks |
-|-------------------------------|---------------------------------------------------------------|------------------------------|-------------------------------|-----------------------------|---------------|---------|
-| `**`<br>                     | Power                                                         | &check;                      | &nbsp;                        | &nbsp;                      | Left          | [^1]    |
+| Operator                   | Description                                                | `field`                      | `u8/u16` `u32/u64`            | `bool`                      | Associativity | Remarks |
+|----------------------------|------------------------------------------------------------|------------------------------|-------------------------------|-----------------------------|---------------|---------|
+| `**`<br>                   | Power                                                      | &check;                      | &nbsp;                        | &nbsp;                      | Left          | [^1]    |
 | `+x`<br>`-x`<br>`!x`<br>   | Positive<br>Negative<br>Negation<br>                       | &check;<br>&check;<br>&nbsp; | &check;<br>&check;<br>&nbsp;  | &nbsp;<br>&nbsp;<br>&check; | Right         |         |
 | `*`<br>`/`<br>`%`<br>      | Multiplication<br> Division<br> Remainder<br>              | &check;<br>&check;<br>&nbsp; | &check;<br>&check;<br>&check; | &nbsp;<br>&nbsp;<br>&nbsp;  | Left          |         |
-| `+`<br>`-`<br>              | Addition<br> Subtraction<br>                                | &check;                      | &check;                       | &nbsp;                      | Left          |         |
-| `<<`<br>`>>`<br>            | Left shift<br> Right shift<br>                              | &nbsp;                       | &check;                       | &nbsp;                      | Left          | [^2]    |
-| `&`                           | Bitwise AND                                                   | &nbsp;                       | &check;                       | &nbsp;                      | Left          |         |
-| <code>&#124;</code>           | Bitwise OR                                                    | &nbsp;                       | &check;                       | &nbsp;                      | Left          |         |
-| `^`                           | Bitwise XOR                                                   | &nbsp;                       | &check;                       | &nbsp;                      | Left          |         |
-| `>=`<br>`>`<br>`<=`<br>`<` | Greater or equal<br>Greater<br>Lower or equal<br>Lower<br>| &check;                      | &check;                       | &nbsp;                      | Left          | [^3]    |
-| `!=`<br>`==`<br>            | Not Equal<br>Equal<br>                                      | &check;                      | &check;                       | &check;                     | Left          |         |
-| `&&`                          | Boolean AND                                                   | &nbsp;                       | &nbsp;                        | &check;                     | Left          |         |
-| <code>&#124;&#124;</code>     | Boolean OR                                                    | &nbsp;                       | &nbsp;                        | &check;                     | Left          |         |
-| `if c then x else y fi`       | Conditional expression                                        | &check;                      | &check;                       | &check;                     | Right         |         |
+| `+`<br>`-`<br>             | Addition<br> Subtraction<br>                               | &check;                      | &check;                       | &nbsp;                      | Left          |         |
+| `<<`<br>`>>`<br>           | Left shift<br> Right shift<br>                             | &nbsp;                       | &check;                       | &nbsp;                      | Left          | [^2]    |
+| `&`                        | Bitwise AND                                                | &nbsp;                       | &check;                       | &nbsp;                      | Left          |         |
+| <code>&#124;</code>        | Bitwise OR                                                 | &nbsp;                       | &check;                       | &nbsp;                      | Left          |         |
+| `^`                        | Bitwise XOR                                                | &nbsp;                       | &check;                       | &nbsp;                      | Left          |         |
+| `>=`<br>`>`<br>`<=`<br>`<` | Greater or equal<br>Greater<br>Lower or equal<br>Lower<br> | &check;                      | &check;                       | &nbsp;                      | Left          | [^3]    |
+| `!=`<br>`==`<br>           | Not Equal<br>Equal<br>                                     | &check;                      | &check;                       | &check;                     | Left          |         |
+| `&&`                       | Boolean AND                                                | &nbsp;                       | &nbsp;                        | &check;                     | Left          |         |
+| <code>&#124;&#124;</code>  | Boolean OR                                                 | &nbsp;                       | &nbsp;                        | &check;                     | Left          |         |
+| `if c then x else y fi`    | Conditional expression                                     | &check;                      | &check;                       | &check;                     | Right         |         |
 
 [^1]: The exponent must be a compile-time constant of type `u32`
 

--- a/zokrates_book/src/language/operators.md
+++ b/zokrates_book/src/language/operators.md
@@ -1,22 +1,22 @@
 ## Operators
 
-The following table lists the precedence and associativity of all operators. Operators are listed top to bottom, in ascending precedence. Operators in the same box group left to right. Operators are binary, unless the syntax is provided.
+The following table lists the precedence and associativity of all operators. Operators are listed top to bottom, in ascending precedence. Operators in the same box group have the same precedence. Operators are binary, unless the syntax is provided.
 
-| Operator                        | Description                                                       | Remarks |
-|---------------------------------|-------------------------------------------------------------------|---------|
-| `**` <br>                       | Power                                                             |  [^1]   |
-| `+x` <br> `-x` <br> `!x` <br>   | Positive <br> Negative <br> Negation <br>                         |         |
-| `*` <br> `/` <br> `%` <br>      | Multiplication <br>  Division <br>  Remainder <br>                |         |
-| `+` <br> `-` <br>               | Addition <br>  Subtraction <br>                                   |         |
-| `<<` <br> `>>` <br>             | Left shift <br>  Right shift <br>                                 |  [^2]   |
-| `&`                             | Bitwise AND                                                       |         |
-| <code>&#124;</code>             | Bitwise OR                                                        |         |
-| `^`                             | Bitwise XOR                                                       |         |
-| `>=` <br> `>` <br> `<=` <br> `<`| Greater or equal <br> Greater <br> Lower or equal <br> Lower <br> |  [^3]   |
-| `!=` <br> `==` <br>             | Not Equal <br> Equal  <br>                                        |         |
-| `&&`                            | Boolean AND                                                       |         |
-| <code>&#124;&#124;</code>       | Boolean OR                                                        |         |
-| `if c then x else y fi`         | Conditional expression                                            |         |
+| Operator                        | Description                                                       | Field                             | Unsigned integers | Bool                              | Associativity | Remarks |
+|---------------------------------|-------------------------------------------------------------------|-----------------------------------|-------------------|-----------------------------------|---------------|---------|
+| `**` <br>                       | Power                                                             | &check;                           | &times;           | &times;                           | Left          | [^1]    |
+| `+x` <br> `-x` <br> `!x` <br>   | Positive <br> Negative <br> Negation <br>                         | &check;                           | &check;           | &times; <br> &times; <br> &check; | Right         |         |
+| `*` <br> `/` <br> `%` <br>      | Multiplication <br>  Division <br>  Remainder <br>                | &check; <br> &check; <br> &times; | &check;           | &times;                           | Left          |         |
+| `+` <br> `-` <br>               | Addition <br>  Subtraction <br>                                   | &check;                           | &check;           | &times;                           | Left          |         |
+| `<<` <br> `>>` <br>             | Left shift <br>  Right shift <br>                                 | &times;                           | &check;           | &times;                           | Left          | [^2]    |
+| `&`                             | Bitwise AND                                                       | &times;                           | &check;           | &times;                           | Left          |         |
+| <code>&#124;</code>             | Bitwise OR                                                        | &times;                           | &check;           | &times;                           | Left          |         |
+| `^`                             | Bitwise XOR                                                       | &times;                           | &check;           | &times;                           | Left          |         |
+| `>=` <br> `>` <br> `<=` <br> `<`| Greater or equal <br> Greater <br> Lower or equal <br> Lower <br> | &check;                           | &check;           | &times;                           | Left          | [^3]    |
+| `!=` <br> `==` <br>             | Not Equal <br> Equal  <br>                                        | &check;                           | &check;           | &check;                           | Left          |         |
+| `&&`                            | Boolean AND                                                       | &times;                           | &times;           | &check;                           | Left          |         |
+| <code>&#124;&#124;</code>       | Boolean OR                                                        | &times;                           | &times;           | &check;                           | Left          |         |
+| `if c then x else y fi`         | Conditional expression                                            | &check;                           | &check;           | &check;                           | Right         |         |
 
 [^1]: The exponent must be a compile-time constant of type `u32`
 

--- a/zokrates_book/src/language/operators.md
+++ b/zokrates_book/src/language/operators.md
@@ -1,22 +1,22 @@
 ## Operators
 
-The following table lists the precedence and associativity of all operators. Operators are listed top to bottom, in ascending precedence. Operators in the same box group have the same precedence. Operators are binary, unless the syntax is provided.
+The following table lists the precedence and associativity of all operators. Operators are listed top to bottom, in ascending precedence. Operators in the same cell have the same precedence. Operators are binary, unless the syntax is provided.
 
-| Operator                        | Description                                                       | Field                             | Unsigned integers | Bool                              | Associativity | Remarks |
-|---------------------------------|-------------------------------------------------------------------|-----------------------------------|-------------------|-----------------------------------|---------------|---------|
-| `**` <br>                       | Power                                                             | &check;                           | &times;           | &times;                           | Left          | [^1]    |
-| `+x` <br> `-x` <br> `!x` <br>   | Positive <br> Negative <br> Negation <br>                         | &check;                           | &check;           | &times; <br> &times; <br> &check; | Right         |         |
-| `*` <br> `/` <br> `%` <br>      | Multiplication <br>  Division <br>  Remainder <br>                | &check; <br> &check; <br> &times; | &check;           | &times;                           | Left          |         |
-| `+` <br> `-` <br>               | Addition <br>  Subtraction <br>                                   | &check;                           | &check;           | &times;                           | Left          |         |
-| `<<` <br> `>>` <br>             | Left shift <br>  Right shift <br>                                 | &times;                           | &check;           | &times;                           | Left          | [^2]    |
-| `&`                             | Bitwise AND                                                       | &times;                           | &check;           | &times;                           | Left          |         |
-| <code>&#124;</code>             | Bitwise OR                                                        | &times;                           | &check;           | &times;                           | Left          |         |
-| `^`                             | Bitwise XOR                                                       | &times;                           | &check;           | &times;                           | Left          |         |
-| `>=` <br> `>` <br> `<=` <br> `<`| Greater or equal <br> Greater <br> Lower or equal <br> Lower <br> | &check;                           | &check;           | &times;                           | Left          | [^3]    |
-| `!=` <br> `==` <br>             | Not Equal <br> Equal  <br>                                        | &check;                           | &check;           | &check;                           | Left          |         |
-| `&&`                            | Boolean AND                                                       | &times;                           | &times;           | &check;                           | Left          |         |
-| <code>&#124;&#124;</code>       | Boolean OR                                                        | &times;                           | &times;           | &check;                           | Left          |         |
-| `if c then x else y fi`         | Conditional expression                                            | &check;                           | &check;           | &check;                           | Right         |         |
+| Operator                      | Description                                                   | `field`                      | `u8/u16` `u32/u64`            | `bool`                      | Associativity | Remarks |
+|-------------------------------|---------------------------------------------------------------|------------------------------|-------------------------------|-----------------------------|---------------|---------|
+| `**`<br>                     | Power                                                         | &check;                      | &nbsp;                        | &nbsp;                      | Left          | [^1]    |
+| `+x`<br>`-x`<br>`!x`<br>   | Positive<br>Negative<br>Negation<br>                       | &check;<br>&check;<br>&nbsp; | &check;<br>&check;<br>&nbsp;  | &nbsp;<br>&nbsp;<br>&check; | Right         |         |
+| `*`<br>`/`<br>`%`<br>      | Multiplication<br> Division<br> Remainder<br>              | &check;<br>&check;<br>&nbsp; | &check;<br>&check;<br>&check; | &nbsp;<br>&nbsp;<br>&nbsp;  | Left          |         |
+| `+`<br>`-`<br>              | Addition<br> Subtraction<br>                                | &check;                      | &check;                       | &nbsp;                      | Left          |         |
+| `<<`<br>`>>`<br>            | Left shift<br> Right shift<br>                              | &nbsp;                       | &check;                       | &nbsp;                      | Left          | [^2]    |
+| `&`                           | Bitwise AND                                                   | &nbsp;                       | &check;                       | &nbsp;                      | Left          |         |
+| <code>&#124;</code>           | Bitwise OR                                                    | &nbsp;                       | &check;                       | &nbsp;                      | Left          |         |
+| `^`                           | Bitwise XOR                                                   | &nbsp;                       | &check;                       | &nbsp;                      | Left          |         |
+| `>=`<br>`>`<br>`<=`<br>`<` | Greater or equal<br>Greater<br>Lower or equal<br>Lower<br>| &check;                      | &check;                       | &nbsp;                      | Left          | [^3]    |
+| `!=`<br>`==`<br>            | Not Equal<br>Equal<br>                                      | &check;                      | &check;                       | &check;                     | Left          |         |
+| `&&`                          | Boolean AND                                                   | &nbsp;                       | &nbsp;                        | &check;                     | Left          |         |
+| <code>&#124;&#124;</code>     | Boolean OR                                                    | &nbsp;                       | &nbsp;                        | &check;                     | Left          |         |
+| `if c then x else y fi`       | Conditional expression                                        | &check;                      | &check;                       | &check;                     | Right         |         |
 
 [^1]: The exponent must be a compile-time constant of type `u32`
 

--- a/zokrates_book/src/language/types.md
+++ b/zokrates_book/src/language/types.md
@@ -16,16 +16,6 @@ While `field` values mostly behave like unsigned integers, one should keep in mi
 {{#include ../../../zokrates_cli/examples/book/field_overflow.zok}}
 ```
 
-#### Arithmetic operations
-
-| Symbol | Meaning                                          |
-| ------ | ------------------------------------------------ |
-| `+`    | Addition mod `p`                                 |
-| `-`    | Subtraction mod `p`                              |
-| `*`    | Product mod `p`                                  |
-| `/`    | Division (multiplication by the inverse) mod `p` |
-| `**`   | Power mod `p`                                    |
-
 Note that [division in the finite field](https://en.wikipedia.org/wiki/Finite_field_arithmetic) behaves differently than in the case of integers.
 For field elements, the division operation multiplies the numerator with the denominator's inverse field element. The results coincide with integer divisions for cases with remainder 0, but differ otherwise.
 

--- a/zokrates_book/src/language/types.md
+++ b/zokrates_book/src/language/types.md
@@ -6,7 +6,7 @@ ZoKrates currently exposes two primitive types and two complex types:
 
 ### `field`
 
-This is the most basic type in ZoKrates, and it represents a field element with positive integer values in `[0,  p - 1]` where `p` is a (large) prime number. Standard arithmetic operations are supported; note that [division in the finite field](https://en.wikipedia.org/wiki/Finite_field_arithmetic) behaves differently than in the case of integers.
+This is the most basic type in ZoKrates, and it represents a field element with positive integer values in `[0,  p - 1]` where `p` is a (large) prime number.
 
 As an example, `p` is set to `21888242871839275222246405745257275088548364400416034343698204186575808495617` when working with the [ALT_BN128](../toolbox/proving_schemes.md#curves) curve supported by Ethereum.
 
@@ -16,7 +16,18 @@ While `field` values mostly behave like unsigned integers, one should keep in mi
 {{#include ../../../zokrates_cli/examples/book/field_overflow.zok}}
 ```
 
-Note that for field elements, the division operation multiplies the numerator with the denominator's inverse field element. The results coincide with integer divisions for cases with remainder 0, but differ otherwise.
+#### Arithmetic operations
+
+| Symbol | Meaning                                          |
+| ------ | ------------------------------------------------ |
+| `+`    | Addition mod `p`                                 |
+| `-`    | Subtraction mod `p`                              |
+| `*`    | Product mod `p`                                  |
+| `/`    | Division (multiplication by the inverse) mod `p` |
+| `**`   | Power mod `p`                                    |
+
+Note that [division in the finite field](https://en.wikipedia.org/wiki/Finite_field_arithmetic) behaves differently than in the case of integers.
+For field elements, the division operation multiplies the numerator with the denominator's inverse field element. The results coincide with integer divisions for cases with remainder 0, but differ otherwise.
 
 ### `bool`
 


### PR DESCRIPTION
https://github.com/Zokrates/ZoKrates/issues/1006

We currently do not support modulo for `field` type, this PR makes it a bit more clear what arithmetic operations are actually supported.