### PR TITLE
Fix `radix-path` help message on `mpc init` subcommand

### DIFF
--- a/changelogs/unreleased/1280-dark64
+++ b/changelogs/unreleased/1280-dark64
@@ -1,0 +1,1 @@
+Fix `radix-path` help message on `mpc init` subcommand

--- a/zokrates_cli/src/ops/mpc/init.rs
+++ b/zokrates_cli/src/ops/mpc/init.rs
@@ -24,8 +24,8 @@ pub fn subcommand() -> App<'static, 'static> {
         .arg(
             Arg::with_name("radix-path")
                 .short("r")
-                .long("radix-dir")
-                .help("Path of the directory containing parameters for various 2^m circuit depths (phase1radix2m{0..=m})")
+                .long("radix-path")
+                .help("Path of the phase1radix2m{n} file")
                 .value_name("PATH")
                 .takes_value(true)
                 .required(true),


### PR DESCRIPTION
The argument should expect a path to a file, not a directory.