### PR TITLE
Fixing pest-ast exact version

### DIFF
--- a/zokrates_pest_ast/Cargo.toml
+++ b/zokrates_pest_ast/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 [dependencies]
 zokrates_parser = { version = "0.3.0", path = "../zokrates_parser" }
 pest = "=2.3"
-pest-ast = "0.3.3"
+pest-ast = "=0.3.3"
 from-pest = "0.3.1"
 lazy_static = "1.3.0"
 


### PR DESCRIPTION
Compilation fails if it tries to build against 0.3.4