### PR TITLE
Add support for the pallas curve field

### DIFF
--- a/changelogs/unreleased/1234-schaeff
+++ b/changelogs/unreleased/1234-schaeff
@@ -1,0 +1,1 @@
+Add support for the Pallas curve field

--- a/zokrates_cli/src/cli_constants.rs
+++ b/zokrates_cli/src/cli_constants.rs
@@ -36,7 +36,7 @@ pub const BACKENDS: &[&str] = if cfg!(feature = "ark") {
     &[]
 };
 
-pub const CURVES: &[&str] = &[BN128, BLS12_381, BLS12_377, BW6_761];
+pub const CURVES: &[&str] = &[BN128, BLS12_381, BLS12_377, BW6_761, PALLAS];
 
 pub const SCHEMES: &[&str] = &[G16, GM17, MARLIN];
 

--- a/zokrates_cli/src/ops/check.rs
+++ b/zokrates_cli/src/ops/check.rs
@@ -7,7 +7,9 @@ use std::path::{Path, PathBuf};
 use zokrates_common::constants::BN128;
 use zokrates_common::helpers::CurveParameter;
 use zokrates_core::compile::{check, CompileConfig, CompileError};
-use zokrates_field::{Bls12_377Field, Bls12_381Field, Bn128Field, Bw6_761Field, Field};
+use zokrates_field::{
+    Bls12_377Field, Bls12_381Field, Bn128Field, Bw6_761Field, Field, PallasField,
+};
 use zokrates_fs_resolver::FileSystemResolver;
 
 pub fn subcommand() -> App<'static, 'static> {
@@ -56,6 +58,7 @@ pub fn exec(sub_matches: &ArgMatches) -> Result<(), String> {
         CurveParameter::Bls12_377 => cli_check::<Bls12_377Field>(sub_matches),
         CurveParameter::Bls12_381 => cli_check::<Bls12_381Field>(sub_matches),
         CurveParameter::Bw6_761 => cli_check::<Bw6_761Field>(sub_matches),
+        CurveParameter::Pallas => cli_check::<PallasField>(sub_matches),
     }
 }
 

--- a/zokrates_cli/src/ops/compile.rs
+++ b/zokrates_cli/src/ops/compile.rs
@@ -10,7 +10,9 @@ use zokrates_circom::write_r1cs;
 use zokrates_common::constants::BN128;
 use zokrates_common::helpers::CurveParameter;
 use zokrates_core::compile::{compile, CompileConfig, CompileError};
-use zokrates_field::{Bls12_377Field, Bls12_381Field, Bn128Field, Bw6_761Field, Field};
+use zokrates_field::{
+    Bls12_377Field, Bls12_381Field, Bn128Field, Bw6_761Field, Field, PallasField,
+};
 use zokrates_fs_resolver::FileSystemResolver;
 
 pub fn subcommand() -> App<'static, 'static> {
@@ -81,6 +83,7 @@ pub fn exec(sub_matches: &ArgMatches) -> Result<(), String> {
         CurveParameter::Bls12_377 => cli_compile::<Bls12_377Field>(sub_matches),
         CurveParameter::Bls12_381 => cli_compile::<Bls12_381Field>(sub_matches),
         CurveParameter::Bw6_761 => cli_compile::<Bw6_761Field>(sub_matches),
+        CurveParameter::Pallas => cli_compile::<PallasField>(sub_matches),
     }
 }
 

--- a/zokrates_common/src/constants.rs
+++ b/zokrates_common/src/constants.rs
@@ -5,6 +5,7 @@ pub const BN128: &str = "bn128";
 pub const BLS12_381: &str = "bls12_381";
 pub const BLS12_377: &str = "bls12_377";
 pub const BW6_761: &str = "bw6_761";
+pub const PALLAS: &str = "pallas";
 
 pub const G16: &str = "g16";
 pub const GM17: &str = "gm17";

--- a/zokrates_common/src/helpers.rs
+++ b/zokrates_common/src/helpers.rs
@@ -7,6 +7,7 @@ pub enum CurveParameter {
     Bls12_381,
     Bls12_377,
     Bw6_761,
+    Pallas,
 }
 
 impl std::fmt::Display for CurveParameter {
@@ -18,6 +19,7 @@ impl std::fmt::Display for CurveParameter {
             Bls12_381 => write!(f, "bls12_381"),
             Bls12_377 => write!(f, "bls12_377"),
             Bw6_761 => write!(f, "bw6_761"),
+            Pallas => write!(f, "pallas"),
         }
     }
 }

--- a/zokrates_field/Cargo.toml
+++ b/zokrates_field/Cargo.toml
@@ -28,6 +28,7 @@ ark-bn254 = { version = "^0.3.0", features = ["curve"], default-features = false
 ark-bls12-377 = { version = "^0.3.0", features = ["curve"], default-features = false }
 ark-bls12-381 = { version = "^0.3.0", features = ["curve"] }
 ark-bw6-761 = { version = "^0.3.0", default-features = false }
+ark-pallas = { version = "^0.3.0", features = ["curve"] }
 ark-serialize = { version = "^0.3.0", default-features = false }
 
 [dev-dependencies]

--- a/zokrates_field/src/bls12_377.rs
+++ b/zokrates_field/src/bls12_377.rs
@@ -1,7 +1,8 @@
 use ark_bls12_377::Bls12_377;
+use ark_ec::PairingEngine;
 
 use crate::G2Type;
 
-prime_field!("bls12_377", Bls12_377, G2Type::Fq2);
+prime_field!("bls12_377", <Bls12_377 as PairingEngine>::Fr, G2Type::Fq2);
 
 ark_extensions!(Bls12_377);

--- a/zokrates_field/src/bls12_381.rs
+++ b/zokrates_field/src/bls12_381.rs
@@ -1,6 +1,7 @@
 use ark_bls12_381::Bls12_381;
+use ark_ec::PairingEngine;
 
-prime_field!("bls12_381", Bls12_381, G2Type::Fq2);
+prime_field!("bls12_381", <Bls12_381 as PairingEngine>::Fr, G2Type::Fq2);
 
 ark_extensions!(Bls12_381);
 

--- a/zokrates_field/src/bn128.rs
+++ b/zokrates_field/src/bn128.rs
@@ -1,6 +1,7 @@
 use ark_bn254::Bn254;
+use ark_ec::PairingEngine;
 
-prime_field!("bn128", Bn254, G2Type::Fq2);
+prime_field!("bn128", <Bn254 as PairingEngine>::Fr, G2Type::Fq2);
 
 ark_extensions!(Bn254);
 

--- a/zokrates_field/src/bw6_761.rs
+++ b/zokrates_field/src/bw6_761.rs
@@ -1,7 +1,8 @@
 use ark_bw6_761::BW6_761;
+use ark_ec::PairingEngine;
 
 use crate::G2Type;
 
-prime_field!("bw6_761", BW6_761, G2Type::Fq);
+prime_field!("bw6_761", <BW6_761 as PairingEngine>::Fr, G2Type::Fq);
 
 ark_extensions!(BW6_761);

--- a/zokrates_field/src/lib.rs
+++ b/zokrates_field/src/lib.rs
@@ -32,7 +32,6 @@ pub trait BellmanFieldExtensions {
     fn into_bellman(self) -> <Self::BellmanEngine as ScalarEngine>::Fr;
     fn new_fq2(c0: &str, c1: &str) -> <Self::BellmanEngine as Engine>::Fqe;
 }
-
 pub trait ArkFieldExtensions {
     /// An associated type to be able to operate with ark ff traits
     type ArkEngine: ark_ec::PairingEngine;
@@ -146,7 +145,7 @@ mod prime_field {
             use std::fmt::{Debug, Display};
             use std::ops::{Add, Div, Mul, Sub};
 
-            type Fr = <$v as ark_ec::PairingEngine>::Fr;
+            type Fr = $v;
 
             #[derive(PartialEq, PartialOrd, Clone, Eq, Ord, Hash)]
             pub struct FieldPrime {
@@ -632,8 +631,10 @@ pub mod bls12_377;
 pub mod bls12_381;
 pub mod bn128;
 pub mod bw6_761;
+pub mod pallas;
 
 pub use bls12_377::FieldPrime as Bls12_377Field;
 pub use bls12_381::FieldPrime as Bls12_381Field;
 pub use bn128::FieldPrime as Bn128Field;
 pub use bw6_761::FieldPrime as Bw6_761Field;
+pub use pallas::FieldPrime as PallasField;

--- a/zokrates_field/src/pallas.rs
+++ b/zokrates_field/src/pallas.rs
@@ -1,0 +1,5 @@
+use ark_pallas::Fr as PallasBaseField;
+
+use crate::G2Type;
+
+prime_field!("pallas", PallasBaseField, G2Type::Fq2);

--- a/zokrates_js/src/lib.rs
+++ b/zokrates_js/src/lib.rs
@@ -25,7 +25,9 @@ use zokrates_core::compile::{
     compile as core_compile, CompilationArtifacts, CompileConfig, CompileError,
 };
 use zokrates_core::imports::Error;
-use zokrates_field::{Bls12_377Field, Bls12_381Field, Bn128Field, Bw6_761Field, Field};
+use zokrates_field::{
+    Bls12_377Field, Bls12_381Field, Bn128Field, Bw6_761Field, Field, PallasField,
+};
 use zokrates_proof_systems::groth16::G16;
 use zokrates_proof_systems::{
     Backend, Marlin, NonUniversalBackend, NonUniversalScheme, Proof, Scheme,
@@ -454,6 +456,9 @@ pub fn compile(
         CurveParameter::Bw6_761 => {
             internal::compile::<Bw6_761Field>(source, location, resolve_callback, config)
         }
+        CurveParameter::Pallas => {
+            internal::compile::<PallasField>(source, location, resolve_callback, config)
+        }
     }
 }
 
@@ -603,6 +608,10 @@ pub fn universal_setup(curve: JsValue, size: u32) -> Result<Vec<u8>, JsValue> {
         CurveParameter::Bw6_761 => {
             Ok(internal::universal_setup_of_size::<Bw6_761Field, Marlin, Ark>(size))
         }
+        c => Err(JsValue::from(format!(
+            "Curve `{}` is not supported for universal setups",
+            c
+        ))),
     }
 }
 
@@ -746,18 +755,21 @@ pub fn verify(vk: JsValue, proof: JsValue, options: JsValue) -> Result<JsValue, 
             CurveParameter::Bls12_381 => internal::verify::<Bls12_381Field, G16, Ark>(vk, proof),
             CurveParameter::Bls12_377 => internal::verify::<Bls12_377Field, G16, Ark>(vk, proof),
             CurveParameter::Bw6_761 => internal::verify::<Bw6_761Field, G16, Ark>(vk, proof),
+            _ => Err(JsValue::from_str("Not supported")),
         },
         (BackendParameter::Ark, SchemeParameter::GM17) => match curve {
             CurveParameter::Bn128 => internal::verify::<Bn128Field, GM17, Ark>(vk, proof),
             CurveParameter::Bls12_381 => internal::verify::<Bls12_381Field, GM17, Ark>(vk, proof),
             CurveParameter::Bls12_377 => internal::verify::<Bls12_377Field, GM17, Ark>(vk, proof),
             CurveParameter::Bw6_761 => internal::verify::<Bw6_761Field, GM17, Ark>(vk, proof),
+            _ => Err(JsValue::from_str("Not supported")),
         },
         (BackendParameter::Ark, SchemeParameter::MARLIN) => match curve {
             CurveParameter::Bn128 => internal::verify::<Bn128Field, Marlin, Ark>(vk, proof),
             CurveParameter::Bls12_381 => internal::verify::<Bls12_381Field, Marlin, Ark>(vk, proof),
             CurveParameter::Bls12_377 => internal::verify::<Bls12_377Field, Marlin, Ark>(vk, proof),
             CurveParameter::Bw6_761 => internal::verify::<Bw6_761Field, Marlin, Ark>(vk, proof),
+            _ => Err(JsValue::from_str("Not supported")),
         },
         _ => Err(JsValue::from_str("Unsupported options")),
     }


### PR DESCRIPTION
Support the pallas curve for compilation. 
- No proof system is implemented for it as of now
- Refactored the PrimeField macro as it made the assumption that the field belonged to a `PairingEngine` implementor, which is not the case for Pallas (which is not pairing-friendly)