### PR TITLE
Sudoku example fix

### DIFF
--- a/changelogs/unreleased/1287-Turupawn
+++ b/changelogs/unreleased/1287-Turupawn
@@ -1,0 +1,1 @@
+Fixed precedence issue on Sudoku example.

--- a/zokrates_cli/examples/sudoku/sudoku_checker.zok
+++ b/zokrates_cli/examples/sudoku/sudoku_checker.zok
@@ -11,13 +11,20 @@
 // We use a naive encoding of the values as `[1, 2, 3, 4]` and rely on if-else statements to detect duplicates
 
 def countDuplicates(field e11, field e12, field e21, field e22) -> field {
-    field mut duplicates = e11 == e12 ? 1 : 0;
-    duplicates = duplicates + e11 == e21 ? 1 : 0;
-    duplicates = duplicates + e11 == e22 ? 1 : 0;
-    duplicates = duplicates + e12 == e21 ? 1 : 0;
-    duplicates = duplicates + e12 == e22 ? 1 : 0;
-    duplicates = duplicates + e21 == e22 ? 1 : 0;
-    return duplicates;
+    field mut duplicates = 0;
+    field mut duplicatesAux = e11 == e12 ? 1 : 0;
+    duplicates = duplicates + duplicatesAux;
+    duplicatesAux = e11 == e21 ? 1 : 0;
+    duplicates = duplicates + duplicatesAux;
+    duplicatesAux = e11 == e22 ? 1 : 0;
+    duplicates = duplicates + duplicatesAux;
+    duplicatesAux = e12 == e21 ? 1 : 0;
+    duplicates = duplicates + duplicatesAux;
+    duplicatesAux = e12 == e22 ? 1 : 0;
+    duplicates = duplicates + duplicatesAux;
+    duplicatesAux = e21 == e22 ? 1 : 0;
+
+    return countDuplicates;
 }
 
 // returns 0 for x in (1..4)
@@ -74,5 +81,6 @@ def main(field a21, field b11, field b22, field c11, field c22, field d21, priva
     duplicates = duplicates + countDuplicates(b12, b22, d12, d22);
 
     // the solution is correct if and only if there are no duplicates
+    assert(duplicates == 0);
     return duplicates == 0;
 }

--- a/zokrates_cli/examples/sudoku/sudoku_checker.zok
+++ b/zokrates_cli/examples/sudoku/sudoku_checker.zok
@@ -11,20 +11,13 @@
 // We use a naive encoding of the values as `[1, 2, 3, 4]` and rely on if-else statements to detect duplicates
 
 def countDuplicates(field e11, field e12, field e21, field e22) -> field {
-    field mut duplicates = 0;
-    field mut duplicatesAux = e11 == e12 ? 1 : 0;
-    duplicates = duplicates + duplicatesAux;
-    duplicatesAux = e11 == e21 ? 1 : 0;
-    duplicates = duplicates + duplicatesAux;
-    duplicatesAux = e11 == e22 ? 1 : 0;
-    duplicates = duplicates + duplicatesAux;
-    duplicatesAux = e12 == e21 ? 1 : 0;
-    duplicates = duplicates + duplicatesAux;
-    duplicatesAux = e12 == e22 ? 1 : 0;
-    duplicates = duplicates + duplicatesAux;
-    duplicatesAux = e21 == e22 ? 1 : 0;
-
-    return countDuplicates;
+    field mut duplicates = e11 == e12 ? 1 : 0;
+    duplicates = duplicates + (e11 == e21 ? 1 : 0);
+    duplicates = duplicates + (e11 == e22 ? 1 : 0);
+    duplicates = duplicates + (e12 == e21 ? 1 : 0);
+    duplicates = duplicates + (e12 == e22 ? 1 : 0);
+    duplicates = duplicates + (e21 == e22 ? 1 : 0);
+    return duplicates;
 }
 
 // returns 0 for x in (1..4)
@@ -33,7 +26,7 @@ def validateInput(field x) -> bool {
 }
 
 // variables naming: box'row''column'
-def main(field a21, field b11, field b22, field c11, field c22, field d21, private field a11, private field a12, private field a22, private field b12, private field b21, private field c12, private field c21, private field d11, private field d12, private field d22) -> bool {
+def main(field a21, field b11, field b22, field c11, field c22, field d21, private field a11, private field a12, private field a22, private field b12, private field b21, private field c12, private field c21, private field d11, private field d12, private field d22) {
 
     // validate inputs
     assert(validateInput(a11));
@@ -82,5 +75,6 @@ def main(field a21, field b11, field b22, field c11, field c22, field d21, priva
 
     // the solution is correct if and only if there are no duplicates
     assert(duplicates == 0);
-    return duplicates == 0;
+    
+    return;
 }

--- a/zokrates_cli/examples/sudoku/sudoku_checker.zok
+++ b/zokrates_cli/examples/sudoku/sudoku_checker.zok
@@ -26,7 +26,7 @@ def validateInput(field x) -> bool {
 }
 
 // variables naming: box'row''column'
-def main(field a21, field b11, field b22, field c11, field c22, field d21, private field a11, private field a12, private field a22, private field b12, private field b21, private field c12, private field c21, private field d11, private field d12, private field d22) {
+def main(field a21, field b11, field b22, field c11, field c22, field d21, private field a11, private field a12, private field a22, private field b12, private field b21, private field c12, private field c21, private field d11, private field d12, private field d22) -> bool {
 
     // validate inputs
     assert(validateInput(a11));

--- a/zokrates_cli/examples/sudoku/sudoku_checker.zok
+++ b/zokrates_cli/examples/sudoku/sudoku_checker.zok
@@ -74,7 +74,5 @@ def main(field a21, field b11, field b22, field c11, field c22, field d21, priva
     duplicates = duplicates + countDuplicates(b12, b22, d12, d22);
 
     // the solution is correct if and only if there are no duplicates
-    assert(duplicates == 0);
-    
-    return;
+    return duplicates == 0;
 }


### PR DESCRIPTION
**The problem**

the logic behind `countDuplicates` is invalid because it's doing this:

(incorrect)
```
if(duplicates + e11 == e21)
  duplicates = 1;
else
  duplicates = 0;
```

Instead of this:
(correct)
```
if(e11 == e21)
  duplicates = duplicates + 1;
else
  duplicates = duplicates;
```

**The solution**

I'm using an auxiliary variable to fix this

**Alternative solution**

We can also fix it with an array and a loop. But I went for the auxiliary variable for no particular reason.

```
def countDuplicates(field e11, field e12, field e21, field e22) -> u32 {
    u32[6] mut duplicates = [0,0,0,0,0,0];
    duplicates[0] = e11 == e12 ? 1 : 0;
    duplicates[1] = e11 == e21 ? 1 : 0;
    duplicates[2] = e11 == e22 ? 1 : 0;
    duplicates[3] = e12 == e21 ? 1 : 0;
    duplicates[4] = e12 == e22 ? 1 : 0;
    duplicates[5] = e21 == e22 ? 1 : 0;

    u32 mut count = 0;
    for u32 i in 0..5 {
        count = count + duplicates[i];
    }

    return count;
}
```

And btw, I also added an assert to make sure we check for this validation. I've tested this on the playground and on chain on goerli and with this changes it works correctly.

Thanks for putting adding the examples. It has helped me a lot.
Cheers!