### PR TITLE
Cast and string utils

### DIFF
--- a/zokrates_stdlib/stdlib/utils/casts/bool_array_to_u8_array.zok
+++ b/zokrates_stdlib/stdlib/utils/casts/bool_array_to_u8_array.zok
@@ -1,0 +1,13 @@
+from "EMBED" import u8_from_bits;
+
+def main<N, P>(bool[N] bits) -> u8[P] {
+    assert(N == 8 * P);
+
+    u8[P] mut res = [0; P];
+
+    for u32 i in 0..P {
+        res[i] = u8_from_bits(bits[8 * i..8 * (i + 1)]);
+    }
+
+    return res;
+}

--- a/zokrates_stdlib/stdlib/utils/casts/u8_array_to_bool_array.zok
+++ b/zokrates_stdlib/stdlib/utils/casts/u8_array_to_bool_array.zok
@@ -1,0 +1,16 @@
+from "EMBED" import u8_to_bits;
+
+def main<N, P>(u8[N] input) -> bool[P] {
+    assert(P == 8 * N);
+
+    bool[P] mut res = [false; P];
+
+    for u32 i in 0..N {
+        bool[8] bits = u8_to_bits(input[i]);
+        for u32 j in 0..8 {
+            res[i * 8 + j] = bits[j];
+        }
+    }
+
+    return res;
+}

--- a/zokrates_stdlib/stdlib/utils/casts/u8_array_to_u32_array.zok
+++ b/zokrates_stdlib/stdlib/utils/casts/u8_array_to_u32_array.zok
@@ -1,0 +1,11 @@
+from "EMBED" import u8_to_bits;
+from "EMBED" import u32_from_bits;
+
+def main<N,M>(u8[N] input) -> u32[M] {
+  assert(N == 4*M);
+  u32[M] mut output = [0; M];
+  for u32 i in 0..M {
+    output[i] = u32_from_bits([...u8_to_bits(input[i*4]), ...u8_to_bits(input[i*4+1]), ...u8_to_bits(input[i*4+2]), ...u8_to_bits(input[i*4+3])]);
+  }
+  return output;
+}

--- a/zokrates_stdlib/stdlib/utils/string/decimal_string_to_field.zok
+++ b/zokrates_stdlib/stdlib/utils/string/decimal_string_to_field.zok
@@ -1,0 +1,14 @@
+import "utils/casts/u8_to_field" as u8_to_field;
+
+// Converts decimal number from a N-byte string (ASCII) to a field, e.g. string "1234" -> field 1234
+// Does not allow for strings larger than 76 digits, but this can be manually changed depending on the curve
+// ALTBN_128 (default curve for ZoKrates) has maximum value 21888242871839275222246405745257275088548364400416034343698204186575808495617, which has 77 digits
+def main<N>(u8[N] string) -> field {
+  assert(N < 77);
+    field mut result = 0;
+    for u32 i in 0..N {
+        field as_field = u8_to_field(string[i] - 48);
+        result = result + as_field * 10**(N-i-1);
+    }
+    return result;
+}

--- a/zokrates_stdlib/stdlib/utils/string/decimal_string_to_field.zok
+++ b/zokrates_stdlib/stdlib/utils/string/decimal_string_to_field.zok
@@ -1,12 +1,31 @@
 import "utils/casts/u8_to_field" as u8_to_field;
 
-// Converts decimal number from a N-byte string (ASCII) to a field, e.g. string "1234" -> field 1234
-// Does not allow for strings larger than 76 digits, but this can be manually changed depending on the curve
-// ALTBN_128 (default curve for ZoKrates) has maximum value 21888242871839275222246405745257275088548364400416034343698204186575808495617, which has 77 digits
-def main<N>(u8[N] string) -> field {
+/* Converts decimal number from a N-byte string (ASCII) to a field, e.g. string "1234" -> field 1234
+ * Does not allow for strings larger than 76 digits, but this can be manually changed depending on the curve
+ * ALTBN_128 (default curve for ZoKrates) has maximum value 21888242871839275222246405745257275088548364400416034343698204186575808495617, which has 77 digits
+
+ * Two versions are in this file, differing by the line:
+ * assert((string[i] >= 48) && (string[i] <=57));
+ * The efficient version saves ~8000 constraints for a 10-digit integer
+ * However, it should only be used if you can gaurantee the input is an ASCII number
+ * Please exercise caution if using the unsafe and efficient version
+ */
+ 
+def unsafe_efficient<N>(u8[N] string) -> field {
   assert(N < 77);
     field mut result = 0;
     for u32 i in 0..N {
+        field as_field = u8_to_field(string[i] - 48);
+        result = result + as_field * 10**(N-i-1);
+    }
+    return result;
+}
+
+def safe_inefficient<N>(u8[N] string) -> field {
+  assert(N < 77);
+    field mut result = 0;
+    for u32 i in 0..N {
+        assert((string[i] >= 48) && (string[i] <=57));
         field as_field = u8_to_field(string[i] - 48);
         result = result + as_field * 10**(N-i-1);
     }

--- a/zokrates_stdlib/stdlib/utils/string/substring_at.zok
+++ b/zokrates_stdlib/stdlib/utils/string/substring_at.zok
@@ -1,0 +1,9 @@
+// Returns a substring of length S, starting at fullString[idx]
+// String here means a string of bytes (u8s), in any encoding
+def main<F,S>(u8[F] fullString, u32 idx) -> u8[S] {
+	u8[S] mut r = [0; S];
+  for u32 i in 0..S {
+    r[i] = fullString[idx + i];
+	}
+  return r;
+}


### PR DESCRIPTION
I made a few new utils for type casts and parsing strings (represented as u8 arrays). I've tested them locally but was having difficulty adding and running tests in `zokrates_stdlib/tests/tests/utils`. Compiler was saying were saying the new utils were not found, even though I rebuilt after adding the utils. I rebuilt with [these](https://zokrates.github.io/gettingstarted.html#from-source) instructions.

I also wrote a base64 conversion string util which could be helpful, but requires these as dependencies, so perhaps let's make sure I contribute these correctly before submitting those.