### PR TITLE
Fix encoding issue causing invalid values on u64 inputs

### DIFF
--- a/changelogs/unreleased/1098-dark64
+++ b/changelogs/unreleased/1098-dark64
@@ -1,0 +1,1 @@
+Fix encoding issue causing invalid values on u64 inputs in js environment

--- a/zokrates_abi/src/lib.rs
+++ b/zokrates_abi/src/lib.rs
@@ -5,7 +5,7 @@ pub enum Inputs<T> {
     Abi(Values<T>),
 }
 
-impl<T: From<usize>> Encode<T> for Inputs<T> {
+impl<T: Field> Encode<T> for Inputs<T> {
     fn encode(self) -> Vec<T> {
         match self {
             Inputs::Raw(v) => v,
@@ -90,15 +90,15 @@ pub trait Decode<T> {
     fn decode(raw: Vec<T>, expected: Self::Expected) -> Self;
 }
 
-impl<T: From<usize>> Encode<T> for Value<T> {
+impl<T: Field> Encode<T> for Value<T> {
     fn encode(self) -> Vec<T> {
         match self {
             Value::Field(t) => vec![t],
-            Value::U8(t) => vec![T::from(t as usize)],
-            Value::U16(t) => vec![T::from(t as usize)],
-            Value::U32(t) => vec![T::from(t as usize)],
-            Value::U64(t) => vec![T::from(t as usize)],
-            Value::Boolean(b) => vec![if b { 1.into() } else { 0.into() }],
+            Value::U8(v) => vec![T::from(v)],
+            Value::U16(v) => vec![T::from(v)],
+            Value::U32(v) => vec![T::from(v)],
+            Value::U64(v) => vec![T::from(v)],
+            Value::Boolean(b) => vec![T::from(b)],
             Value::Array(a) => a.into_iter().flat_map(|v| v.encode()).collect(),
             Value::Struct(s) => s.into_iter().flat_map(|(_, v)| v.encode()).collect(),
         }
@@ -174,7 +174,7 @@ impl<T: Field> Decode<T> for Value<T> {
     }
 }
 
-impl<T: From<usize>> Encode<T> for Values<T> {
+impl<T: Field> Encode<T> for Values<T> {
     fn encode(self) -> Vec<T> {
         self.0.into_iter().flat_map(|v| v.encode()).collect()
     }
@@ -542,39 +542,39 @@ mod tests {
 
         #[test]
         fn fields() {
-            let v = Values(vec![Value::Field(1), Value::Field(2)]);
-            assert_eq!(v.encode(), vec![1, 2]);
+            let v = Values::<Bn128Field>(vec![Value::Field(1.into()), Value::Field(2.into())]);
+            assert_eq!(v.encode(), vec![1.into(), 2.into()]);
         }
 
         #[test]
         fn u8s() {
-            let v = Values::<usize>(vec![Value::U8(1), Value::U8(2)]);
-            assert_eq!(v.encode(), vec![1, 2]);
+            let v = Values::<Bn128Field>(vec![Value::U8(1), Value::U8(2)]);
+            assert_eq!(v.encode(), vec![1.into(), 2.into()]);
         }
 
         #[test]
         fn bools() {
-            let v: Values<usize> = Values(vec![Value::Boolean(true), Value::Boolean(false)]);
-            assert_eq!(v.encode(), vec![1, 0]);
+            let v: Values<Bn128Field> = Values(vec![Value::Boolean(true), Value::Boolean(false)]);
+            assert_eq!(v.encode(), vec![1.into(), 0.into()]);
         }
 
         #[test]
         fn array() {
-            let v: Values<usize> = Values(vec![Value::Array(vec![
+            let v: Values<Bn128Field> = Values(vec![Value::Array(vec![
                 Value::Boolean(true),
                 Value::Boolean(false),
             ])]);
-            assert_eq!(v.encode(), vec![1, 0]);
+            assert_eq!(v.encode(), vec![1.into(), 0.into()]);
         }
 
         #[test]
         fn struc() {
-            let v: Values<usize> = Values(vec![Value::Struct(
-                vec![("a".to_string(), Value::Field(42))]
+            let v: Values<Bn128Field> = Values(vec![Value::Struct(
+                vec![("a".to_string(), Value::Field(42.into()))]
                     .into_iter()
                     .collect(),
             )]);
-            assert_eq!(v.encode(), vec![42]);
+            assert_eq!(v.encode(), vec![42.into()]);
         }
     }
 }

--- a/zokrates_core/src/proof_system/mod.rs
+++ b/zokrates_core/src/proof_system/mod.rs
@@ -12,13 +12,18 @@ pub use self::scheme::*;
 pub use self::solidity::*;
 
 use crate::ir;
-use rand_0_4::Rng;
+
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
-use std::io::{Read, Write};
-#[cfg(feature = "bellman")]
-use zokrates_field::BellmanFieldExtensions;
 use zokrates_field::{Bls12_377Field, Bls12_381Field, Bn128Field, Field};
+
+cfg_if::cfg_if! {
+    if #[cfg(feature = "bellman")] {
+        use rand_0_4::Rng;
+        use std::io::{Read, Write};
+        use zokrates_field::BellmanFieldExtensions;
+    }
+}
 
 pub trait NotBw6_761Field {}
 impl NotBw6_761Field for Bls12_377Field {}

--- a/zokrates_core/src/static_analysis/zir_propagation.rs
+++ b/zokrates_core/src/static_analysis/zir_propagation.rs
@@ -13,7 +13,7 @@ type Constants<'ast, T> = HashMap<Identifier<'ast>, ZirExpression<'ast, T>>;
 
 #[derive(Debug, PartialEq)]
 pub enum Error {
-    OutOfBounds(u128, u128),
+    OutOfBounds(usize, usize),
     DivisionByZero,
     AssertionFailed(RuntimeError),
 }
@@ -147,7 +147,7 @@ impl<'ast, T: Field> ResultFolder<'ast, T> for ZirPropagator<'ast, T> {
                     UExpressionInner::Value(v) => e
                         .get(v as usize)
                         .cloned()
-                        .ok_or(Error::OutOfBounds(v, e.len() as u128)),
+                        .ok_or(Error::OutOfBounds(v as usize, e.len())),
                     i => Ok(FieldElementExpression::Select(
                         e,
                         box i.annotate(UBitwidth::B32),
@@ -279,7 +279,7 @@ impl<'ast, T: Field> ResultFolder<'ast, T> for ZirPropagator<'ast, T> {
                     UExpressionInner::Value(v) => e
                         .get(*v as usize)
                         .cloned()
-                        .ok_or(Error::OutOfBounds(*v, e.len() as u128)),
+                        .ok_or(Error::OutOfBounds(*v as usize, e.len())),
                     _ => Ok(BooleanExpression::Select(e, box index)),
                 }
             }
@@ -510,7 +510,7 @@ impl<'ast, T: Field> ResultFolder<'ast, T> for ZirPropagator<'ast, T> {
                     UExpressionInner::Value(v) => e
                         .get(v as usize)
                         .cloned()
-                        .ok_or(Error::OutOfBounds(v, e.len() as u128))
+                        .ok_or(Error::OutOfBounds(v as usize, e.len()))
                         .map(|e| e.into_inner()),
                     i => Ok(UExpressionInner::Select(e, box i.annotate(UBitwidth::B32))),
                 }

--- a/zokrates_core/src/typed_absy/types.rs
+++ b/zokrates_core/src/typed_absy/types.rs
@@ -544,7 +544,7 @@ pub enum UBitwidth {
 
 impl UBitwidth {
     pub fn to_usize(self) -> usize {
-        self as u32 as usize
+        self as usize
     }
 }
 

--- a/zokrates_field/src/lib.rs
+++ b/zokrates_field/src/lib.rs
@@ -53,11 +53,14 @@ pub trait Field:
     'static
     + Sync
     + Send
+    + From<u128>
+    + From<u64>
+    + From<u32>
+    + From<u16>
+    + From<u8>
+    + From<usize>
     + From<bool>
     + From<i32>
-    + From<u32>
-    + From<usize>
-    + From<u128>
     + TryFrom<BigUint, Error = ()>
     + Zero
     + One
@@ -266,30 +269,32 @@ mod prime_field {
                 }
             }
 
-            impl From<i32> for FieldPrime {
-                fn from(num: i32) -> Self {
-                    if num < 0 {
-                        FieldPrime {
-                            v: -Fr::from((-num) as u32),
-                        }
-                    } else {
-                        FieldPrime {
-                            v: Fr::from(num as u32),
-                        }
-                    }
+            impl From<u128> for FieldPrime {
+                fn from(num: u128) -> Self {
+                    FieldPrime { v: Fr::from(num) }
                 }
             }
 
-            impl From<bool> for FieldPrime {
-                fn from(num: bool) -> Self {
-                    FieldPrime {
-                        v: Fr::from(num as u32),
-                    }
+            impl From<u64> for FieldPrime {
+                fn from(num: u64) -> Self {
+                    FieldPrime { v: Fr::from(num) }
                 }
             }
 
             impl From<u32> for FieldPrime {
                 fn from(num: u32) -> Self {
+                    FieldPrime { v: Fr::from(num) }
+                }
+            }
+
+            impl From<u16> for FieldPrime {
+                fn from(num: u16) -> Self {
+                    FieldPrime { v: Fr::from(num) }
+                }
+            }
+
+            impl From<u8> for FieldPrime {
+                fn from(num: u8) -> Self {
                     FieldPrime { v: Fr::from(num) }
                 }
             }
@@ -302,9 +307,23 @@ mod prime_field {
                 }
             }
 
-            impl From<u128> for FieldPrime {
-                fn from(num: u128) -> Self {
-                    FieldPrime { v: Fr::from(num) }
+            impl From<bool> for FieldPrime {
+                fn from(b: bool) -> Self {
+                    FieldPrime { v: Fr::from(b) }
+                }
+            }
+
+            impl From<i32> for FieldPrime {
+                fn from(num: i32) -> Self {
+                    if num < 0 {
+                        FieldPrime {
+                            v: -Fr::from((-num) as u32),
+                        }
+                    } else {
+                        FieldPrime {
+                            v: Fr::from(num as u32),
+                        }
+                    }
                 }
             }
 


### PR DESCRIPTION
Closes https://github.com/Zokrates/ZoKrates/issues/1096

We need to be careful with using `as usize` casts (`usize` is `u32` in wasm so it produces unexpected values with `u64` type). I had a look at the entire codebase and it seems everything else is fine, the only cast causing issues is the one fixed in this PR, residing in the `zokrates_abi` crate. To combat this from happening again, we should have more integration tests for js environments, starting at running all tests in `zokrates_core_test`. This will be done in a separate PR.