### PR TITLE
fix padding inside of keccak base function

### DIFF
--- a/zokrates_stdlib/stdlib/hashes/keccak/keccak.zok
+++ b/zokrates_stdlib/stdlib/hashes/keccak/keccak.zok
@@ -93,6 +93,9 @@ def main<N, W>(u64[N] input, u64 pad) -> u64[25]:
         q = if pt == 0 then keccakf(q) else q fi
     endfor
 
+    // if pad then start after last byte
+    pt = if pad != 0x0000000000000001 then pt - 1 else pt fi
+
     // finalize
     q[pt] = q[pt] ^ pad
     q[rate - 1] = q[rate - 1] ^ 0x8000000000000000

--- a/zokrates_stdlib/tests/tests/hashes/keccak/keccak.json
+++ b/zokrates_stdlib/tests/tests/hashes/keccak/keccak.json
@@ -1,0 +1,15 @@
+{
+    "entry_point": "./tests/tests/hashes/keccak/keccak.zok",
+    "tests": [
+      {
+        "input": {
+          "values": []
+        },
+        "output": {
+          "Ok": {
+            "values": []
+          }
+        }
+      }
+    ]
+  }

--- a/zokrates_stdlib/tests/tests/hashes/keccak/keccak.zok
+++ b/zokrates_stdlib/tests/tests/hashes/keccak/keccak.zok
@@ -1,0 +1,15 @@
+import "hashes/keccak/keccak" as keccak
+
+// # testing padding with last 4 bytes of rlp header from ETH block #1 (532bytes)
+// Python code:
+// >>> from Crypto.Hash import keccak
+
+// >>> digest = keccak.new(digest_bits=256)
+// >>> digest.update(bytes.fromhex('9fef1ec4'))
+// >>> digest.hexdigest()
+// '274a259b1b2099ad819d5078bc4b2ac8b002f553e5b5a113d4a53cc6ba509d64'
+
+def main():
+    u64[4] h = keccak::<_, 256>([11524463798626811904], 0x0000000100000000)[..4]
+    assert(h == [2831116663861057965, 9339709681721617096, 12682969241313714451, 15322720131425017188])
+    return


### PR DESCRIPTION
# Summary
The base [keccak function](https://github.com/thecodingshrimp/ZoKrates/blob/7fae54d598ad2a9240e4634acd2f58d7518d2190/zokrates_stdlib/stdlib/hashes/keccak/keccak.zok#L79) pads the wrong u64 entry in `u64[N] input` if the byte length of the input is != N * 8.

# Problem Description
https://github.com/thecodingshrimp/ZoKrates/blob/7fae54d598ad2a9240e4634acd2f58d7518d2190/zokrates_stdlib/stdlib/hashes/keccak/keccak.zok#L89-L99
In the for loop in [line 90](https://github.com/thecodingshrimp/ZoKrates/blob/7fae54d598ad2a9240e4634acd2f58d7518d2190/zokrates_stdlib/stdlib/hashes/keccak/keccak.zok#L90), `pt` is incremented after XORing it with the last 8 bytes from `u64 input[N]`. This is only correct behavior when we hash 8 * N bytes since in [line 97](https://github.com/thecodingshrimp/ZoKrates/blob/7fae54d598ad2a9240e4634acd2f58d7518d2190/zokrates_stdlib/stdlib/hashes/keccak/keccak.zok#L97) we add padding in the first byte after 8 * N.
Example: Let's assume we want to hash 4 bytes `0x9fef1ec4`. We call `keccak::<_, 256>([0x9fef1ec400000000], 0x0000000100000000)` which, in the current implementation, pads the 12th byte since we went through the loop 1 time and incremented `pt` to 1.

# Solution
Check if `pad != 0x0000000000000001` and if so, decrement `pt` to pad the correct byte.