### PR TITLE
Output structured Marlin artifacts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23,7 +23,7 @@ version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "991984e3fd003e7ba02eb724f87a0f997b78677c46c0e91f8424ad7394c9886a"
 dependencies = [
- "getrandom 0.2.3",
+ "getrandom",
  "once_cell",
  "version_check",
 ]
@@ -57,9 +57,9 @@ dependencies = [
 
 [[package]]
 name = "ark-bls12-377"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb89b97424403ec9cc22a1df0db748dd7396c9ba5fb5c71a6f0e10ae1d1a7449"
+checksum = "dc41c02c0d18a226947ee9ee023b1d957bdb6a68fc22ac296722935a9fef423c"
 dependencies = [
  "ark-ec",
  "ark-ff",
@@ -69,9 +69,9 @@ dependencies = [
 
 [[package]]
 name = "ark-bn254"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ead066869de5e8cb2938123204d1572f09496b629e146a6f80fa8ec508446ba"
+checksum = "ea691771ebbb28aea556c044e2e5c5227398d840cee0c34d4d20fa8eb2689e8c"
 dependencies = [
  "ark-ec",
  "ark-ff",
@@ -80,9 +80,9 @@ dependencies = [
 
 [[package]]
 name = "ark-bw6-761"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69ad8d74a8e083a59defc4a226a19759691337006d5c9397dbd793af9e406418"
+checksum = "5abb465edcdee2bec3eff283e43f1c2414d1a4f6eaeb8e3de02aba3695d0520b"
 dependencies = [
  "ark-bls12-377",
  "ark-ec",
@@ -92,15 +92,16 @@ dependencies = [
 
 [[package]]
 name = "ark-crypto-primitives"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74b83a7e125e5c611e4a997123effb2f02e3fbc66531dd77751d3016ee920741"
+checksum = "ff773c0ef8c655c98071d3026a63950798a66b2f45baef22d8334c1756f1bd18"
 dependencies = [
  "ark-ec",
  "ark-ff",
  "ark-nonnative-field",
  "ark-r1cs-std",
  "ark-relations",
+ "ark-serialize",
  "ark-snark",
  "ark-std",
  "blake2",
@@ -111,9 +112,9 @@ dependencies = [
 
 [[package]]
 name = "ark-ec"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c56006994f509d76fbce6f6ffe3108f7191b4f3754ecd00bbae7cac20ec05020"
+checksum = "dea978406c4b1ca13c2db2373b05cc55429c3575b8b21f1b9ee859aa5b03dd42"
 dependencies = [
  "ark-ff",
  "ark-serialize",
@@ -125,25 +126,27 @@ dependencies = [
 
 [[package]]
 name = "ark-ff"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4d8802d40fce9212c5c09be08f75c4b3becc0c488e87f60fff787b01250ce33"
+checksum = "6b3235cc41ee7a12aaaf2c575a2ad7b46713a8a50bda2fc3b003a04845c05dd6"
 dependencies = [
  "ark-ff-asm",
  "ark-ff-macros",
  "ark-serialize",
  "ark-std",
  "derivative",
+ "num-bigint 0.4.2",
  "num-traits 0.2.14",
+ "paste",
  "rustc_version",
  "zeroize",
 ]
 
 [[package]]
 name = "ark-ff-asm"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e8cb28c2137af1ef058aa59616db3f7df67dbb70bf2be4ee6920008cc30d98c"
+checksum = "db02d390bf6643fb404d3d22d31aee1c4bc4459600aef9113833d17e786c6e44"
 dependencies = [
  "quote 1.0.10",
  "syn 1.0.80",
@@ -151,9 +154,9 @@ dependencies = [
 
 [[package]]
 name = "ark-ff-macros"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b9c256a93a10ed9708c16a517d6dcfaba3d215c0d7fab44d29a9affefb5eeb8"
+checksum = "db2fd794a08ccb318058009eefdf15bcaaaaf6f8161eb3345f907222bac38b20"
 dependencies = [
  "num-bigint 0.4.2",
  "num-traits 0.2.14",
@@ -163,9 +166,9 @@ dependencies = [
 
 [[package]]
 name = "ark-gm17"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c9085a6c89aa65178aa2718b2efb62fd7c4dc23fe25285204e30b56e4cbfcac"
+checksum = "94713045868e99a606a89825ff5a901667ba707ad1966a32c7f3a4d4dbcc0e9a"
 dependencies = [
  "ark-crypto-primitives",
  "ark-ec",
@@ -181,9 +184,8 @@ dependencies = [
 
 [[package]]
 name = "ark-marlin"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85eea366fcce1487bd8f1bee281fbc9de1d7bce353a89ace8eee6ebc9d65e2d2"
+version = "0.3.0"
+source = "git+https://github.com/Schaeff/marlin?branch=add-index-info-constructor#10a8053ceb010f1b8c4d8ff897c5df496cc748e0"
 dependencies = [
  "ark-ff",
  "ark-poly",
@@ -193,14 +195,14 @@ dependencies = [
  "ark-std",
  "derivative",
  "digest 0.9.0",
- "rand_chacha 0.2.2",
+ "rand_chacha",
 ]
 
 [[package]]
 name = "ark-nonnative-field"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17887af156e9911d1dba5b30d49256d508f82f6a4f765a6fad8b5c637b700353"
+checksum = "440ad4569974910adbeb84422b7e622b79e08d27142afd113785b7fcfb446186"
 dependencies = [
  "ark-ec",
  "ark-ff",
@@ -216,9 +218,9 @@ dependencies = [
 
 [[package]]
 name = "ark-poly"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72d6683d21645a2abb94034f6a14e708405e55d9597687952d54b2269922857a"
+checksum = "7b0f78f47537c2f15706db7e98fe64cc1711dbf9def81218194e17239e53e5aa"
 dependencies = [
  "ark-ff",
  "ark-serialize",
@@ -229,9 +231,9 @@ dependencies = [
 
 [[package]]
 name = "ark-poly-commit"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad7df2d50062d718e5914d013ee2f30dc203324e08070d16b241e869b8717ed6"
+checksum = "a71ddfa72bad1446cab7bbecb6018dbbdc9abcbc3a0065483ae5186ad2a64dcd"
 dependencies = [
  "ark-ec",
  "ark-ff",
@@ -245,9 +247,9 @@ dependencies = [
 
 [[package]]
 name = "ark-r1cs-std"
-version = "0.2.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a90fea2b84ae4443983d56540360ea004cab952292b7a6535798b6b9dcb7f41"
+checksum = "22e8fdacb1931f238a0d866ced1e916a49d36de832fd8b83dc916b718ae72893"
 dependencies = [
  "ark-ec",
  "ark-ff",
@@ -261,9 +263,9 @@ dependencies = [
 
 [[package]]
 name = "ark-relations"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a42f124f8dfff2b0561143c0c7ea48d7f7dc8d2c4c1e87eca14a27430c653c0b"
+checksum = "4cba4c1c99792a6834bd97f7fd76578ec2cd58d2afc5139a17e1d1bec65b38f6"
 dependencies = [
  "ark-ff",
  "ark-std",
@@ -272,19 +274,20 @@ dependencies = [
 
 [[package]]
 name = "ark-serialize"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3e9b59329dc9b92086b3dc619f31cef4a0c802f10829b575a3666d48a48387d"
+checksum = "1d6c2b318ee6e10f8c2853e73a83adc0ccb88995aa978d8a3408d492ab2ee671"
 dependencies = [
  "ark-serialize-derive",
  "ark-std",
+ "digest 0.9.0",
 ]
 
 [[package]]
 name = "ark-serialize-derive"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ac3d78c750b01f5df5b2e76d106ed31487a93b3868f14a7f0eb3a74f45e1d8a"
+checksum = "8dd4e5f0bf8285d5ed538d27fab7411f3e297908fd93c62195de8bee3f199e82"
 dependencies = [
  "proc-macro2 1.0.29",
  "quote 1.0.10",
@@ -293,9 +296,9 @@ dependencies = [
 
 [[package]]
 name = "ark-snark"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39da26432fe584b0010741299820145ec69180fe9ea18ddf96946932763624a1"
+checksum = "0dc3dff1a5f67a9c0b34df32b079752d8dd17f1e9d06253da0453db6c1b7cc8a"
 dependencies = [
  "ark-ff",
  "ark-relations",
@@ -304,12 +307,12 @@ dependencies = [
 
 [[package]]
 name = "ark-std"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb5b856a29bea7b810858116a596beee3d20fc4c5aeb240e8e5a8bca4845a470"
+checksum = "1df2c09229cbc5a028b1d70e00fdb2acee28b1055dfb5ca73eea49c5a25c4e7c"
 dependencies = [
- "rand 0.7.3",
- "rand_xorshift",
+ "num-traits 0.2.14",
+ "rand 0.8.4",
 ]
 
 [[package]]
@@ -1019,17 +1022,6 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
-dependencies = [
- "cfg-if 1.0.0",
- "libc",
- "wasi 0.9.0+wasi-snapshot-preview1",
-]
-
-[[package]]
-name = "getrandom"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
@@ -1037,7 +1029,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "js-sys",
  "libc",
- "wasi 0.10.2+wasi-snapshot-preview1",
+ "wasi",
  "wasm-bindgen",
 ]
 
@@ -1408,6 +1400,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "paste"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acbf547ad0c65e31259204bd90935776d1c693cec2f4ff7abb7a1bbbd40dfe58"
+
+[[package]]
 name = "percent-encoding"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1567,37 +1565,14 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
-dependencies = [
- "getrandom 0.1.16",
- "libc",
- "rand_chacha 0.2.2",
- "rand_core 0.5.1",
- "rand_hc 0.2.0",
-]
-
-[[package]]
-name = "rand"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e7573632e6454cf6b99d7aac4ccca54be06da05aca2ef7423d22d27d4d4bcd8"
 dependencies = [
  "libc",
- "rand_chacha 0.3.1",
+ "rand_chacha",
  "rand_core 0.6.3",
- "rand_hc 0.3.1",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.5.1",
+ "rand_hc",
 ]
 
 [[package]]
@@ -1627,29 +1602,11 @@ checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
 
 [[package]]
 name = "rand_core"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
-dependencies = [
- "getrandom 0.1.16",
-]
-
-[[package]]
-name = "rand_core"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
 dependencies = [
- "getrandom 0.2.3",
-]
-
-[[package]]
-name = "rand_hc"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
-dependencies = [
- "rand_core 0.5.1",
+ "getrandom",
 ]
 
 [[package]]
@@ -1659,15 +1616,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d51e9f596de227fda2ea6c84607f5558e196eeaf43c986b724ba4fb8fdf497e7"
 dependencies = [
  "rand_core 0.6.3",
-]
-
-[[package]]
-name = "rand_xorshift"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77d416b86801d23dde1aa643023b775c3a462efc0ed96443add11546cdf1dca8"
-dependencies = [
- "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -1694,7 +1642,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "528532f3d801c87aec9def2add9ca802fe569e44a544afe633765267840abe64"
 dependencies = [
- "getrandom 0.2.3",
+ "getrandom",
  "redox_syscall",
 ]
 
@@ -2205,12 +2153,6 @@ dependencies = [
 
 [[package]]
 name = "wasi"
-version = "0.9.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
-
-[[package]]
-name = "wasi"
 version = "0.10.2+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
@@ -2427,7 +2369,7 @@ dependencies = [
  "cmake",
  "csv",
  "ff_ce 0.9.0",
- "getrandom 0.2.3",
+ "getrandom",
  "git2",
  "hex",
  "lazy_static",
@@ -2437,7 +2379,7 @@ dependencies = [
  "pairing_ce",
  "pretty_assertions",
  "rand 0.4.6",
- "rand 0.7.3",
+ "rand 0.8.4",
  "reduce",
  "regex 0.2.11",
  "serde",

--- a/changelogs/unreleased/1035-schaeff
+++ b/changelogs/unreleased/1035-schaeff
@@ -1,0 +1,1 @@
+Output structured data for Marlin artifacts

--- a/zokrates_core/Cargo.toml
+++ b/zokrates_core/Cargo.toml
@@ -35,7 +35,7 @@ zokrates_common = { path = "../zokrates_common" }
 zokrates_embed = { version = "0.1.0", path = "../zokrates_embed" }
 getrandom = { version = "0.2", features = ["js"] }
 rand_0_4 = { version = "0.4", package = "rand" }
-rand_0_7 = { version = "0.7", package = "rand" }
+rand_0_8 = { version = "0.8", package = "rand" }
 csv = "1"
 
 # bellman
@@ -44,17 +44,17 @@ pairing_ce = { version = "^0.21", optional = true }
 ff_ce = { version = "^0.9", optional = true }
 
 # ark
-ark-ff = { version = "^0.2.0", default-features = false, optional = true }
-ark-ec = { version = "^0.2.0", default-features = false, optional = true }
-ark-bn254 = { version = "^0.2.0", features = ["curve"], default-features = false, optional = true }
-ark-bls12-377 = { version = "^0.2.0", features = ["curve"], default-features = false, optional = true }
-ark-bw6-761 = { version = "^0.2.0", default-features = false, optional = true }
-ark-gm17 = { version = "^0.2.0", default-features = false, optional = true }
-ark-serialize = { version = "^0.2.0", default-features = false, optional = true }
-ark-relations = { version = "^0.2.0", default-features = false, optional = true }
-ark-marlin = { version = "^0.2.0", default-features = false, optional = true }
-ark-poly = { version = "^0.2.0", default-features = false, optional = true }
-ark-poly-commit = { version = "^0.2.0", default-features = false, optional = true }
+ark-ff = { version = "^0.3.0", default-features = false, optional = true }
+ark-ec = { version = "^0.3.0", default-features = false, optional = true }
+ark-bn254 = { version = "^0.3.0", features = ["curve"], default-features = false, optional = true }
+ark-bls12-377 = { version = "^0.3.0", features = ["curve"], default-features = false, optional = true }
+ark-bw6-761 = { version = "^0.3.0", default-features = false, optional = true }
+ark-gm17 = { version = "^0.3.0", default-features = false, optional = true }
+ark-serialize = { version = "^0.3.0", default-features = false, optional = true }
+ark-relations = { version = "^0.3.0", default-features = false, optional = true }
+ark-marlin = { git = "https://github.com/Schaeff/marlin", branch = "add-index-info-constructor", default-features = false, optional = true }
+ark-poly = { version = "^0.3.0", default-features = false, optional = true }
+ark-poly-commit = { version = "^0.3.0", default-features = false, optional = true }
 sha2 = { version = "0.9.3", optional = true }
 
 [dev-dependencies]

--- a/zokrates_core/src/proof_system/ark/gm17.rs
+++ b/zokrates_core/src/proof_system/ark/gm17.rs
@@ -9,7 +9,7 @@ use zokrates_field::{ArkFieldExtensions, Bw6_761Field, Field};
 use crate::ir::{Prog, Witness};
 use crate::proof_system::ark::Ark;
 use crate::proof_system::ark::Computation;
-use crate::proof_system::ark::{parse_fr, parse_g1, parse_g2, parse_g2_fq};
+use crate::proof_system::ark::{parse_fr, parse_g1, parse_g2, parse_g2_fq, serialization};
 use crate::proof_system::gm17::{NotBw6_761Field, ProofPoints, VerificationKey, GM17};
 use crate::proof_system::Scheme;
 use crate::proof_system::{Backend, NonUniversalBackend, Proof, SetupKeypair};
@@ -200,51 +200,6 @@ impl Backend<Bw6_761Field, GM17> for Ark {
             .collect::<Vec<_>>();
 
         verify_proof(&pvk, &ark_proof, &public_inputs).unwrap()
-    }
-}
-
-pub mod serialization {
-    use crate::proof_system::{G1Affine, G2Affine, G2AffineFq};
-    use ark_ec::PairingEngine;
-    use ark_ff::FromBytes;
-    use zokrates_field::ArkFieldExtensions;
-
-    #[inline]
-    fn decode_hex(value: String) -> Vec<u8> {
-        let mut bytes = hex::decode(value.strip_prefix("0x").unwrap()).unwrap();
-        bytes.reverse();
-        bytes
-    }
-
-    pub fn to_g1<T: ArkFieldExtensions>(g1: G1Affine) -> <T::ArkEngine as PairingEngine>::G1Affine {
-        let mut bytes = vec![];
-        bytes.append(&mut decode_hex(g1.0));
-        bytes.append(&mut decode_hex(g1.1));
-        bytes.push(0u8); // infinity flag
-
-        <T::ArkEngine as PairingEngine>::G1Affine::read(&*bytes).unwrap()
-    }
-
-    pub fn to_g2<T: ArkFieldExtensions>(g2: G2Affine) -> <T::ArkEngine as PairingEngine>::G2Affine {
-        let mut bytes = vec![];
-        bytes.append(&mut decode_hex((g2.0).0));
-        bytes.append(&mut decode_hex((g2.0).1));
-        bytes.append(&mut decode_hex((g2.1).0));
-        bytes.append(&mut decode_hex((g2.1).1));
-        bytes.push(0u8); // infinity flag
-
-        <T::ArkEngine as PairingEngine>::G2Affine::read(&*bytes).unwrap()
-    }
-
-    pub fn to_g2_fq<T: ArkFieldExtensions>(
-        g2: G2AffineFq,
-    ) -> <T::ArkEngine as PairingEngine>::G2Affine {
-        let mut bytes = vec![];
-        bytes.append(&mut decode_hex(g2.0));
-        bytes.append(&mut decode_hex(g2.1));
-        bytes.push(0u8); // infinity flag
-
-        <T::ArkEngine as PairingEngine>::G2Affine::read(&*bytes).unwrap()
     }
 }
 

--- a/zokrates_core/src/proof_system/ark/marlin.rs
+++ b/zokrates_core/src/proof_system/ark/marlin.rs
@@ -178,11 +178,7 @@ impl<T: Field + ArkFieldExtensions> Backend<T, marlin::Marlin> for Ark {
                             .collect()
                     })
                     .collect(),
-                evaluations: proof
-                    .evaluations
-                    .into_iter()
-                    .map(|e| T::from_ark(e))
-                    .collect(),
+                evaluations: proof.evaluations.into_iter().map(T::from_ark).collect(),
                 pc_proof_proof: proof
                     .pc_proof
                     .proof
@@ -192,7 +188,7 @@ impl<T: Field + ArkFieldExtensions> Backend<T, marlin::Marlin> for Ark {
                 pc_proof_evals: proof
                     .pc_proof
                     .evals
-                    .map(|evals| evals.into_iter().map(|eval| T::from_ark(eval)).collect()),
+                    .map(|evals| evals.into_iter().map(T::from_ark).collect()),
                 prover_messages_count: proof.prover_messages.len(),
             },
             inputs,

--- a/zokrates_core/src/proof_system/ark/mod.rs
+++ b/zokrates_core/src/proof_system/ark/mod.rs
@@ -277,3 +277,48 @@ mod parse {
         format!("0x{}", hex::encode(&bytes))
     }
 }
+
+pub mod serialization {
+    use crate::proof_system::{G1Affine, G2Affine, G2AffineFq};
+    use ark_ec::PairingEngine;
+    use ark_ff::FromBytes;
+    use zokrates_field::ArkFieldExtensions;
+
+    #[inline]
+    fn decode_hex(value: String) -> Vec<u8> {
+        let mut bytes = hex::decode(value.strip_prefix("0x").unwrap()).unwrap();
+        bytes.reverse();
+        bytes
+    }
+
+    pub fn to_g1<T: ArkFieldExtensions>(g1: G1Affine) -> <T::ArkEngine as PairingEngine>::G1Affine {
+        let mut bytes = vec![];
+        bytes.append(&mut decode_hex(g1.0));
+        bytes.append(&mut decode_hex(g1.1));
+        bytes.push(0u8); // infinity flag
+
+        <T::ArkEngine as PairingEngine>::G1Affine::read(&*bytes).unwrap()
+    }
+
+    pub fn to_g2<T: ArkFieldExtensions>(g2: G2Affine) -> <T::ArkEngine as PairingEngine>::G2Affine {
+        let mut bytes = vec![];
+        bytes.append(&mut decode_hex((g2.0).0));
+        bytes.append(&mut decode_hex((g2.0).1));
+        bytes.append(&mut decode_hex((g2.1).0));
+        bytes.append(&mut decode_hex((g2.1).1));
+        bytes.push(0u8); // infinity flag
+
+        <T::ArkEngine as PairingEngine>::G2Affine::read(&*bytes).unwrap()
+    }
+
+    pub fn to_g2_fq<T: ArkFieldExtensions>(
+        g2: G2AffineFq,
+    ) -> <T::ArkEngine as PairingEngine>::G2Affine {
+        let mut bytes = vec![];
+        bytes.append(&mut decode_hex(g2.0));
+        bytes.append(&mut decode_hex(g2.1));
+        bytes.push(0u8); // infinity flag
+
+        <T::ArkEngine as PairingEngine>::G2Affine::read(&*bytes).unwrap()
+    }
+}

--- a/zokrates_core/src/proof_system/ark/mod.rs
+++ b/zokrates_core/src/proof_system/ark/mod.rs
@@ -19,7 +19,7 @@ use zokrates_field::{ArkFieldExtensions, Field};
 
 pub use self::parse::*;
 
-use rand_0_7::SeedableRng;
+use rand_0_8::SeedableRng;
 
 pub struct Ark;
 
@@ -150,7 +150,7 @@ impl<T: Field + ArkFieldExtensions> Prog<T> {
 
 impl<T: Field + ArkFieldExtensions> Computation<T> {
     pub fn prove(self, params: &ProvingKey<T::ArkEngine>) -> Proof<T::ArkEngine> {
-        let rng = &mut rand_0_7::rngs::StdRng::from_entropy();
+        let rng = &mut rand_0_8::rngs::StdRng::from_entropy();
 
         let proof = create_random_proof(self.clone(), params, rng).unwrap();
 
@@ -173,7 +173,7 @@ impl<T: Field + ArkFieldExtensions> Computation<T> {
     }
 
     pub fn setup(self) -> ProvingKey<T::ArkEngine> {
-        let rng = &mut rand_0_7::rngs::StdRng::from_entropy();
+        let rng = &mut rand_0_8::rngs::StdRng::from_entropy();
 
         // run setup phase
         generate_random_parameters(self, rng).unwrap()

--- a/zokrates_core/src/proof_system/mod.rs
+++ b/zokrates_core/src/proof_system/mod.rs
@@ -49,7 +49,7 @@ pub type Fq2 = (String, String);
 pub struct G1Affine(Fq, Fq);
 
 // When G2 is defined on Fq2 field
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Clone)]
 pub struct G2Affine(Fq2, Fq2);
 
 // When G2 is defined on a Fq field (BW6_761 curve)

--- a/zokrates_core/src/proof_system/scheme/marlin.rs
+++ b/zokrates_core/src/proof_system/scheme/marlin.rs
@@ -1,4 +1,5 @@
 use crate::proof_system::scheme::{Scheme, UniversalScheme};
+use crate::proof_system::{G1Affine, G2Affine};
 use serde::{Deserialize, Serialize};
 use zokrates_field::Field;
 
@@ -11,12 +12,40 @@ pub struct ProofPoints {
 }
 
 #[derive(Serialize, Deserialize)]
-pub struct VerificationKey {
-    pub raw: Vec<u8>,
+pub struct KZGVerifierKey<G1, G2> {
+    /// The generator of G1.
+    pub g: G1,
+    /// The generator of G1 that is used for making a commitment hiding.
+    pub gamma_g: G1,
+    /// The generator of G2.
+    pub h: G2,
+    /// \beta times the above generator of G2.
+    pub beta_h: G2,
+    // /// The generator of G2, prepared for use in pairings.
+    // #[derivative(Debug = "ignore")]
+    // pub prepared_h: E::G2Prepared,
+    // /// \beta times the above generator of G2, prepared for use in pairings.
+    // #[derivative(Debug = "ignore")]
+    // pub prepared_beta_h: E::G2Prepared,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct VerificationKey<G1, G2> {
+    // index_info
+    pub num_variables: usize,
+    pub num_constraints: usize,
+    pub num_non_zero: usize,
+    pub num_instance_variables: usize,
+    // index comms
+    pub index_comms: Vec<G1>,
+    // verifier key
+    pub vk: KZGVerifierKey<G1, G2>,
+    pub max_degree: usize,
+    pub supported_degree: usize,
 }
 
 impl<T: Field> Scheme<T> for Marlin {
-    type VerificationKey = VerificationKey;
+    type VerificationKey = VerificationKey<G1Affine, G2Affine>;
     type ProofPoints = ProofPoints;
 }
 

--- a/zokrates_core/src/proof_system/scheme/marlin.rs
+++ b/zokrates_core/src/proof_system/scheme/marlin.rs
@@ -1,14 +1,14 @@
 use crate::proof_system::scheme::{Scheme, UniversalScheme};
 use crate::proof_system::{G1Affine, G2Affine};
 use serde::{Deserialize, Serialize};
-use zokrates_field::{ArkFieldExtensions, Field};
+use zokrates_field::Field;
 
 #[allow(clippy::upper_case_acronyms)]
 pub struct Marlin;
 
 #[derive(Serialize, Deserialize)]
 pub struct ProofPoints<Fr, G1> {
-    pub commitments: Vec<Vec<G1>>,
+    pub commitments: Vec<Vec<(G1, Option<G1>)>>,
     pub evaluations: Vec<Fr>,
     pub pc_proof_proof: Vec<(G1, Option<Fr>)>,
     pub pc_proof_evals: Option<Vec<Fr>>,
@@ -25,12 +25,6 @@ pub struct KZGVerifierKey<G1, G2> {
     pub h: G2,
     /// \beta times the above generator of G2.
     pub beta_h: G2,
-    // /// The generator of G2, prepared for use in pairings.
-    // #[derivative(Debug = "ignore")]
-    // pub prepared_h: E::G2Prepared,
-    // /// \beta times the above generator of G2, prepared for use in pairings.
-    // #[derivative(Debug = "ignore")]
-    // pub prepared_beta_h: E::G2Prepared,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -41,11 +35,12 @@ pub struct VerificationKey<G1, G2> {
     pub num_non_zero: usize,
     pub num_instance_variables: usize,
     // index comms
-    pub index_comms: Vec<G1>,
+    pub index_comms: Vec<(G1, Option<G1>)>,
     // verifier key
     pub vk: KZGVerifierKey<G1, G2>,
     pub max_degree: usize,
     pub supported_degree: usize,
+    pub degree_bounds_and_shift_powers: Option<Vec<(usize, G1)>>,
 }
 
 impl<T: Field> Scheme<T> for Marlin {

--- a/zokrates_core/src/proof_system/scheme/marlin.rs
+++ b/zokrates_core/src/proof_system/scheme/marlin.rs
@@ -1,14 +1,18 @@
 use crate::proof_system::scheme::{Scheme, UniversalScheme};
 use crate::proof_system::{G1Affine, G2Affine};
 use serde::{Deserialize, Serialize};
-use zokrates_field::Field;
+use zokrates_field::{ArkFieldExtensions, Field};
 
 #[allow(clippy::upper_case_acronyms)]
 pub struct Marlin;
 
 #[derive(Serialize, Deserialize)]
-pub struct ProofPoints {
-    pub raw: Vec<u8>,
+pub struct ProofPoints<Fr, G1> {
+    pub commitments: Vec<Vec<G1>>,
+    pub evaluations: Vec<Fr>,
+    pub pc_proof_proof: Vec<(G1, Option<Fr>)>,
+    pub pc_proof_evals: Option<Vec<Fr>>,
+    pub prover_messages_count: usize,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -46,7 +50,7 @@ pub struct VerificationKey<G1, G2> {
 
 impl<T: Field> Scheme<T> for Marlin {
     type VerificationKey = VerificationKey<G1Affine, G2Affine>;
-    type ProofPoints = ProofPoints;
+    type ProofPoints = ProofPoints<T, G1Affine>;
 }
 
 impl<T: Field> UniversalScheme<T> for Marlin {}

--- a/zokrates_embed/Cargo.toml
+++ b/zokrates_embed/Cargo.toml
@@ -13,12 +13,12 @@ multicore = ["bellman_ce/multicore", "sapling-crypto_ce/multicore"]
 zokrates_field = { version = "0.4.0", path = "../zokrates_field", default-features = false }
 bellman_ce = { version = "^0.3", default-features = false }
 sapling-crypto_ce = { version = "^0.1", default-features = false }
-ark-bls12-377 = { version = "^0.2.0", features = ["curve", "r1cs"], default-features = false }
-ark-bw6-761 = { version = "^0.2.0", default-features = false }
-ark-gm17 = { version = "^0.2.0", default-features = false, features = ["r1cs"] }
-ark-relations = { version = "^0.2.0", default-features = false }
-ark-crypto-primitives = { version = "^0.2.0", default-features = false, features = ["r1cs"] }
-ark-r1cs-std = { version = "^0.2.0", default-features = false }
-ark-std = { version = "^0.2.0", default-features = false }
-ark-ec = { version = "^0.2.0", default-features = false }
-ark-ff = { version = "^0.2.0", default-features = false}
+ark-bls12-377 = { version = "^0.3.0", features = ["curve", "r1cs"], default-features = false }
+ark-bw6-761 = { version = "^0.3.0", default-features = false }
+ark-gm17 = { version = "^0.3.0", default-features = false, features = ["r1cs"] }
+ark-relations = { version = "^0.3.0", default-features = false }
+ark-crypto-primitives = { version = "^0.3.0", default-features = false, features = ["r1cs"] }
+ark-r1cs-std = { version = "^0.3.0", default-features = false }
+ark-std = { version = "^0.3.0", default-features = false }
+ark-ec = { version = "^0.3.0", default-features = false }
+ark-ff = { version = "^0.3.0", default-features = false}

--- a/zokrates_field/Cargo.toml
+++ b/zokrates_field/Cargo.toml
@@ -23,11 +23,11 @@ num-integer = { version = "0.1", default-features = false }
 bellman_ce = { version = "^0.3", default-features = false, optional = true }
 
 # ark
-ark-ff = { version = "^0.2.0", default-features = false, optional = true }
-ark-ec = { version = "^0.2.0", default-features = false, optional = true }
-ark-bn254 = { version = "^0.2.0", features = ["curve"], default-features = false, optional = true }
-ark-bls12-377 = { version = "^0.2.0", features = ["curve"], default-features = false, optional = true }
-ark-bw6-761 = { version = "^0.2.0", default-features = false, optional = true }
+ark-ff = { version = "^0.3.0", default-features = false, optional = true }
+ark-ec = { version = "^0.3.0", default-features = false, optional = true }
+ark-bn254 = { version = "^0.3.0", features = ["curve"], default-features = false, optional = true }
+ark-bls12-377 = { version = "^0.3.0", features = ["curve"], default-features = false, optional = true }
+ark-bw6-761 = { version = "^0.3.0", default-features = false, optional = true }
 
 [dev-dependencies]
 rand = "0.4"

--- a/zokrates_pest_ast/src/lib.rs
+++ b/zokrates_pest_ast/src/lib.rs
@@ -1307,7 +1307,7 @@ mod tests {
                                         span: Span::new(source, 76, 77).unwrap()
                                     }
                                 ))),
-                                Span::new(&source, 59, 80).unwrap()
+                                Span::new(source, 59, 80).unwrap()
                             )],
                             span: Span::new(source, 52, 80).unwrap(),
                         })],


### PR DESCRIPTION
We currently use Vec<u8> for all Marlin artifacts. A first step towards Solidity compatibility is to have a structured data output for vk and proof.

Currently blocked by https://github.com/arkworks-rs/marlin/pull/83