### PR TITLE
Fix whitespace definition in pest

### DIFF
--- a/changelogs/unreleased/1232-dark64
+++ b/changelogs/unreleased/1232-dark64
@@ -1,0 +1,1 @@
+Loosen up whitespace restrictions to allow more formatting styles

--- a/zokrates_ast/src/untyped/from_ast.rs
+++ b/zokrates_ast/src/untyped/from_ast.rs
@@ -23,7 +23,7 @@ fn import_directive_to_symbol_vec(
     match import {
         pest::ImportDirective::Main(import) => {
             let span = import.span;
-            let source = Path::new(import.source.span.as_str());
+            let source = Path::new(import.source.raw.span.as_str());
             let id = "main";
             let alias = import.alias.map(|a| a.span.as_str());
 
@@ -41,7 +41,7 @@ fn import_directive_to_symbol_vec(
         }
         pest::ImportDirective::From(import) => {
             let span = import.span;
-            let source = Path::new(import.source.span.as_str());
+            let source = Path::new(import.source.raw.span.as_str());
             import
                 .symbols
                 .into_iter()
@@ -251,7 +251,7 @@ impl<'ast> From<pest::LogStatement<'ast>> for untyped::StatementNode<'ast> {
             .map(untyped::ExpressionNode::from)
             .collect();
 
-        untyped::Statement::Log(statement.format_string.span.as_str(), expressions)
+        untyped::Statement::Log(statement.format_string.raw.span.as_str(), expressions)
             .span(statement.span)
     }
 }
@@ -321,7 +321,7 @@ impl<'ast> From<pest::AssertionStatement<'ast>> for untyped::StatementNode<'ast>
 
         untyped::Statement::Assertion(
             untyped::ExpressionNode::from(statement.expression),
-            statement.message.map(|m| m.value),
+            statement.message.map(|m| m.raw.value),
         )
         .span(statement.span)
     }

--- a/zokrates_core_test/tests/tests/whitespace.zok
+++ b/zokrates_core_test/tests/tests/whitespace.zok
@@ -1,0 +1,21 @@
+from "field" import FIELD_MIN,
+    FIELD_MAX,
+    FIELD_SIZE_IN_BITS;
+
+struct Foo
+{
+    field a;
+    field b;
+}
+
+def main(
+    private Foo foo,
+    field c
+) -> bool
+{
+    field[2] arr = [
+        foo.a,
+        foo.b
+    ];
+    return arr[0] * arr[1] == c;
+}

--- a/zokrates_parser/src/zokrates.pest
+++ b/zokrates_parser/src/zokrates.pest
@@ -2,9 +2,9 @@ file = { SOI ~ pragma? ~ symbol_declaration* ~ EOI }
 
 pragma = { "#pragma" ~ "curve" ~ curve }
 curve = @{ (ASCII_ALPHANUMERIC | "_") * }
-string = @{(!"\"" ~ ANY)*}
+raw_string = @{(!"\"" ~ ANY)*}
+quoted_string = ${ "\"" ~ raw_string ~ "\"" }
 semicolon = _{";"}
-quoted_string = _{ "\"" ~ string ~ "\"" }
 
 symbol_declaration = { (((import_directive | const_definition | type_definition) ~ semicolon) | (ty_struct_definition | function_definition)) }
 

--- a/zokrates_parser/src/zokrates.pest
+++ b/zokrates_parser/src/zokrates.pest
@@ -1,4 +1,4 @@
-file = { SOI ~ NEWLINE* ~ pragma? ~ NEWLINE* ~ symbol_declaration* ~ EOI }
+file = { SOI ~ pragma? ~ symbol_declaration* ~ EOI }
 
 pragma = { "#pragma" ~ "curve" ~ curve }
 curve = @{ (ASCII_ALPHANUMERIC | "_") * }
@@ -6,7 +6,7 @@ string = @{(!"\"" ~ ANY)*}
 semicolon = _{";"}
 quoted_string = _{ "\"" ~ string ~ "\"" }
 
-symbol_declaration = { (((import_directive | const_definition | type_definition) ~ semicolon) | (ty_struct_definition | function_definition)) ~ NEWLINE* }
+symbol_declaration = { (((import_directive | const_definition | type_definition) ~ semicolon) | (ty_struct_definition | function_definition)) }
 
 import_directive = { main_import_directive | from_import_directive }
 from_import_directive = { "from" ~ quoted_string ~ "import" ~ import_symbol_list }
@@ -41,8 +41,8 @@ ty_tuple_multiple_inner = _{ ty ~ ("," ~ ty)+ ~ ","? }
 // structs
 ty_struct = { identifier ~ explicit_generics? }
 // type definitions
-ty_struct_definition = { "struct" ~ identifier ~ constant_generics_declaration? ~ "{" ~ NEWLINE* ~ struct_field_list ~ NEWLINE* ~ "}" ~ NEWLINE* }
-struct_field_list = _{ (struct_field ~ semicolon ~ NEWLINE*)* }
+ty_struct_definition = { "struct" ~ identifier ~ constant_generics_declaration? ~ "{" ~ struct_field_list ~ "}" }
+struct_field_list = _{ (struct_field ~ semicolon)* }
 struct_field = { typed_identifier }
 
 vis_private = {"private"}
@@ -57,10 +57,10 @@ statement = { (iteration_statement // does not require semicolon
                 |return_statement
                 | definition_statement
                 | assertion_statement
-                ) ~ semicolon)) ~ NEWLINE* }
+                ) ~ semicolon)) }
 
 log_statement = { "log" ~ "(" ~ quoted_string ~ "," ~ expression_list ~ ")"}
-block_statement = _{ "{" ~ NEWLINE* ~ statement* ~ NEWLINE* ~ "}" }
+block_statement = _{ "{" ~ statement* ~ "}" }
 iteration_statement = { "for" ~ typed_identifier ~ "in" ~ expression ~ ".." ~ expression ~ block_statement }
 return_statement = { "return" ~ expression? }
 definition_statement = { typed_identifier_or_assignee ~ "=" ~ expression }
@@ -86,7 +86,7 @@ inline_tuple_empty_expression_inner = _{ "" }
 inline_tuple_single_expression_inner = _{ expression ~ "," }
 inline_tuple_multiple_expression_inner = _{ expression ~ ("," ~ expression)+ ~ ","? }
 
-block_expression = _{ "{" ~ NEWLINE* ~ statement* ~ expression ~ NEWLINE* ~ "}" }
+block_expression = _{ "{" ~ statement* ~ expression ~ "}" }
 if_else_expression = { "if" ~ expression ~ block_expression ~ "else" ~ block_expression }
 
 access = { array_access | call_access | dot_access }
@@ -102,12 +102,12 @@ identifier_or_decimal = { identifier | decimal_number }
 
 primary_expression = { identifier | literal }
 
-inline_struct_expression = { identifier ~ "{" ~ NEWLINE* ~ inline_struct_member_list ~ NEWLINE* ~ "}" }
-inline_struct_member_list = _{(inline_struct_member ~ ("," ~ NEWLINE* ~ inline_struct_member)*)? ~ ","? }
+inline_struct_expression = { identifier ~ "{" ~ inline_struct_member_list ~ "}" }
+inline_struct_member_list = _{(inline_struct_member ~ ("," ~ inline_struct_member)*)? ~ ","? }
 inline_struct_member = { identifier ~ ":" ~ expression }
 
-inline_array_expression = { "[" ~ NEWLINE* ~ inline_array_inner ~ NEWLINE* ~ "]" }
-inline_array_inner = _{(spread_or_expression ~ ("," ~ NEWLINE* ~ spread_or_expression)*)?}
+inline_array_expression = { "[" ~ inline_array_inner ~ "]" }
+inline_array_inner = _{(spread_or_expression ~ ("," ~ spread_or_expression)*)?}
 spread_or_expression = { spread | expression }
 range_or_expression = { range | expression }
 
@@ -174,7 +174,7 @@ op_ternary = {"?" ~ expression ~ ":"}
 op_binary = _ { op_or | op_and | op_bit_xor | op_bit_and | op_bit_or | op_left_shift | op_right_shift | op_equal | op_not_equal | op_lte | op_lt | op_gte | op_gt | op_add | op_sub | op_mul | op_div | op_rem | op_ternary }
 op_unary = { op_pos | op_neg | op_not }
 
-WHITESPACE = _{ " " | "\t" | "\\" ~ COMMENT? ~ NEWLINE}
+WHITESPACE = _{ " " | "\t" | "\\" | COMMENT | NEWLINE }
 COMMENT = _{ ("/*" ~ (!"*/" ~ ANY)* ~ "*/") | ("//" ~ (!NEWLINE ~ ANY)*) }
 
 // the ordering of reserved keywords matters: if "as" is before "assert", then "assert" gets parsed as (as)(sert) and incorrectly

--- a/zokrates_parser/src/zokrates.pest
+++ b/zokrates_parser/src/zokrates.pest
@@ -2,8 +2,8 @@ file = { SOI ~ pragma? ~ symbol_declaration* ~ EOI }
 
 pragma = { "#pragma" ~ "curve" ~ curve }
 curve = @{ (ASCII_ALPHANUMERIC | "_") * }
-raw_string = @{(!"\"" ~ ANY)*}
-quoted_string = ${ "\"" ~ raw_string ~ "\"" }
+string = @{(!"\"" ~ ANY)*}
+quoted_string = ${ "\"" ~ string ~ "\"" }
 semicolon = _{";"}
 
 symbol_declaration = { (((import_directive | const_definition | type_definition) ~ semicolon) | (ty_struct_definition | function_definition)) }

--- a/zokrates_pest_ast/src/lib.rs
+++ b/zokrates_pest_ast/src/lib.rs
@@ -211,7 +211,7 @@ mod ast {
     #[derive(Debug, FromPest, PartialEq, Eq, Clone)]
     #[pest_ast(rule(Rule::main_import_directive))]
     pub struct MainImportDirective<'ast> {
-        pub source: AnyString<'ast>,
+        pub source: QString<'ast>,
         pub alias: Option<IdentifierExpression<'ast>>,
         #[pest_ast(outer())]
         pub span: Span<'ast>,
@@ -229,7 +229,7 @@ mod ast {
     #[derive(Debug, FromPest, PartialEq, Eq, Clone)]
     #[pest_ast(rule(Rule::from_import_directive))]
     pub struct FromImportDirective<'ast> {
-        pub source: AnyString<'ast>,
+        pub source: QString<'ast>,
         pub symbols: Vec<ImportSymbol<'ast>>,
         #[pest_ast(outer())]
         pub span: Span<'ast>,
@@ -371,7 +371,7 @@ mod ast {
     #[derive(Debug, FromPest, PartialEq, Clone)]
     #[pest_ast(rule(Rule::log_statement))]
     pub struct LogStatement<'ast> {
-        pub format_string: AnyString<'ast>,
+        pub format_string: QString<'ast>,
         pub expressions: Vec<Expression<'ast>>,
         #[pest_ast(outer())]
         pub span: Span<'ast>,
@@ -387,10 +387,18 @@ mod ast {
     }
 
     #[derive(Debug, FromPest, PartialEq, Eq, Clone)]
-    #[pest_ast(rule(Rule::string))]
-    pub struct AnyString<'ast> {
+    #[pest_ast(rule(Rule::raw_string))]
+    pub struct RawString<'ast> {
         #[pest_ast(outer(with(span_into_str)))]
         pub value: String,
+        #[pest_ast(outer())]
+        pub span: Span<'ast>,
+    }
+
+    #[derive(Debug, FromPest, PartialEq, Eq, Clone)]
+    #[pest_ast(rule(Rule::quoted_string))]
+    pub struct QString<'ast> {
+        pub raw: RawString<'ast>,
         #[pest_ast(outer())]
         pub span: Span<'ast>,
     }
@@ -399,7 +407,7 @@ mod ast {
     #[pest_ast(rule(Rule::assertion_statement))]
     pub struct AssertionStatement<'ast> {
         pub expression: Expression<'ast>,
-        pub message: Option<AnyString<'ast>>,
+        pub message: Option<QString<'ast>>,
         #[pest_ast(outer())]
         pub span: Span<'ast>,
     }
@@ -1178,9 +1186,12 @@ mod tests {
                 pragma: None,
                 declarations: vec![
                     SymbolDeclaration::Import(ImportDirective::Main(MainImportDirective {
-                        source: AnyString {
-                            value: String::from("foo"),
-                            span: Span::new(source, 17, 20).unwrap()
+                        source: QString {
+                            raw: RawString {
+                                value: String::from("foo"),
+                                span: Span::new(source, 17, 20).unwrap()
+                            },
+                            span: Span::new(source, 16, 21).unwrap()
                         },
                         alias: None,
                         span: Span::new(source, 9, 21).unwrap()
@@ -1243,9 +1254,12 @@ mod tests {
                 pragma: None,
                 declarations: vec![
                     SymbolDeclaration::Import(ImportDirective::Main(MainImportDirective {
-                        source: AnyString {
-                            value: String::from("foo"),
-                            span: Span::new(source, 17, 20).unwrap()
+                        source: QString {
+                            raw: RawString {
+                                value: String::from("foo"),
+                                span: Span::new(source, 17, 20).unwrap()
+                            },
+                            span: Span::new(source, 16, 21).unwrap()
                         },
                         alias: None,
                         span: Span::new(source, 9, 21).unwrap()
@@ -1332,9 +1346,12 @@ mod tests {
                 pragma: None,
                 declarations: vec![
                     SymbolDeclaration::Import(ImportDirective::Main(MainImportDirective {
-                        source: AnyString {
-                            value: String::from("foo"),
-                            span: Span::new(source, 17, 20).unwrap()
+                        source: QString {
+                            raw: RawString {
+                                value: String::from("foo"),
+                                span: Span::new(source, 17, 20).unwrap()
+                            },
+                            span: Span::new(source, 16, 21).unwrap()
                         },
                         alias: None,
                         span: Span::new(source, 9, 21).unwrap()

--- a/zokrates_pest_ast/src/lib.rs
+++ b/zokrates_pest_ast/src/lib.rs
@@ -387,7 +387,7 @@ mod ast {
     }
 
     #[derive(Debug, FromPest, PartialEq, Eq, Clone)]
-    #[pest_ast(rule(Rule::raw_string))]
+    #[pest_ast(rule(Rule::string))]
     pub struct RawString<'ast> {
         #[pest_ast(outer(with(span_into_str)))]
         pub value: String,


### PR DESCRIPTION
Our syntax is currently strict on how and where newlines are allowed eg.

```
def main(...) { // <-- `{` must be in the same line
    ...
}
```

This PR changes `WHITESPACE` definition in the grammar so that newlines are allowed everywhere except in atomic definitions. This makes the syntax not so strict on newlines.