### PR TITLE
fix: typos in documentation files

### DIFF
--- a/zokrates_book/src/toolbox/verification.md
+++ b/zokrates_book/src/toolbox/verification.md
@@ -9,7 +9,7 @@ const address = '0x456...'; // verifier contract address
 
 let verifier = new web3.eth.Contract(abi, address, {
     from: accounts[0], // default from address
-    gasPrice: '20000000000000'; // default gas price in wei
+    gasPrice: '20000000000000', // default gas price in wei
 });
 
 let result = await verifier.methods


### PR DESCRIPTION
This pull request contains changes to improve clarity, correctness and structure.

**Description correction:**
The typo lies in the use of a period at the end of the line with the `gasPrice` parameter:

`gasPrice: '20000000000000'; // default gas price in wei`

In the JavaScript programming language, object properties should be separated by commas, not periods. This is a syntax requirement of the language. The period in this context is an incorrect separator that will cause a syntax error when attempting to execute the code.

Please review the changes and let me know if any additional changes are needed.

