### PR TITLE
Fix duplicate optimiser

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3031,6 +3031,7 @@ dependencies = [
  "ark-bls12-377",
  "cfg-if 0.1.10",
  "csv",
+ "derivative",
  "num-bigint 0.2.6",
  "pairing_ce",
  "serde",
@@ -3215,7 +3216,7 @@ dependencies = [
 
 [[package]]
 name = "zokrates_js"
-version = "1.1.2"
+version = "1.1.3"
 dependencies = [
  "console_error_panic_hook",
  "indexmap",

--- a/changelogs/unreleased/1226-schaeff
+++ b/changelogs/unreleased/1226-schaeff
@@ -1,0 +1,1 @@
+Fix duplicate constraint optimiser

--- a/zokrates_ast/Cargo.toml
+++ b/zokrates_ast/Cargo.toml
@@ -20,7 +20,4 @@ serde_json = { version = "1.0", features = ["preserve_order"] }
 zokrates_embed = { version = "0.1.0", path = "../zokrates_embed", default-features = false }
 pairing_ce = { version = "^0.21", optional = true }
 ark-bls12-377 = { version = "^0.3.0", features = ["curve"], default-features = false, optional = true }
-
-
-
-
+derivative = "2.2.0"

--- a/zokrates_core/src/optimizer/duplicate.rs
+++ b/zokrates_core/src/optimizer/duplicate.rs
@@ -39,6 +39,7 @@ impl<T: Field> Folder<T> for DuplicateOptimizer {
     }
 
     fn fold_statement(&mut self, s: Statement<T>) -> Vec<Statement<T>> {
+        println!("{}", s);
         let hashed = hash(&s);
         let result = match self.seen.get(&hashed) {
             Some(_) => vec![],

--- a/zokrates_core/src/optimizer/duplicate.rs
+++ b/zokrates_core/src/optimizer/duplicate.rs
@@ -39,7 +39,6 @@ impl<T: Field> Folder<T> for DuplicateOptimizer {
     }
 
     fn fold_statement(&mut self, s: Statement<T>) -> Vec<Statement<T>> {
-        println!("{}", s);
         let hashed = hash(&s);
         let result = match self.seen.get(&hashed) {
             Some(_) => vec![],

--- a/zokrates_core_test/tests/tests/duplicate.json
+++ b/zokrates_core_test/tests/tests/duplicate.json
@@ -1,7 +1,6 @@
 {
-    "entry_point": "./tests/tests/duplicate.zok",
-    "max_constraint_count": 1,
-    "curves": ["Bn128"],
-    "tests": []
-  }
-  
+  "entry_point": "./tests/tests/duplicate.zok",
+  "max_constraint_count": 1,
+  "curves": ["Bn128"],
+  "tests": []
+}

--- a/zokrates_core_test/tests/tests/duplicate.json
+++ b/zokrates_core_test/tests/tests/duplicate.json
@@ -1,0 +1,7 @@
+{
+    "entry_point": "./tests/tests/duplicate.zok",
+    "max_constraint_count": 1,
+    "curves": ["Bn128"],
+    "tests": []
+  }
+  

--- a/zokrates_core_test/tests/tests/duplicate.zok
+++ b/zokrates_core_test/tests/tests/duplicate.zok
@@ -1,0 +1,4 @@
+def main(field a) {
+    assert(a == 0);
+    assert(a == 0);
+}


### PR DESCRIPTION
Since we added error messages in assertion statements, equivalent statements with different error messages hash to different values, and are therefore not deduplicated. Ignore the message in the Hash implementation.

The PartialEq implementation remains unchanged, so the `k1 == k2 -> hash(k1) == hash(k2)` requirement is satisfied.