### PR TITLE
Add "multicore" bellman feature to fix plonk test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -437,6 +437,7 @@ dependencies = [
 [[package]]
 name = "bellman_ce"
 version = "0.3.2"
+source = "git+https://github.com/georgwiese/bellman?rev=b356c7001f30da23bfad2b43eb0b7ca9804c8252#b356c7001f30da23bfad2b43eb0b7ca9804c8252"
 dependencies = [
  "bit-vec",
  "blake2s_const",
@@ -571,6 +572,7 @@ dependencies = [
 [[package]]
 name = "blake2s_const"
 version = "0.6.0"
+source = "git+https://github.com/georgwiese/bellman?rev=b356c7001f30da23bfad2b43eb0b7ca9804c8252#b356c7001f30da23bfad2b43eb0b7ca9804c8252"
 dependencies = [
  "arrayref",
  "arrayvec 0.5.2",
@@ -3160,7 +3162,7 @@ dependencies = [
 name = "zokrates_bellman"
 version = "0.1.0"
 dependencies = [
- "bellman_ce 0.3.2",
+ "bellman_ce 0.3.2 (git+https://github.com/georgwiese/bellman?rev=b356c7001f30da23bfad2b43eb0b7ca9804c8252)",
  "getrandom",
  "hex 0.4.3",
  "phase2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2568,7 +2568,7 @@ checksum = "eb703cfe953bccee95685111adeedb76fabe4e97549a58d16f03ea7b9367bb32"
 [[package]]
 name = "solc"
 version = "0.1.0"
-source = "git+https://github.com/g-r-a-n-t/solc-rust?rev=52d4146#52d414631bc6c3f0c29749503923a8d7e48b9f4d"
+source = "git+https://github.com/g-r-a-n-t/solc-rust?rev=f8bc7f1#f8bc7f1475a76d22a53df2cf23652910b32951d1"
 dependencies = [
  "cmake",
  "lazy_static",

--- a/zokrates_bellman/Cargo.toml
+++ b/zokrates_bellman/Cargo.toml
@@ -12,7 +12,7 @@ zokrates_field = { version = "0.5", path = "../zokrates_field", default-features
 zokrates_ast = { version = "0.1", path = "../zokrates_ast", default-features = false }
 zokrates_proof_systems = { version = "0.1", path = "../zokrates_proof_systems", default-features = false }
 
-bellman_ce = { path = "../../bellman", default-features = false, features = ["plonk"] }
+bellman_ce = { path = "../../bellman", default-features = false, features = ["plonk", "multicore"] }
 # pairing = { package = "pairing_ce", version = "^0.21" }
 phase2 = { git = "https://github.com/Zokrates/phase2", default-features = false }
 rand_0_4 = { version = "0.4", package = "rand" }#

--- a/zokrates_bellman/Cargo.toml
+++ b/zokrates_bellman/Cargo.toml
@@ -12,7 +12,7 @@ zokrates_field = { version = "0.5", path = "../zokrates_field", default-features
 zokrates_ast = { version = "0.1", path = "../zokrates_ast", default-features = false }
 zokrates_proof_systems = { version = "0.1", path = "../zokrates_proof_systems", default-features = false }
 
-bellman_ce = { path = "../../bellman", default-features = false, features = ["plonk", "multicore"] }
+bellman_ce = { git = "https://github.com/georgwiese/bellman", rev="b356c7001f30da23bfad2b43eb0b7ca9804c8252", default-features = false, features = ["plonk", "multicore"] }
 # pairing = { package = "pairing_ce", version = "^0.21" }
 phase2 = { git = "https://github.com/Zokrates/phase2", default-features = false }
 rand_0_4 = { version = "0.4", package = "rand" }#

--- a/zokrates_bellman/src/plonk.rs
+++ b/zokrates_bellman/src/plonk.rs
@@ -1,5 +1,4 @@
 use bellman::kate_commitment::{Crs, CrsForMonomialForm};
-use bellman::pairing::ff::to_hex;
 use bellman::plonk::better_cs::cs::PlonkCsWidth4WithNextStepParams;
 use bellman::plonk::commitments::transcript::keccak_transcript::RollingKeccakTranscript;
 use bellman::plonk::{
@@ -293,13 +292,12 @@ fn serialize_proof<T: Field + BellmanFieldExtensions>(
 #[cfg(test)]
 mod tests {
     use bellman::plonk::commitments::transcript::Blake2sTranscript;
-    use bellman::{Circuit, ConstraintSystem, LinearCombination, ScalarEngine};
     use zokrates_field::Bn128Field;
     use zokrates_interpreter::Interpreter;
 
     use super::*;
     use zokrates_ast::common::{Parameter, Variable};
-    use zokrates_ast::ir::{Prog, QuadComb, Statement};
+    use zokrates_ast::ir::{Prog, Statement};
 
     #[test]
     fn setup_prove_verify() {
@@ -319,8 +317,6 @@ mod tests {
         // transpile
         let hints = transpile(Computation::without_witness(program.clone())).unwrap();
 
-        println!("Hints: {:?}", hints);
- 
         // run a circuit specific (transparent) setup
         let pols = setup(Computation::without_witness(program.clone()), &hints).unwrap();
 

--- a/zokrates_solidity_test/Cargo.toml
+++ b/zokrates_solidity_test/Cargo.toml
@@ -15,4 +15,4 @@ serde_json = { version = "1.0" }
 rand = { version = "0.8" }
 
 revm = { version = "1.6.0" }
-solc = { git = "https://github.com/g-r-a-n-t/solc-rust", rev = "52d4146" }
+solc = { git = "https://github.com/g-r-a-n-t/solc-rust", rev = "f8bc7f1" }


### PR DESCRIPTION
As mentioned in the comments of https://github.com/matter-labs/bellman/issues/46, the single core implementation of `bellman_ce` does not seem to work properly. This should be fixed now.

Two other changes:
- I updated the `solc` version, because the one used does not compile on my Mac. This makes my IDE happy. But I'm not sure of the implications, so if it's a problem, I can revert 74ea66620333dd46145a59ae54d8c3569e347f51.
- I also changed the test case to contain one (instead of zero) constraint.
- Switched to [this fork](https://github.com/matter-labs/bellman/compare/dev...georgwiese:bellman:zokrates-plonk?expand=1) of `matter-labs/bellman`, instead of relying on a modified version that's locally available. This fixes at least some CI steps.