### PR TITLE
Fix bits cache panic due to different bitwidths

### DIFF
--- a/changelogs/unreleased/1129-schaeff
+++ b/changelogs/unreleased/1129-schaeff
@@ -1,0 +1,1 @@
+Fix panic in some range checks over unsigned integers

--- a/zokrates_core_test/tests/tests/range_check/assert_lt_u8.json
+++ b/zokrates_core_test/tests/tests/range_check/assert_lt_u8.json
@@ -1,0 +1,55 @@
+{
+    "entry_point": "./tests/tests/range_check/assert_lt_u8.zok",
+    "max_constraint_count": 9,
+    "curves": ["Bn128"],
+    "tests": [
+        {
+            "input": {
+                "values": ["0x00"]
+            },
+            "output": {
+                "Ok": {
+                    "values": []
+                }
+            }
+        },
+        {
+            "input": {
+                "values": ["0x01"]
+            },
+            "output": {
+                "Ok": {
+                    "values": []
+                }
+            }
+        },
+        {
+            "input": {
+                "values": ["0x02"]
+            },
+            "output": {
+                "Err": {
+                    "UnsatisfiedConstraint": {
+                        "error": {
+                            "SourceAssertion": "Assertion failed at ./tests/tests/range_check/assert_lt_u8.zok:2:5"
+                        }
+                    }
+                }
+            }
+        },
+        {
+            "input": {
+                "values": ["0x0f"]
+            },
+            "output": {
+                "Err": {
+                    "UnsatisfiedConstraint": {
+                        "error": {
+                            "SourceAssertion": "Assertion failed at ./tests/tests/range_check/assert_lt_u8.zok:2:5"
+                        }
+                    }
+                }
+            }
+        }
+    ]
+}

--- a/zokrates_core_test/tests/tests/range_check/assert_lt_u8.zok
+++ b/zokrates_core_test/tests/tests/range_check/assert_lt_u8.zok
@@ -1,0 +1,3 @@
+def main(field x):
+    assert(x < 2)
+    return


### PR DESCRIPTION
If we cached a representation of `n` bits, it can be turned into a representation of `m >= n` bits by left padding with zeroes. Currently we force `n == m`. Relax that constraint.