### PR TITLE
Fix typos in `expression.rs` and `verify.rs`

### DIFF
--- a/zokrates_ast/src/ir/expression.rs
+++ b/zokrates_ast/src/ir/expression.rs
@@ -195,7 +195,7 @@ impl<T> WithSpan for LinComb<T> {
 impl<T: Field> LinComb<T> {
     pub fn try_constant(self) -> Result<T, Self> {
         match self.value.len() {
-            // if the lincomb is empty, it is reduceable to 0
+            // if the lincomb is empty, it is reducible to 0
             0 => Ok(T::zero()),
             _ => {
                 // take the first variable in the lincomb

--- a/zokrates_ast/src/ir/expression.rs
+++ b/zokrates_ast/src/ir/expression.rs
@@ -223,7 +223,7 @@ impl<T: Field> LinComb<T> {
 
     pub fn try_summand(self) -> Result<(Variable, T), Self> {
         match self.value.len() {
-            // if the lincomb is empty, it is not reduceable to a summand
+            // if the lincomb is empty, it is not reducible to a summand
             0 => Err(self),
             _ => {
                 // take the first variable in the lincomb

--- a/zokrates_cli/src/ops/nova/verify.rs
+++ b/zokrates_cli/src/ops/nova/verify.rs
@@ -116,7 +116,7 @@ fn cli_nova_verify<'ast, T: NovaField>(
     let steps = instance.steps;
 
     if nova::verify_compressed(&proof, &vk, init, steps) {
-        println!("Compressed proof succesfully verified");
+        println!("Compressed proof successfully verified");
     } else {
         eprintln!("Compressed proof verification failed");
     }


### PR DESCRIPTION
# Pull Request Template

### **Title**: Fix typos in `expression.rs` and `verify.rs`

---

## **Description**

This PR fixes minor typos in comments and output messages within the following files:

1. **`zokrates_ast/src/ir/expression.rs`**  
   - Corrected the word "reduceable" to "reducible" in comments.

2. **`zokrates_cli/src/ops/nova/verify.rs`**  
   - Fixed a typo in a user-facing message:  
     Changed "succesfully" to "successfully."

---

## **Changes**

### **Files Modified**
1. `zokrates_ast/src/ir/expression.rs`  
   - Line 195:  
     *Before*: `it is reduceable to 0`  
     *After*: `it is reducible to 0`  
   - Line 223:  
     *Before*: `it is not reduceable to a summand`  
     *After*: `it is not reducible to a summand`  

2. `zokrates_cli/src/ops/nova/verify.rs`  
   - Line 116:  
     *Before*: `Compressed proof succesfully verified`  
     *After*: `Compressed proof successfully verified`

---

## **Motivation and Context**

Fixing these typos improves code clarity and ensures polished user-facing messages. Correct spelling and grammar contribute to better code documentation and a professional user experience.

---

## **How Has This Been Tested?**

- Verified the changes compile successfully.  
- Ran basic checks to ensure no unintended behaviors were introduced.

---

## **Checklist**

- [x] My changes follow the project's coding style and guidelines.  
- [x] I have performed a self-review of my code.  
- [x] I have commented on changes where necessary.  
- [x] I have ensured the code compiles without errors.  


