### PR TITLE
Fixed a small typo, the right bracket next to bitwidth was mistyped.

### DIFF
--- a/zokrates_book/src/language/types.md
+++ b/zokrates_book/src/language/types.md
@@ -25,7 +25,7 @@ Booleans are available in ZoKrates. When a boolean is used as a parameter of the
 
 ### `u8/u16/u32/u64`
 
-Unsigned integers represent positive numbers of the interval `[0, 2 ** bitwidth]`, where `bitwidth` is specified in the type's name, e.g., 32 bits in the case of u32. Their arithmetics are defined modulo `2 ** bitwidth`.
+Unsigned integers represent positive numbers of the interval `[0, 2 ** bitwidth)`, where `bitwidth` is specified in the type's name, e.g., 32 bits in the case of u32. Their arithmetics are defined modulo `2 ** bitwidth`.
 
 Internally, they use a binary encoding, which makes them particularly efficient for implementing programs that operate on that binary representation, e.g., the SHA256 hash function.
 

--- a/zokrates_book/src/language/types.md
+++ b/zokrates_book/src/language/types.md
@@ -25,7 +25,7 @@ Booleans are available in ZoKrates. When a boolean is used as a parameter of the
 
 ### `u8/u16/u32/u64`
 
-Unsigned integers represent positive numbers of the interval `[0, 2 ** bitwidth[`, where `bitwidth` is specified in the type's name, e.g., 32 bits in the case of u32. Their arithmetics are defined modulo `2 ** bitwidth`.
+Unsigned integers represent positive numbers of the interval `[0, 2 ** bitwidth]`, where `bitwidth` is specified in the type's name, e.g., 32 bits in the case of u32. Their arithmetics are defined modulo `2 ** bitwidth`.
 
 Internally, they use a binary encoding, which makes them particularly efficient for implementing programs that operate on that binary representation, e.g., the SHA256 hash function.
 


### PR DESCRIPTION
Corrected a typo in the documentation, the right bracket next to bitwidth was typed as a left bracket. This has been fixed.