### PR TITLE
Improve setup FFI in zokrates-js

### DIFF
--- a/changelogs/unreleased/1277-dark64
+++ b/changelogs/unreleased/1277-dark64
@@ -1,0 +1,1 @@
+Fix a potential crash in `zokrates-js` due to inefficient serialization of a setup keypair

--- a/zokrates_js/index.js
+++ b/zokrates_js/index.js
@@ -68,13 +68,25 @@ const initialize = async () => {
       return result;
     },
     setup: (program, entropy, options) => {
-      return wasmExports.setup(program, entropy, options);
+      const ptr = wasmExports.setup(program, entropy, options);
+      const result = {
+        vk: ptr.vk(),
+        pk: ptr.pk(),
+      };
+      ptr.free();
+      return result;
     },
     universalSetup: (curve, size, entropy) => {
       return wasmExports.universal_setup(curve, size, entropy);
     },
     setupWithSrs: (srs, program, options) => {
-      return wasmExports.setup_with_srs(srs, program, options);
+      const ptr = wasmExports.setup_with_srs(srs, program, options);
+      const result = {
+        vk: ptr.vk(),
+        pk: ptr.pk(),
+      };
+      ptr.free();
+      return result;
     },
     generateProof: (program, witness, provingKey, entropy, options) => {
       return wasmExports.generate_proof(

--- a/zokrates_js/package-lock.json
+++ b/zokrates_js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zokrates-js",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "zokrates-js",
-      "version": "1.1.4",
+      "version": "1.1.5",
       "license": "GPLv3",
       "dependencies": {
         "pako": "^2.1.0"


### PR DESCRIPTION
Fixes https://github.com/Zokrates/ZoKrates/issues/1276

This issue seems to be because we are serializing the setup keypair directly to `JsValue`. When calling `JsValue::from_serde`, the function will serialize the provided value to a JSON string, send the JSON string to JS, parse it into a JS object, and then return a handle to the JS object. 

This is fine in most cases, but in some extreme cases with circuits that end up with a large proving key, this serialization method would fail because of a large JSON string that gets produced. This PR solves this issue with the same method we use for compilation artifacts.