### PR TITLE
Avoid double wrapping of blocks in branch isolation

### DIFF
--- a/zokrates_core/src/static_analysis/branch_isolator.rs
+++ b/zokrates_core/src/static_analysis/branch_isolator.rs
@@ -31,4 +31,16 @@ impl<'ast, T: Field> Folder<'ast, T> for Isolator {
             e.kind,
         ))
     }
+
+    fn fold_block_expression<E: Expr<'ast, T> + Fold<'ast, T>>(
+        &mut self,
+        _: &E::Ty,
+        block: BlockExpression<'ast, T, E>,
+    ) -> BlockOrExpression<'ast, T, E> {
+        assert!(block.statements.is_empty());
+
+        let expression = block.value.fold(self);
+
+        BlockOrExpression::Expression(expression.into_inner())
+    }
 }

--- a/zokrates_core/src/typed_absy/folder.rs
+++ b/zokrates_core/src/typed_absy/folder.rs
@@ -311,10 +311,11 @@ pub trait Folder<'ast, T: Field>: Sized {
         }
     }
 
-    fn fold_block_expression<E: Fold<'ast, T>>(
+    fn fold_block_expression<E: Expr<'ast, T> + Fold<'ast, T>>(
         &mut self,
+        _: &E::Ty,
         block: BlockExpression<'ast, T, E>,
-    ) -> BlockExpression<'ast, T, E> {
+    ) -> BlockOrExpression<'ast, T, E> {
         fold_block_expression(self, block)
     }
 
@@ -553,7 +554,10 @@ pub fn fold_array_expression_inner<'ast, T: Field, F: Folder<'ast, T>>(
     use ArrayExpressionInner::*;
 
     match e {
-        Block(block) => Block(f.fold_block_expression(block)),
+        Block(block) => match f.fold_block_expression(ty, block) {
+            BlockOrExpression::Block(c) => Block(c),
+            BlockOrExpression::Expression(u) => u,
+        },
         Identifier(id) => Identifier(f.fold_name(id)),
         Value(exprs) => Value(
             exprs
@@ -603,7 +607,10 @@ pub fn fold_struct_expression_inner<'ast, T: Field, F: Folder<'ast, T>>(
     use StructExpressionInner::*;
 
     match e {
-        Block(block) => Block(f.fold_block_expression(block)),
+        Block(block) => match f.fold_block_expression(ty, block) {
+            BlockOrExpression::Block(c) => Block(c),
+            BlockOrExpression::Expression(u) => u,
+        },
         Identifier(id) => Identifier(f.fold_name(id)),
         Value(exprs) => Value(exprs.into_iter().map(|e| f.fold_expression(e)).collect()),
         FunctionCall(function_call) => match f.fold_function_call_expression(ty, function_call) {
@@ -637,7 +644,10 @@ pub fn fold_tuple_expression_inner<'ast, T: Field, F: Folder<'ast, T>>(
     use TupleExpressionInner::*;
 
     match e {
-        Block(block) => Block(f.fold_block_expression(block)),
+        Block(block) => match f.fold_block_expression(ty, block) {
+            BlockOrExpression::Block(c) => Block(c),
+            BlockOrExpression::Expression(u) => u,
+        },
         Identifier(id) => Identifier(f.fold_name(id)),
         Value(exprs) => Value(exprs.into_iter().map(|e| f.fold_expression(e)).collect()),
         FunctionCall(function_call) => match f.fold_function_call_expression(ty, function_call) {
@@ -669,8 +679,13 @@ pub fn fold_field_expression<'ast, T: Field, F: Folder<'ast, T>>(
 ) -> FieldElementExpression<'ast, T> {
     use FieldElementExpression::*;
 
+    let ty = Type::FieldElement;
+
     match e {
-        Block(block) => Block(f.fold_block_expression(block)),
+        Block(block) => match f.fold_block_expression(&ty, block) {
+            BlockOrExpression::Block(c) => Block(c),
+            BlockOrExpression::Expression(u) => u,
+        },
         Number(n) => Number(n),
         Identifier(id) => Identifier(f.fold_name(id)),
         Add(box e1, box e2) => {
@@ -708,27 +723,23 @@ pub fn fold_field_expression<'ast, T: Field, F: Folder<'ast, T>>(
 
             Pos(box e)
         }
-        Conditional(c) => match f.fold_conditional_expression(&Type::FieldElement, c) {
+        Conditional(c) => match f.fold_conditional_expression(&ty, c) {
             ConditionalOrExpression::Conditional(s) => Conditional(s),
             ConditionalOrExpression::Expression(u) => u,
         },
-        FunctionCall(function_call) => {
-            match f.fold_function_call_expression(&Type::FieldElement, function_call) {
-                FunctionCallOrExpression::FunctionCall(function_call) => {
-                    FunctionCall(function_call)
-                }
-                FunctionCallOrExpression::Expression(u) => u,
-            }
-        }
-        Select(select) => match f.fold_select_expression(&Type::FieldElement, select) {
+        FunctionCall(function_call) => match f.fold_function_call_expression(&ty, function_call) {
+            FunctionCallOrExpression::FunctionCall(function_call) => FunctionCall(function_call),
+            FunctionCallOrExpression::Expression(u) => u,
+        },
+        Select(select) => match f.fold_select_expression(&ty, select) {
             SelectOrExpression::Select(s) => Select(s),
             SelectOrExpression::Expression(u) => u,
         },
-        Member(m) => match f.fold_member_expression(&Type::FieldElement, m) {
+        Member(m) => match f.fold_member_expression(&ty, m) {
             MemberOrExpression::Member(m) => Member(m),
             MemberOrExpression::Expression(u) => u,
         },
-        Element(m) => match f.fold_element_expression(&Type::FieldElement, m) {
+        Element(m) => match f.fold_element_expression(&ty, m) {
             ElementOrExpression::Element(m) => Element(m),
             ElementOrExpression::Expression(u) => u,
         },
@@ -821,8 +832,13 @@ pub fn fold_boolean_expression<'ast, T: Field, F: Folder<'ast, T>>(
 ) -> BooleanExpression<'ast, T> {
     use BooleanExpression::*;
 
+    let ty = Type::Boolean;
+
     match e {
-        Block(block) => BooleanExpression::Block(f.fold_block_expression(block)),
+        Block(block) => match f.fold_block_expression(&ty, block) {
+            BlockOrExpression::Block(c) => Block(c),
+            BlockOrExpression::Expression(u) => u,
+        },
         Value(v) => BooleanExpression::Value(v),
         Identifier(id) => BooleanExpression::Identifier(f.fold_name(id)),
         FieldEq(e) => match f.fold_eq_expression(e) {
@@ -903,27 +919,23 @@ pub fn fold_boolean_expression<'ast, T: Field, F: Folder<'ast, T>>(
             let e = f.fold_boolean_expression(e);
             Not(box e)
         }
-        FunctionCall(function_call) => {
-            match f.fold_function_call_expression(&Type::Boolean, function_call) {
-                FunctionCallOrExpression::FunctionCall(function_call) => {
-                    FunctionCall(function_call)
-                }
-                FunctionCallOrExpression::Expression(u) => u,
-            }
-        }
-        Conditional(c) => match f.fold_conditional_expression(&Type::Boolean, c) {
+        FunctionCall(function_call) => match f.fold_function_call_expression(&ty, function_call) {
+            FunctionCallOrExpression::FunctionCall(function_call) => FunctionCall(function_call),
+            FunctionCallOrExpression::Expression(u) => u,
+        },
+        Conditional(c) => match f.fold_conditional_expression(&ty, c) {
             ConditionalOrExpression::Conditional(s) => Conditional(s),
             ConditionalOrExpression::Expression(u) => u,
         },
-        Select(select) => match f.fold_select_expression(&Type::Boolean, select) {
+        Select(select) => match f.fold_select_expression(&ty, select) {
             SelectOrExpression::Select(s) => Select(s),
             SelectOrExpression::Expression(u) => u,
         },
-        Member(m) => match f.fold_member_expression(&Type::Boolean, m) {
+        Member(m) => match f.fold_member_expression(&ty, m) {
             MemberOrExpression::Member(m) => Member(m),
             MemberOrExpression::Expression(u) => u,
         },
-        Element(m) => match f.fold_element_expression(&Type::Boolean, m) {
+        Element(m) => match f.fold_element_expression(&ty, m) {
             ElementOrExpression::Element(m) => Element(m),
             ElementOrExpression::Expression(u) => u,
         },
@@ -948,7 +960,10 @@ pub fn fold_uint_expression_inner<'ast, T: Field, F: Folder<'ast, T>>(
     use UExpressionInner::*;
 
     match e {
-        Block(block) => Block(f.fold_block_expression(block)),
+        Block(block) => match f.fold_block_expression(&ty, block) {
+            BlockOrExpression::Block(c) => Block(c),
+            BlockOrExpression::Expression(u) => u,
+        },
         Value(v) => Value(v),
         Identifier(id) => Identifier(f.fold_name(id)),
         Add(box left, box right) => {
@@ -1055,18 +1070,23 @@ pub fn fold_uint_expression_inner<'ast, T: Field, F: Folder<'ast, T>>(
     }
 }
 
-pub fn fold_block_expression<'ast, T: Field, E: Fold<'ast, T>, F: Folder<'ast, T>>(
+pub fn fold_block_expression<
+    'ast,
+    T: Field,
+    E: Fold<'ast, T> + Expr<'ast, T>,
+    F: Folder<'ast, T>,
+>(
     f: &mut F,
     block: BlockExpression<'ast, T, E>,
-) -> BlockExpression<'ast, T, E> {
-    BlockExpression {
+) -> BlockOrExpression<'ast, T, E> {
+    BlockOrExpression::Block(BlockExpression {
         statements: block
             .statements
             .into_iter()
             .flat_map(|s| f.fold_statement(s))
             .collect(),
         value: box block.value.fold(f),
-    }
+    })
 }
 
 pub fn fold_declaration_function_key<'ast, T: Field, F: Folder<'ast, T>>(

--- a/zokrates_core/src/typed_absy/mod.rs
+++ b/zokrates_core/src/typed_absy/mod.rs
@@ -1052,24 +1052,10 @@ impl<'ast, T: fmt::Display, E: fmt::Display> fmt::Display for ConditionalExpress
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self.kind {
             ConditionalKind::IfElse => {
-                let consequence = self.consequence.to_string();
-                let alternative = self.alternative.to_string();
-                let is_block = consequence.starts_with("{") && alternative.starts_with("{");
-
                 write!(
                     f,
                     "if {} {} else {}",
-                    self.condition,
-                    if is_block {
-                        consequence
-                    } else {
-                        format!("{{ {} }}", consequence)
-                    },
-                    if is_block {
-                        alternative
-                    } else {
-                        format!("{{ {} }}", alternative)
-                    },
+                    self.condition, self.consequence, self.alternative,
                 )
             }
             ConditionalKind::Ternary => write!(
@@ -2020,6 +2006,11 @@ pub enum ElementOrExpression<'ast, T, E: Expr<'ast, T>> {
 
 pub enum ConditionalOrExpression<'ast, T, E: Expr<'ast, T>> {
     Conditional(ConditionalExpression<'ast, T, E>),
+    Expression(E::Inner),
+}
+
+pub enum BlockOrExpression<'ast, T, E: Expr<'ast, T>> {
+    Block(BlockExpression<'ast, T, E>),
     Expression(E::Inner),
 }
 


### PR DESCRIPTION
Introduce `BlockOrExpression` so we can wrap all expressions except blocks (which are already wrapped)