### PR TITLE
Fix input/output size in staticcall for addition and scalar_mul

### DIFF
--- a/changelogs/unreleased/1368-dark64
+++ b/changelogs/unreleased/1368-dark64
@@ -1,0 +1,1 @@
+Fix staticcall input/output size in `addition` & `scalar_mul`

--- a/zokrates_proof_systems/src/solidity.rs
+++ b/zokrates_proof_systems/src/solidity.rs
@@ -481,7 +481,7 @@ library Pairing {
         input[2] = s;
         bool success;
         assembly {
-            success := staticcall(sub(gas(), 2000), 7, input, 0x80, r, 0x60)
+            success := staticcall(sub(gas(), 2000), 7, input, 0x60, r, 0x40)
             // Use "invalid" to make gas estimation work
             switch success case 0 { invalid() }
         }

--- a/zokrates_proof_systems/src/solidity.rs
+++ b/zokrates_proof_systems/src/solidity.rs
@@ -456,7 +456,7 @@ library Pairing {
         input[3] = p2.Y;
         bool success;
         assembly {
-            success := staticcall(sub(gas(), 2000), 6, input, 0xc0, r, 0x60)
+            success := staticcall(sub(gas(), 2000), 6, input, 0x80, r, 0x40)
             // Use "invalid" to make gas estimation work
             switch success case 0 { invalid() }
         }


### PR DESCRIPTION
Closes https://github.com/Zokrates/ZoKrates/issues/1364, merge after https://github.com/Zokrates/ZoKrates/pull/1369

Note: This is not a huge issue as the sizes are clamped in the precompile to the correct values anyways (see [here](https://github.com/ethereum/go-ethereum/blob/master/core/vm/contracts.go#L447))