### PR TITLE
Add proof formatting utility to zokrates-js

### DIFF
--- a/changelogs/unreleased/1131-dark64
+++ b/changelogs/unreleased/1131-dark64
@@ -1,0 +1,1 @@
+Add proof formatting utility to zokrates-js

--- a/zokrates_cli/src/ops/print_proof.rs
+++ b/zokrates_cli/src/ops/print_proof.rs
@@ -115,8 +115,10 @@ fn cli_print_proof<T: SolidityCompatibleField, S: SolidityCompatibleScheme<T>>(
                     .collect::<Vec<_>>()
                     .join(", ")
             );
-            print!(",");
-            print!("{}", inputs);
+            if !proof.inputs.is_empty() {
+                print!(",");
+                print!("{}", inputs);
+            }
             println!();
         }
         _ => unreachable!(),

--- a/zokrates_js/index.d.ts
+++ b/zokrates_js/index.d.ts
@@ -76,6 +76,9 @@ declare module "zokrates-js" {
     ): Proof;
     verify(verificationKey: VerificationKey, proof: Proof): boolean;
     exportSolidityVerifier(verificationKey: VerificationKey): string;
+    utils: {
+      formatProof(proof: Proof): any[];
+    }
   }
 
   export interface Metadata {

--- a/zokrates_js/wrapper.js
+++ b/zokrates_js/wrapper.js
@@ -80,6 +80,11 @@ module.exports = (dep) => {
     exportSolidityVerifier: (vk, options) => {
       return zokrates.export_solidity_verifier(vk, options);
     },
+    utils: {
+      formatProof: (proof, options) => {
+        return zokrates.format_proof(proof, options);
+      }
+    }
   };
 
   const withOptions = (options) => {
@@ -102,6 +107,9 @@ module.exports = (dep) => {
       verify: (vk, proof) => defaultProvider.verify(vk, proof, options),
       exportSolidityVerifier: (vk) =>
         defaultProvider.exportSolidityVerifier(vk, options),
+      utils: {
+        formatProof: (proof) => defaultProvider.utils.formatProof(proof, options),
+      }
     };
   };
 


### PR DESCRIPTION
- Added `formatProof` utility function so that a native proof (in the case when marlin scheme is used) can be converted to a "solidity" proof used as an input to the contract. This also helps in the remix plugin so that we can get formatted inputs to able to call `verifyTx`.
- Fixed edge case in the `print-proof` cli command when no public inputs are present.