### PR TITLE
fix: one liner script doesn't work on windows

### DIFF
--- a/scripts/one_liner.sh
+++ b/scripts/one_liner.sh
@@ -265,7 +265,7 @@ main() {
 
     url="$url/releases"
 
-    tag=$(curl -Ls -w %{url_effective} -o /dev/null "$url/latest" | cut -d'"' -f2 | rev | cut -d'/' -f1 | rev)
+    tag=$(curl -Ls -w %{url_effective} -o /dev/null "$url/latest" | awk -F'tag/' '{print $2}')
     say_err "Tag: latest ($tag)"
 
     # detect host architecture


### PR DESCRIPTION
## Description
Previously, the process of retrieving the ZoKrates release tag resulted in an incorrect URL being used on Windows, leading to installation errors. This pull request addresses the issue by enhancing the tag retrieval process, ensuring the correct URL is utilized for a successful installation.

## Changes Made
Replaced the previous tag retrieval method:

```bash
tag=$(curl -Ls -w %{url_effective} -o /dev/null "$url/latest" | cut -d'"' -f2 | rev | cut -d'/' -f1 | rev)
```

With the updated method:

```bash
tag=$(curl -Ls -w %{url_effective} -o /dev/null "$url/latest" | awk -F'tag/' '{print $2}')
```

## Explanation

* `-F'tag/'`: Sets "tag/" as the separator for splitting text into parts.
* `'{print $2}'`: Prints the second part of the text after splitting it at "tag/".

Input: `https://github.com/zokrates/zokrates/releases/tag/0.8.7`
Output: `0.8.7`

## Impact

This change ensures that ZoKrates installations on Windows systems using the provided script will correctly fetch the required release tag, preventing 404 errors.

## Testing

The pull request has been tested to confirm that the new tag retrieval method functions as expected and resolves the issue of incorrect URL usage for Windows, macOS and Linux.