### PR TITLE
Fix broken documentation link

### DIFF
--- a/zokrates_codegen/src/lib.rs
+++ b/zokrates_codegen/src/lib.rs
@@ -297,7 +297,7 @@ impl<'ast, T: Field> Flattener<'ast, T> {
     ///
     /// # Notes
     ///
-    /// Algorithm from [the sapling spec](https://github.com/zcash/zips/blob/master/protocol/sapling.pdf) A.3.2.2
+    /// Algorithm from [the sapling spec](https://github.com/zcash/zips/blob/main/rendered/protocol/sapling.pdf) A.3.2.2
     ///
     /// Let's assume b = [1, 1, 1, 0]
     ///


### PR DESCRIPTION
Fix broken documentation links
  - Replaced `https://github.com/zcash/zips/blob/master/protocol/sapling.pdf`
   with `https://github.com/zcash/zips/blob/main/rendered/protocol/sapling.pdf`.