### PR TITLE
Improve inspect command

### DIFF
--- a/changelogs/unreleased/1072-dark64
+++ b/changelogs/unreleased/1072-dark64
@@ -1,0 +1,1 @@
+Improve `inspect` command to include information about constraint count and curve

--- a/zokrates_cli/src/ops/inspect.rs
+++ b/zokrates_cli/src/ops/inspect.rs
@@ -68,7 +68,8 @@ fn cli_inspect<T: Field, I: Iterator<Item = ir::Statement<T>>>(
             .and(write!(w, "{}", ir_prog))
             .map_err(|why| format!("Could not write to `{}`: {}", output_path.display(), why))?;
 
-        w.flush().expect("could not flush buffer");
+        w.flush()
+            .map_err(|why| format!("Failed to flush the buffer: {}", why))?;
 
         println!("ztf file written to '{}'", output_path.display());
     }

--- a/zokrates_cli/src/ops/inspect.rs
+++ b/zokrates_cli/src/ops/inspect.rs
@@ -23,7 +23,7 @@ pub fn subcommand() -> App<'static, 'static> {
         .arg(
             Arg::with_name("ztf")
                 .long("ztf")
-                .help("Writes human readable output (ztf) to disk")
+                .help("Writes human readable output (ztf) to a file")
                 .required(false),
         )
 }


### PR DESCRIPTION
By introducing iterator-based compilation we lost important information eg. constraint count in the compile command. We can add this information to the `inspect` command because we collect the program there.

```
$ zokrates inspect --ztf
curve:            bn128
constraint_count: 514
ztf file written to 'out.ztf'
```